### PR TITLE
docs: fix link to admonitions and add disable antivirus while downloading/installing xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ mkdocs gh-deploy
 * Use images for clarity whenever appropriate
 
 ### Admonitions
-[Admonitions](https://pythonhosted.org/Markdown/extensions/admonition.html) are a markdown extension that enable formatted blocks for visually calling out information. The types are: note, info, warning, and danger. Here are some examples of how to write the markdown:
+[Admonitions](https://python-markdown.github.io/extensions/admonition/) are a markdown extension that enable formatted blocks for visually calling out information. The types are: note, info, warning, and danger. Here are some examples of how to write the markdown:
 
 ```markdown
 !!! note

--- a/docs/build/build-xcode.md
+++ b/docs/build/build-xcode.md
@@ -6,7 +6,7 @@ You are getting closer.  This next step is simply to download and install a free
     If you are building for Omnipod Loop, Loop dev, or have iOS 12.2 installed, make sure you have followed the previous section for updating to macOS 10.14.3 at a minimum...you won't be able to download and use Xcode 10.2 without that update first.
 
 ## Download Xcode
-Open the App Store application on your computer (it is in your Applications folder).  Search for Xcode and click on the link to download/install Xcode for free.  The most current version of Xcode is 10.2.1.  Do not download the Xcode beta program, just get the regular version of the program. The file size is fairly large so expect about 45 minutes, or even multiple hours, to download depending on your internet speed. 
+Open the App Store application on your computer (it is in your Applications folder).  Search for Xcode and click on the link to download/install Xcode for free.  The most current version of Xcode is 10.2.1.  Do not download the Xcode beta program, just get the regular version of the program. The file size is fairly large so expect about 45 minutes, or even multiple hours, to download depending on your internet speed. If your download stalls you might temporary need to disable your AntiVirus program.
 
 If you already had a previous installation of Xcode, you can just check your App Store for macOS and then Xcode updates before building Loop.
 


### PR DESCRIPTION
Hi @Kdisimone 

Long time no digital see.... I'm about to switch to loop. Found two minor issues in the loop docs:
- fix link to admonitions
- xcode did not install with Norton Security running, so added a note to disable AntiVirus