### PR TITLE
Updates starting bolus image path

### DIFF
--- a/docs/operation/features/bolus.md
+++ b/docs/operation/features/bolus.md
@@ -22,7 +22,7 @@ Occasionally, a recommended bolus will be offered in the bolus tool unrelated to
 A new status line will appear when Loop is sending a bolus command to the pump. Just above the main screen's glucose chart, you will see a "starting bolus" indicator.
 
 <p align="center">
-<img src="/setup/update/img/starting_bolus.png" width="250">
+<img src="/build/update/img/starting_bolus.png" width="250">
 </p>
 
 ## Bolus Failure Notifications


### PR DESCRIPTION
This PR is intended to update the path to the ‘starting bolus’ screenshot in the main Bolus page so that this image no longer 404’s. Submitting only because it seemed to be broken when I came across that page when setting up my Loop, I have very little of the context on the repo so of course feel free to close if changing the src is not the approach that fits best with activity in the repo.

Thank you so much for writing and maintaining these docs, they’re amazing!!