### PR TITLE
Clarify the end of Step 6

### DIFF
--- a/docs/nightscout/new_user.md
+++ b/docs/nightscout/new_user.md
@@ -239,6 +239,8 @@ Click `Save` when you have entered the information.  You will be prompted to aut
 
 </br></br>
 
+Close out of the Profile Editor to return to the main Nightscout page and configure your NS settings.
+
 ## Step 7: Nightscout Settings
 The last step is to finish your Nightscout's settings. Click on the settings (those three horizontal lines in upper right corner).  Now check that you have everything displaying correctly:
 


### PR DESCRIPTION
It took me a few minutes to figure out that the authentication was done, because I thought the page would automatically load the screen that you show next in the instructions, which isn't the case. I was searching and searching for the settings button (three horizontal lines) on the Profile Settings page, but it doesn't exist there. The user needs to exit the Profile Settings page to get back to the main screen to access the Nightscout settings button (three horizontal lines).