### PR TITLE
Configure pre-commit to run Prettier on All the Markdown!

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/prettier/prettier
+    rev: 1.18.2
+    hooks:
+      - id: prettier
+        args: [--write, --prose-wrap=always, "**/*.md", "*.md"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: prettier
+  name: Prettier Formatter
+  description: This hook wraps markdown lines at 80 characters.
+  entry: prettier
+  language: node
+  types: [markdown]

--- a/README.md
+++ b/README.md
@@ -1,57 +1,104 @@
 # Loop Docs
 
-This is the repo that contains the source files for the [Loop Docs](https://loopkit.github.io/loopdocs) site.
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
+This is the repo that contains the source files for the
+[Loop Docs](https://loopkit.github.io/loopdocs) site.
 
 ## Contributing
 
-To suggest changes, fork this repository, edit the files, and submit your changes as a pull request.
+To suggest changes, fork this repository, edit the files, and submit your
+changes as a pull request.
 
 ### Previewing Changes
-To preview your work as you edit you must set up two python packages that are used to create this site using [MkDocs](http://www.mkdocs.org/). They are `mkdocs`, and `mkdocs-bootswatch`.
 
-Review [Properly Installing Python](http://docs.python-guide.org/en/latest/starting/installation/) for help getting Python installed. MkDocs works with Python 2.7, 3.3+, and pypy.
+To preview your work as you edit you must set up two python packages that are
+used to create this site using [MkDocs](http://www.mkdocs.org/). They are
+`mkdocs`, and `mkdocs-bootswatch`.
 
-* Install python modules
+Review
+[Properly Installing Python](http://docs.python-guide.org/en/latest/starting/installation/)
+for help getting Python installed. MkDocs works with Python 2.7, 3.3+, and pypy.
+
+- Install python modules
 
 ```bash
 $ cd <loopdocs project location>
 $ pip install -r requirements.txt
 ```
 
-**mkdocs Version Warning:** Use the latest `0.16.x` patch version of `mkdocs`, but don't upgrade `mkdocs` to version `0.17.x`. It is NOT compatible with the theme being used.  Same for updated versions of `mkdocs-bootswatch`, do not use the latest version.
+**mkdocs Version Warning:** Use the latest `0.16.x` patch version of `mkdocs`,
+but don't upgrade `mkdocs` to version `0.17.x`. It is NOT compatible with the
+theme being used. Same for updated versions of `mkdocs-bootswatch`, do not use
+the latest version.
 
-* Or, install modules individually
+- Or, install modules individually
+
 ```bash
 $ pip install mkdocs<0.17
 $ pip install mkdocs-bootswatch==0.4.0
 ```
 
-* Run mkdocs server locally
+- Run mkdocs server locally
+
 ```bash
 $ cd <loopdocs project location>
 $ mkdocs serve
 ```
 
-* Preview docs in browser. Most changes will update automatically as you edit. Configuration and navigation changes will require restarting the mkdocs server.
-* Optionally, you can share the preview with others by uploading them to your repository's `gh-pages` branch
+- Preview docs in browser. Most changes will update automatically as you edit.
+  Configuration and navigation changes will require restarting the mkdocs
+  server.
+- Optionally, you can share the preview with others by uploading them to your
+  repository's `gh-pages` branch
+
 ```bash
 $ mkdocs gh-deploy
 ```
 
+#### Autoformatting Changes
+
+Before committing, set up the project's auto-formatter. This will prettify your
+code upon commit! If you `pip install -r requirements.txt` above, you will have
+pre-commit installed in your environment. To configure it in the repo,
+
+- Set up pre-commit
+
+```bash
+$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
+If you want to format your code before commit, you will need to install
+prettier:
+
+```bash
+npm install --save-dev --save-exact prettier
+# or globally
+npm install --global prettier
+```
+
+then you can run:
+
+```bash
+$ prettier --write --prose-wrap=always "**/*.md" "*.md"
+```
+
 ## Conventions
 
-* Use images for clarity whenever appropriate
+- Use images for clarity whenever appropriate
 
 ### Admonitions
-[Admonitions](https://pythonhosted.org/Markdown/extensions/admonition.html) are a markdown extension that enable formatted blocks for visually calling out information. The types are: note, info, warning, and danger. Here are some examples of how to write the markdown:
+
+[Admonitions](https://pythonhosted.org/Markdown/extensions/admonition.html) are
+a markdown extension that enable formatted blocks for visually calling out
+information. The types are: note, info, warning, and danger. Here are some
+examples of how to write the markdown:
 
 ```markdown
-!!! note
-    This admonition uses the default title: 'Note'.
+!!! note This admonition uses the default title: 'Note'.
 
-!!! info "My Custom Title"
-    This admonition is blue and has a custom title.
+!!! info "My Custom Title" This admonition is blue and has a custom title.
 
-!!! warning ""
-    This admonition is yellow and has no title.
+!!! warning "" This admonition is yellow and has no title.
 ```

--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -1,62 +1,115 @@
 # Build Errors
 
-There are two types of build errors that happen; they are yellow warnings and red alerts. You'll see the warnings and alerts in the left-hand column of the Xcode window.
+There are two types of build errors that happen; they are yellow warnings and
+red alerts. You'll see the warnings and alerts in the left-hand column of the
+Xcode window.
 
-<font color="orange">**Yellow warnings**</font> do not cause the build to fail, those are just warnings.  Occasionally, a Loop version may have some minor discrepancies that cause a yellow alert...ignore those. Do not try to do anything to fix those...leave them alone.
+<font color="orange">**Yellow warnings**</font> do not cause the build to fail,
+those are just warnings. Occasionally, a Loop version may have some minor
+discrepancies that cause a yellow alert...ignore those. Do not try to do
+anything to fix those...leave them alone.
 
-<font color="red">**Red error alerts** </font> will have to be resolved before you can successfully build the Loop app. The steps below explain how to resolve them based on the messages you are seeing.
+<font color="red">**Red error alerts** </font> will have to be resolved before
+you can successfully build the Loop app. The steps below explain how to resolve
+them based on the messages you are seeing.
 
 ## Start with the obvious error causes
 
-Before you start trying to resolve your red errors...start with the most obvious things that can cause a red error message:
+Before you start trying to resolve your red errors...start with the most obvious
+things that can cause a red error message:
 
-1. **DO NOT USE BETA VERSIONS**  If you are using an iOS beta version or an Xcode beta version, your Loop will not build. If you have Xcode beta, uninstall it and get regular Xcode. If you have iOS beta on your iPhone, you will need to restore your iPhone entirely. You can restore to either (1) the last non-beta backup version you saved or (2) restore as a new iPhone (default settings). Yes, deleting iOS beta is a pain...so don't install it in the first place.
+1. **DO NOT USE BETA VERSIONS** If you are using an iOS beta version or an Xcode
+   beta version, your Loop will not build. If you have Xcode beta, uninstall it
+   and get regular Xcode. If you have iOS beta on your iPhone, you will need to
+   restore your iPhone entirely. You can restore to either (1) the last non-beta
+   backup version you saved or (2) restore as a new iPhone (default settings).
+   Yes, deleting iOS beta is a pain...so don't install it in the first place.
 
-2. **Did you check for updates?** 
+2. **Did you check for updates?**
 
-    !!!info "Minimum Versions"
-        If you are building for Omnipod Loop, Loop dev, or have iOS 13 installed, make sure you have macOS 10.14.3 (Mojave) and Xcode 11 at a minimum. You will not be able to build for those without the minimum updates. Download Xcode 11 from the App Store to replace your Xcode 11 GM if you downloaded that previously.
+   !!!info "Minimum Versions" If you are building for Omnipod Loop, Loop dev, or
+   have iOS 13 installed, make sure you have macOS 10.14.3 (Mojave) and Xcode 11
+   at a minimum. You will not be able to build for those without the minimum
+   updates. Download Xcode 11 from the App Store to replace your Xcode 11 GM if
+   you downloaded that previously.
 
-3. **Did you reboot your computer after updating Xcode?** Yup...that was in the message on the Update Loop page...did you ignore it? ;)
+3. **Did you reboot your computer after updating Xcode?** Yup...that was in the
+   message on the Update Loop page...did you ignore it? ;)
 
-4. **Get a fresh download of Loop code, don't just recycle an old download that you built with a long time ago.** That old version may not be compatible with new iOS and new Xcode versions.
+4. **Get a fresh download of Loop code, don't just recycle an old download that
+   you built with a long time ago.** That old version may not be compatible with
+   new iOS and new Xcode versions.
 
-5. If you are using a free developer account, you need to have finished the [removal of Siri capabilities](https://loopkit.github.io/loopdocs/build/step14/#sign-four-targets).
+5. If you are using a free developer account, you need to have finished the
+   [removal of Siri capabilities](https://loopkit.github.io/loopdocs/build/step14/#sign-four-targets).
 
 ## Posting for help
 
-STOP!!  Read this section! Important!
+STOP!! Read this section! Important!
 
-Before you post in Zulipchat or Looped Group asking for help with build errors, <u>do your work first</u>. The build errors listed below (and the obvious checks listed above) are very successful ***IF PEOPLE READ THIS PAGE***. The volunteer group of people answering questions in Looped and Zulipchat would love to spend more time on improving Loop in other ways than answering build error questions that can be answered by using this page as a first step.
+Before you post in Zulipchat or Looped Group asking for help with build errors,
+<u>do your work first</u>. The build errors listed below (and the obvious checks
+listed above) are very successful **_IF PEOPLE READ THIS PAGE_**. The volunteer
+group of people answering questions in Looped and Zulipchat would love to spend
+more time on improving Loop in other ways than answering build error questions
+that can be answered by using this page as a first step.
 
-Therefore, first use the error topics (listed in sections below) to try to resolve your build error yourself. Then, if you need to post for help because this page did not fix your problem, you'll need to include information with the post so we (the troubleshooters) know you read this page and where you are in your troubleshooting attempts
+Therefore, first use the error topics (listed in sections below) to try to
+resolve your build error yourself. Then, if you need to post for help because
+this page did not fix your problem, you'll need to include information with the
+post so we (the troubleshooters) know you read this page and where you are in
+your troubleshooting attempts
 
-!!!danger "Must include in your post" 
-    * The version of Xcode you are using
-    * The version of Loop you are building with
-    * The version of iOS on your Loop iPhone
-    * Specify if you are using a free or paid account, and if free...confirm you deleted Siri capabilities
-    * Confirm you are not using an Xcode beta or iOS beta version (so we don't have to ask, actually type "I am not using beta versions"...this will save a lot of time and hassle)
-    * Screenshots of your WHOLE Xcode window and/or Terminal window showing your error and any messages you've seen while working through the build errors/solutions.
-    * **<u>State which fixes from the below list that you have already tried AND post the screenshots of the results of those fix attempts.</u>**
+!!!danger "Must include in your post" _ The version of Xcode you are using _ The
+version of Loop you are building with _ The version of iOS on your Loop iPhone _
+Specify if you are using a free or paid account, and if free...confirm you
+deleted Siri capabilities _ Confirm you are not using an Xcode beta or iOS beta
+version (so we don't have to ask, actually type "I am not using beta
+versions"...this will save a lot of time and hassle) _ Screenshots of your WHOLE
+Xcode window and/or Terminal window showing your error and any messages you've
+seen while working through the build errors/solutions. \* **<u>State which fixes
+from the below list that you have already tried AND post the screenshots of the
+results of those fix attempts.</u>**
 
-Helpful tip #1: Shift-Command-4 will give you a little screenshot tool that you can click-and-drag to highlight the area you'd like to screenshot. When you release the drag, the screenshot will save to your desktop so you can include it in your post. Phone photos of your computer screen won't likely be of sufficient clarity to read the needed information.
+Helpful tip #1: Shift-Command-4 will give you a little screenshot tool that you
+can click-and-drag to highlight the area you'd like to screenshot. When you
+release the drag, the screenshot will save to your desktop so you can include it
+in your post. Phone photos of your computer screen won't likely be of sufficient
+clarity to read the needed information.
 
-Helpful tip #2: When taking screenshots for a post, include the whole Xcode window. Don't zoom in on any one area. There is information in all parts of the Xcode window that are helpful to the troubleshooters, so it saves time to see the whole Xcode window at once.
+Helpful tip #2: When taking screenshots for a post, include the whole Xcode
+window. Don't zoom in on any one area. There is information in all parts of the
+Xcode window that are helpful to the troubleshooters, so it saves time to see
+the whole Xcode window at once.
 
 ## Find your error message(s)
 
-To begin fixing the error (assuming you didn't have one of the obvious issues listed above), the key is to (1) ***READ THE ERROR MESSAGE*** and then (2) ***FIND YOUR MESSAGE IN ONE OF THE TOPICS BELOW***.
+To begin fixing the error (assuming you didn't have one of the obvious issues
+listed above), the key is to (1) **_READ THE ERROR MESSAGE_** and then (2)
+**_FIND YOUR MESSAGE IN ONE OF THE TOPICS BELOW_**.
 
-Here's a super tip: Merely seeing the "exit code" in Xcode is not enough information to discern what error is causing your build to fail. Look at the detailed message to really help guide your search for the matching solution.
+Here's a super tip: Merely seeing the "exit code" in Xcode is not enough
+information to discern what error is causing your build to fail. Look at the
+detailed message to really help guide your search for the matching solution.
 
-Notice how in the screenshots in the topics below, there are red circles highlighting certain error messages? Read your error messages similar to where those red circles are in the screenshots below. Once you find your error message (hint: not "exit code"), you can either:
+Notice how in the screenshots in the topics below, there are red circles
+highlighting certain error messages? Read your error messages similar to where
+those red circles are in the screenshots below. Once you find your error message
+(hint: not "exit code"), you can either:
 
-* Take the error message from your Xcode screen and use LoopDoc's search function to enter in some of that phrase to bring up the appropriate solution topic, or
+- Take the error message from your Xcode screen and use LoopDoc's search
+  function to enter in some of that phrase to bring up the appropriate solution
+  topic, or
 
-* Take the error message from your Xcode screen and read through EACH OF THE TOPICS BELOW. Check each of the red circles to see if you have a match. Kind of like a matching puzzle.
+- Take the error message from your Xcode screen and read through EACH OF THE
+  TOPICS BELOW. Check each of the red circles to see if you have a match. Kind
+  of like a matching puzzle.
 
-For example, if you see "Invalid active developer path (/Library/Developer/CommandLineTools)" in your error message, use the search tool in LoopDocs with simply "invalid active". You will get a couple of links and one is the Command Line Tools fix for that error message. Click on the link and you'll find your solution.
+For example, if you see "Invalid active developer path
+(/Library/Developer/CommandLineTools)" in your error message, use the search
+tool in LoopDocs with simply "invalid active". You will get a couple of links
+and one is the Command Line Tools fix for that error message. Click on the link
+and you'll find your solution.
 
 </p>
 <p align="center">
@@ -65,31 +118,45 @@ For example, if you see "Invalid active developer path (/Library/Developer/Comma
 
 ## No such module 'LoopKit' or similar message
 
-If you see a **Cartfile failure** and several other red errors (in particular saying there is "no such module 'LoopKit'"), double click on the Cartfile error message.  If it says that the build failed in one of the schemes, as shown in the screenshot below, then you need to open the Terminal app.  You will use the command `cd ~/downloads/loop-master && carthage update`.  NOTE:  YOU MAY HAVE TO CHANGE THE COMMAND SLIGHTLY.  If your loop folder isn't named loop-master and instead is loop-master-2 or loop-dev or some other folder name...change the command to match your folder's actual name. 
+If you see a **Cartfile failure** and several other red errors (in particular
+saying there is "no such module 'LoopKit'"), double click on the Cartfile error
+message. If it says that the build failed in one of the schemes, as shown in the
+screenshot below, then you need to open the Terminal app. You will use the
+command `cd ~/downloads/loop-master && carthage update`. NOTE: YOU MAY HAVE TO
+CHANGE THE COMMAND SLIGHTLY. If your loop folder isn't named loop-master and
+instead is loop-master-2 or loop-dev or some other folder name...change the
+command to match your folder's actual name.
 
 </p>
 <p align="center">
 <img src="../img/exit-code-65.png" width="850">
 </p>
 
-Carthage update will take about 15-25 minutes to run successfully.  A successful carthage update will look like the following:
+Carthage update will take about 15-25 minutes to run successfully. A successful
+carthage update will look like the following:
 
 </p>
 <p align="center">
 <img src="../img/carthage-update-success.png" width="550">
 </p>
 
-Once carthage update has run successfully, you can return to Xcode and press the build button again.  Your project should build successfully.
+Once carthage update has run successfully, you can return to Xcode and press the
+build button again. Your project should build successfully.
 
-If your carthage update fails, try opening the Terminal app and running these commands to clear out your carthage cache and saved derived data in Xcode:
+If your carthage update fails, try opening the Terminal app and running these
+commands to clear out your carthage cache and saved derived data in Xcode:
 
-`rm -rf ~/Library/Caches/org.carthage.CarthageKit` and `rm -rf ~/Library/Developer/Xcode/DerivedData`
+`rm -rf ~/Library/Caches/org.carthage.CarthageKit` and
+`rm -rf ~/Library/Developer/Xcode/DerivedData`
 
-After running those commands, retry the `cd ~/downloads/loop-master && carthage update` (remembering to update the name of your Loop download folder, as needed).
+After running those commands, retry the
+`cd ~/downloads/loop-master && carthage update` (remembering to update the name
+of your Loop download folder, as needed).
 
 ## Carthage version outdated
 
-If you see a message about updating carthage version, open Terminal app and enter the following command `brew update && brew upgrade carthage`
+If you see a message about updating carthage version, open Terminal app and
+enter the following command `brew update && brew upgrade carthage`
 
 </p>
 <p align="center">
@@ -98,7 +165,9 @@ If you see a message about updating carthage version, open Terminal app and ente
 
 ## Missing Command Line Tools
 
-Error message:  "**<u>Invalid active developer path (/Library/Developer/CommandLineTools)</u>**" or "**<u>unable to find utility "xcodebuild", not a developer tool or in PATH</u>**"
+Error message: "**<u>Invalid active developer path
+(/Library/Developer/CommandLineTools)</u>**" or "**<u>unable to find utility
+"xcodebuild", not a developer tool or in PATH</u>**"
 
 </p>
 <p align="center">
@@ -110,7 +179,8 @@ Error message:  "**<u>Invalid active developer path (/Library/Developer/CommandL
 <img src="../img/command-line-error-2.jpg" width="550">
 </p>
 
-Solution: Go to your Xcode preferences and under the Locations tab, select "Xcode 11" in the dropdown menu for Command Line Tools.
+Solution: Go to your Xcode preferences and under the Locations tab, select
+"Xcode 11" in the dropdown menu for Command Line Tools.
 
 </p>
 <p align="center">
@@ -119,52 +189,76 @@ Solution: Go to your Xcode preferences and under the Locations tab, select "Xcod
 
 ## Pending Certificate Request
 
-Error message: "You already have a current iOS Development certificate or a pending certificate request."
+Error message: "You already have a current iOS Development certificate or a
+pending certificate request."
 
 <p align="center">
 <img src="../img/pending_certification_request.jpg" width="750">
 </p>
 
-Solution: This error message has just recently started to appear for some new Loop builders. To resolve the issue, please log in to your Developer account at [developer.apple.com](https://developer.apple.com) and then click on "Certificates, Identifiers & Profiles".  Under that screen, you will see "Development" under the "Certificates" section in the column on the left.  You will need to click on the certificates, and choose to "revoke" from the options that show after you click on the certificate. Confirm the warning message that will appear asking "Do you want to revoke the certificate?"
+Solution: This error message has just recently started to appear for some new
+Loop builders. To resolve the issue, please log in to your Developer account at
+[developer.apple.com](https://developer.apple.com) and then click on
+"Certificates, Identifiers & Profiles". Under that screen, you will see
+"Development" under the "Certificates" section in the column on the left. You
+will need to click on the certificates, and choose to "revoke" from the options
+that show after you click on the certificate. Confirm the warning message that
+will appear asking "Do you want to revoke the certificate?"
 
 <p align="center">
 <img src="../img/revoke1.png" width="750">
 </p>
 
-After you do that, return to Xcode and open up Xcode preferences.  Under the Accounts section of Preferences, click on the minus sign to delete your Apple ID.
+After you do that, return to Xcode and open up Xcode preferences. Under the
+Accounts section of Preferences, click on the minus sign to delete your Apple
+ID.
 
 <p align="center">
 <img src="../img/account.png" width="650">
 </p>
 
-Re-enter your Apple ID (yes...add that account right back that you literally just deleted), return to your Loop's target signing areas in Xcode and your error message should have resolved itself now as a new certificate will have been issued and a provisioning profile should have been created automatically.
+Re-enter your Apple ID (yes...add that account right back that you literally
+just deleted), return to your Loop's target signing areas in Xcode and your
+error message should have resolved itself now as a new certificate will have
+been issued and a provisioning profile should have been created automatically.
 
-For double measure, you can verify that the iOS development certificates are all in good working order by clicking on your "Manage Certificates" in your Xcode Preferences, Accounts and viewing the iOS development Certificates.  You should have one for your account that has a clean status similar to the screenshot below.
+For double measure, you can verify that the iOS development certificates are all
+in good working order by clicking on your "Manage Certificates" in your Xcode
+Preferences, Accounts and viewing the iOS development Certificates. You should
+have one for your account that has a clean status similar to the screenshot
+below.
 
 <p align="center">
 <img src="../img/verify_cert.png" width="650">
 </p>
 
-
 ## Command CodeSign failed
 
-Error message: "**<u>errSecInternalComponent,  Command CodeSign failed with a nonzero exit code</u>**"
+Error message: "**<u>errSecInternalComponent, Command CodeSign failed with a
+nonzero exit code</u>**"
 
 </p>
 <p align="center">
 <img src="../img/errsecinternal.jpg" width="850">
 </p>
 
-
-Solution:  This error message is likely due to inadvertently saying "no" to allowing Keychain Access or changing your computer or AppleID password. Regardless, the solution is as follows:
+Solution: This error message is likely due to inadvertently saying "no" to
+allowing Keychain Access or changing your computer or AppleID password.
+Regardless, the solution is as follows:
 
 1. Close Xcode
-2. Open your Keychain Access application (found in Applications within the Utilities folder, similar to where Terminal app is found)
-3. In the upper left corner of keychain access, make sure you have the keychain `login` highlighted and then click the large lock icon above the keychains area (High Sierra users) or right-click the lock next to the `login` (Mojave macOS users).  Click the lock closed, and then click the lock to open it again. You will be prompted for a password.  Enter your computer admin password.  Close Keychain Access app.
-</p>
-<p align="center">
-<img src="../img/keychain3.png" width="450">
-</p>
+2. Open your Keychain Access application (found in Applications within the
+   Utilities folder, similar to where Terminal app is found)
+3. In the upper left corner of keychain access, make sure you have the keychain
+   `login` highlighted and then click the large lock icon above the keychains
+   area (High Sierra users) or right-click the lock next to the `login` (Mojave
+   macOS users). Click the lock closed, and then click the lock to open it
+   again. You will be prompted for a password. Enter your computer admin
+   password. Close Keychain Access app.
+   </p>
+   <p align="center">
+   <img src="../img/keychain3.png" width="450">
+   </p>
 
 </p>
 <p align="center">
@@ -172,13 +266,22 @@ Solution:  This error message is likely due to inadvertently saying "no" to allo
 </p>
 
 4. Open your Loop project again in Xcode.
-5. In the main Xcode menu (grey menu bar at the very top of your Apple display area), select the word `Product` and then select the option for `Clean`. (keyboard shortcut is shift-command-k)
-6. Now try rebuilding your Loop app.  If you ever get prompted again to allow Xcode access to Keychain, make sure to Always Allow.
+5. In the main Xcode menu (grey menu bar at the very top of your Apple display
+   area), select the word `Product` and then select the option for `Clean`.
+   (keyboard shortcut is shift-command-k)
+6. Now try rebuilding your Loop app. If you ever get prompted again to allow
+   Xcode access to Keychain, make sure to Always Allow.
 
 ## Developer License Update
-Error message: "**<u>The Apple Developer Program License Agreement has been updated,  In order to access certain membership resources, you must accept the latest license agreement.</u>**"
 
-Solution: You'll need to log onto your developer account at [developer.apple.com](https://developer.apple.com/account/) and accept the latest license agreement.
+Error message: "**<u>The Apple Developer Program License Agreement has been
+updated, In order to access certain membership resources, you must accept the
+latest license agreement.</u>**"
+
+Solution: You'll need to log onto your developer account at
+[developer.apple.com](https://developer.apple.com/account/) and accept the
+latest license agreement.
+
 <p align="center">
 <img src="../img/license.png" width="750">
 </p>
@@ -197,12 +300,19 @@ Error message: "**<u>Unrecognized arguments: --cache-builds</u>**"
 <img src="../img/exit-code-1-cartfile.jpg" width="850">
 </p>
 
-
-Solution: Please open your Terminal app found in the Applications>>Utilities folder and then enter `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`  Confirm installation by pressing enter, and then typing in your computer password.  When the installation finishes, use the command `brew link --overwrite carthage`.  After those two steps, you can close out Terminal app, return to Xcode and press the build/play button again.
-
+Solution: Please open your Terminal app found in the Applications>>Utilities
+folder and then enter
+`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+Confirm installation by pressing enter, and then typing in your computer
+password. When the installation finishes, use the command
+`brew link --overwrite carthage`. After those two steps, you can close out
+Terminal app, return to Xcode and press the build/play button again.
 
 ## Abort with Payload
-Error message: "**<u>Abort with payload</u>**"  Your app will only open briefly with a white screen and then close, if you build with this error.
+
+Error message: "**<u>Abort with payload</u>**" Your app will only open briefly
+with a white screen and then close, if you build with this error.
+
 <p align="center">
 <img src="../img/abort_payload.png" width="750">
 </p>
@@ -211,19 +321,36 @@ Solution: This error message is caused by either
 1. Saving Loop download folder into an iCloud mapped drive, or
 2. Having a space in the name of your Loop download folder.
 
-Rename the folder to have no spaces and/or move it back to the Downloads folder, then rebuild.
+Rename the folder to have no spaces and/or move it back to the Downloads folder,
+then rebuild.
 
 ## Apple Watch: Loop app not appearing
+
 Error: **<u>Apple watch app is not appearing</u>**.
 
-Solution: Usually because you have not updated to watchOS prior to when you built Loop, or you didn't have your Apple watch paired at the time of building Loop.  Don't forget to open the iPhone's Watch app, select My Watch tab on the bottom left, scroll all the way down, and click `Install` for the Loop app listed at the very bottom under "available apps".
+Solution: Usually because you have not updated to watchOS prior to when you
+built Loop, or you didn't have your Apple watch paired at the time of building
+Loop. Don't forget to open the iPhone's Watch app, select My Watch tab on the
+bottom left, scroll all the way down, and click `Install` for the Loop app
+listed at the very bottom under "available apps".
 
 ## Apple Watch: Loop app not installing
-Error: **<u>The Loop app appears on the list of apps available to install on the watch, but when you press "install", and it goes through the animation of filling in the circle while it's installing, but then at the end it just toggles back to saying "INSTALL"</u>**.
 
-Solution:  Plug your iPhone into the computer and start Xcode.  On your watch, look for a prompt that says "Trust this computer".  Scroll down on the watch face and select the "Trust" button.  
+Error: **<u>The Loop app appears on the list of apps available to install on the
+watch, but when you press "install", and it goes through the animation of
+filling in the circle while it's installing, but then at the end it just toggles
+back to saying "INSTALL"</u>**.
 
-Now we need to do one step before rebuilding Loop app again. Go to the top menu bar of Xcode and select "Clean Build Folder" from the Product menu option. Rebuild your Loop app. 
+Solution: Plug your iPhone into the computer and start Xcode. On your watch,
+look for a prompt that says "Trust this computer". Scroll down on the watch face
+and select the "Trust" button.
 
-For an unknown reason (developers are working on fixing it currently), if you do repeated builds in the same Loop project folder...the watch app can fail to install properly after the first build. Therefore, a simple "Clean Build Folder" will reset the folder back to new and you'll be able to install the watch after that fresh build.
+Now we need to do one step before rebuilding Loop app again. Go to the top menu
+bar of Xcode and select "Clean Build Folder" from the Product menu option.
+Rebuild your Loop app.
 
+For an unknown reason (developers are working on fixing it currently), if you do
+repeated builds in the same Loop project folder...the watch app can fail to
+install properly after the first build. Therefore, a simple "Clean Build Folder"
+will reset the folder back to new and you'll be able to install the watch after
+that fresh build.

--- a/docs/build/code_customization.md
+++ b/docs/build/code_customization.md
@@ -1,14 +1,25 @@
 ## Code Customizations
-Based on Loop users’ experience, there are some customizations that you may want to incorporate ahead of building your Loop app and Apple Watch app.  These customizations must be done prior to building the Loop app onto your iPhone, they cannot be done from within the app itself.
 
-!!!info ""
-    Note: Every effort will be made to update the line numbers as the code is updated, but there may be times where the screenshots and line numbers are slightly different than the current version of Loop code.  These instructions have been updated for Loop v1.9.4.
+Based on Loop users’ experience, there are some customizations that you may want
+to incorporate ahead of building your Loop app and Apple Watch app. These
+customizations must be done prior to building the Loop app onto your iPhone,
+they cannot be done from within the app itself.
+
+!!!info "" Note: Every effort will be made to update the line numbers as the
+code is updated, but there may be times where the screenshots and line numbers
+are slightly different than the current version of Loop code. These instructions
+have been updated for Loop v1.9.4.
 
 ### Disable Authentication for Bolusing
 
-Depending on your iPhone preferences and model, you may have Face ID or Touch ID enabled.  Those security features will also be used to authenticate bolus delivery in Loop.  You can choose to disable authentication (i.e., not require Face ID, Touch ID, or passcode for bolusing) through the following code customization:
+Depending on your iPhone preferences and model, you may have Face ID or Touch ID
+enabled. Those security features will also be used to authenticate bolus
+delivery in Loop. You can choose to disable authentication (i.e., not require
+Face ID, Touch ID, or passcode for bolusing) through the following code
+customization:
 
- Modify Line 191 in the Loop>>View Controllers>>BolusViewController.swift.  Add the `false &&` as shown in the screenshot below:
+Modify Line 191 in the Loop>>View Controllers>>BolusViewController.swift. Add
+the `false &&` as shown in the screenshot below:
 
 <p align="center">
 <img src="../img/custom-id.png" width="750">
@@ -19,7 +30,13 @@ Depending on your iPhone preferences and model, you may have Face ID or Touch ID
 <img style="float: right;" width="200" src="../img/workout_default.png">
 If you’d like more than just the standard 1 or 2-hour duration for the Workout Range, you can add or modify the code to add another time interval or edit the existing ones.
 
-Go to the Loop>>Extensions>>UIAlertController.swift and modify Line 32.  The default has 1 and 2 hours as shown where the arrow is pointing in the screenshot.  You can edit those to whatever duration you want (in units of hours) and add a duration if you prefer.  If you’d like 1, 2, and 3 hours options...simply edit the numbers in the brackets to read [1, 2, 3]. It is possible to enter less than 1-hour intervals such as 15 min, 30 min, 45 min by editing the brackets to read [0.25, 0.5, 0.75].
+Go to the Loop>>Extensions>>UIAlertController.swift and modify Line 32. The
+default has 1 and 2 hours as shown where the arrow is pointing in the
+screenshot. You can edit those to whatever duration you want (in units of hours)
+and add a duration if you prefer. If you’d like 1, 2, and 3 hours
+options...simply edit the numbers in the brackets to read [1, 2, 3]. It is
+possible to enter less than 1-hour intervals such as 15 min, 30 min, 45 min by
+editing the brackets to read [0.25, 0.5, 0.75].
 
 <p align="center">
 <img src="../img/workout_add.png" width="750">
@@ -29,43 +46,72 @@ Go to the Loop>>Extensions>>UIAlertController.swift and modify Line 32.  The def
 
 <img style="float: right;" width="200" src="../img/carb_screen.png">
 
-Loop’s default carb absorption times are based on the high, medium, and low glycemic index absorption curves presented in <i>Think Like A Pancreas</i> by Gary Scheiner.  Currently the lollipop icon is set for 2 hours, taco icon for 3 hours, and pizza icon for 4 hours.  
+Loop’s default carb absorption times are based on the high, medium, and low
+glycemic index absorption curves presented in <i>Think Like A Pancreas</i> by
+Gary Scheiner. Currently the lollipop icon is set for 2 hours, taco icon for 3
+hours, and pizza icon for 4 hours.
 
-You can modify these defaults to suit your needs, however modification of these values is not as helpful/common as previous Loop versions. Since Loop v1.4, Loop has included dynamic carb absorption means that Loop will start with your entered carb absorption time (initially multiplying the absorption time by 1.5 to help give an margin of error), and then dynamically adjust the observed absorption time (either shorter or longer) based on the observed BG impacts.  So, typically, most people are finding that modification of the default carb absorption times is no longer necessary.
+You can modify these defaults to suit your needs, however modification of these
+values is not as helpful/common as previous Loop versions. Since Loop v1.4, Loop
+has included dynamic carb absorption means that Loop will start with your
+entered carb absorption time (initially multiplying the absorption time by 1.5
+to help give an margin of error), and then dynamically adjust the observed
+absorption time (either shorter or longer) based on the observed BG impacts. So,
+typically, most people are finding that modification of the default carb
+absorption times is no longer necessary.
 
-If you would like to modify those defaults, you can do so in the Loop>>Managers>>LoopDataManager.swift Lines 65-67.  Note the times are in hours, not minutes, in the code.  For Omnipod-testing branch users, this code is instead found in Loop Core >> LoopSettings.swift Line 16.
+If you would like to modify those defaults, you can do so in the
+Loop>>Managers>>LoopDataManager.swift Lines 65-67. Note the times are in hours,
+not minutes, in the code. For Omnipod-testing branch users, this code is instead
+found in Loop Core >> LoopSettings.swift Line 16.
 
 <p align="center">
 <img src="../img/carb_times.png" width="750">
 </p>
 
 ### Exponential Insulin Curve
-The Exponential Insulin Curve Models (Rapid-Acting Adult, Rapid-Acting Child, and Fiasp) default to an insulin duration of 360 minutes...but the peak activity of the various curves differs, as follows:
 
-* Rapid-acting adult curve peaks at 75 minutes
-* Rapid-acting child curve peaks at 65 minutes
-* Fiasp peaks curve peaks at 55 minutes
+The Exponential Insulin Curve Models (Rapid-Acting Adult, Rapid-Acting Child,
+and Fiasp) default to an insulin duration of 360 minutes...but the peak activity
+of the various curves differs, as follows:
 
-If you wish to customize these values, you can adjust them on Lines 22-38 in the Common>>Models>>Insulin>>ExponentialInsulinModelPreset.swift file
+- Rapid-acting adult curve peaks at 75 minutes
+- Rapid-acting child curve peaks at 65 minutes
+- Fiasp peaks curve peaks at 55 minutes
+
+If you wish to customize these values, you can adjust them on Lines 22-38 in the
+Common>>Models>>Insulin>>ExponentialInsulinModelPreset.swift file
 
 <p align="center">
 <img src="../img/exponential.png" width="750">
 </p>
 
 ### Loop Logo
-If you want an app logo other than the default green circle for your Loop app, you can easily customize this.  To make it easy to generate the correct sizes of icons, you can use a site like [appicon.build](http://www.appicon.build/) and just drag and drop your source image. The source image needs to be 1024 pixels x 1024 pixels.  The site will email you a zip file.  Double click the zip file, choose the “ios” folder, and copy the contents of the Appicon.appiconset as shown highlighted below.
+
+If you want an app logo other than the default green circle for your Loop app,
+you can easily customize this. To make it easy to generate the correct sizes of
+icons, you can use a site like [appicon.build](http://www.appicon.build/) and
+just drag and drop your source image. The source image needs to be 1024 pixels x
+1024 pixels. The site will email you a zip file. Double click the zip file,
+choose the “ios” folder, and copy the contents of the Appicon.appiconset as
+shown highlighted below.
 
 <p align="center">
 <img src="../img/appicon1.jpg" width="450">
 </p>
 
-Now navigate to the corresponding Loop folder as shown below.  Replace the contents of the Appicon.appiconset with your copied images.
+Now navigate to the corresponding Loop folder as shown below. Replace the
+contents of the Appicon.appiconset with your copied images.
 
 <p align="center">
 <img src="../img/appicon2.jpg" width="450">
 </p>
 
-You can confirm the successful change by looking in Xcode.  You should see your custom logo in the Appicon set now.  You will also likely see a yellow alert that there are “unassigned children”.  This alert will not prevent your app from building, it’s simply because the zip file contained more sizes of images than Loop app uses.  You can just leave the unassigned images as is.
+You can confirm the successful change by looking in Xcode. You should see your
+custom logo in the Appicon set now. You will also likely see a yellow alert that
+there are “unassigned children”. This alert will not prevent your app from
+building, it’s simply because the zip file contained more sizes of images than
+Loop app uses. You can just leave the unassigned images as is.
 
 <p align="center">
 <img src="../img/appicon3.jpg" width="450">
@@ -74,14 +120,28 @@ You can confirm the successful change by looking in Xcode.  You should see your 
 ### Apple Watch Customizations
 
 #### Recommended Bolus Autofill
-The Apple Watch's default is to auto-fill to 75% of the recommended bolus.  If you wish, you can customize so that the watch auto-fills a different percentage. To do this, the multiplier can be changed from 0.75 to a value of your choice. A value of 1 will autofill 100% of the recommended bolus. A value of 0 will autofill 0% of the recommended bolus.   Go to the Watchapp Extension>>Controllers>>BolusInterfaceController.swift. Edit the section of line 96 for your customization.
+
+The Apple Watch's default is to auto-fill to 75% of the recommended bolus. If
+you wish, you can customize so that the watch auto-fills a different percentage.
+To do this, the multiplier can be changed from 0.75 to a value of your choice. A
+value of 1 will autofill 100% of the recommended bolus. A value of 0 will
+autofill 0% of the recommended bolus. Go to the Watchapp
+Extension>>Controllers>>BolusInterfaceController.swift. Edit the section of line
+96 for your customization.
 
 <p align="center">
 <img src="../img/watch_bolus.png" width="750">
 </p>
 
 #### Adjust the sensitivity of digital crown for carb and bolus entry
-The rate of change of the carb and bolus entry pickers when using the digital crown can be altered. You'll need to edit two lines in files within the WatchApp Extension>>Controllers folder.  In BolusInterfaceController.swift edit line 174, and in AddCarbsInterfaceController.swift edit line 215. The 1/24 value is the ratio of rotations of the crown to the amount of change in the value. Changing it to 1/12 would mean that twice as many turns would be needed for the same amount of carb or bolus entry.
+
+The rate of change of the carb and bolus entry pickers when using the digital
+crown can be altered. You'll need to edit two lines in files within the WatchApp
+Extension>>Controllers folder. In BolusInterfaceController.swift edit line 174,
+and in AddCarbsInterfaceController.swift edit line 215. The 1/24 value is the
+ratio of rotations of the crown to the amount of change in the value. Changing
+it to 1/12 would mean that twice as many turns would be needed for the same
+amount of carb or bolus entry.
 
 <p align="center">
 <img src="../img/sensitivity1.png" width="800">
@@ -90,5 +150,3 @@ The rate of change of the carb and bolus entry pickers when using the digital cr
 <p align="center">
 <img src="../img/sensitivity2.png" width="800">
 </p>
-
-

--- a/docs/build/health.md
+++ b/docs/build/health.md
@@ -1,6 +1,12 @@
 # Health Data
 
-Loop app uses the iPhone's Health app to store blood glucose, insulin, and carbohydrate data. Additional details about how to use Health to interpret your longer-term looping data can be found [here in LoopTips](https://kdisimone.github.io/looptips/data/health/). Health data can also be accessed and uploaded by Tidepool's Mobile app and is an important step in Jaeb Observational Study enrollment. Please review the settings below to ensure you have the proper settings.
+Loop app uses the iPhone's Health app to store blood glucose, insulin, and
+carbohydrate data. Additional details about how to use Health to interpret your
+longer-term looping data can be found
+[here in LoopTips](https://kdisimone.github.io/looptips/data/health/). Health
+data can also be accessed and uploaded by Tidepool's Mobile app and is an
+important step in Jaeb Observational Study enrollment. Please review the
+settings below to ensure you have the proper settings.
 
 ## Loop Permissions
 
@@ -11,10 +17,12 @@ Loop app uses the iPhone's Health app to store blood glucose, insulin, and carbo
 
 ## Dexcom Permissions
 
-You also need to enable your Dexcom app to write to the Health app. You can find this in your Dexcom app's Settings, under Health.  Click on the `Enable` button and then `Turn All Categories On` so that the toggle for allowing Dexcom to write data is now a green color.
+You also need to enable your Dexcom app to write to the Health app. You can find
+this in your Dexcom app's Settings, under Health. Click on the `Enable` button
+and then `Turn All Categories On` so that the toggle for allowing Dexcom to
+write data is now a green color.
 
 <p align="center">
 <img src="../img/health_g5.jpg" width="550">
 </p>
 </br></br>
-

--- a/docs/build/new-iphone.md
+++ b/docs/build/new-iphone.md
@@ -1,16 +1,27 @@
 # New iPhone
 
-If you get a new iPhone, the Loop app will need to be rebuilt onto the iPhone. Loop will not restore onto the new phone from a saved backup.
+If you get a new iPhone, the Loop app will need to be rebuilt onto the iPhone.
+Loop will not restore onto the new phone from a saved backup.
 
 To install Loop onto the new iPhone just take a few simple steps.
 
-1. Pair your new iPhone with your existing Apple Watch before rebuilding Loop onto the new iPhone.</br>
+1. Pair your new iPhone with your existing Apple Watch before rebuilding Loop
+   onto the new iPhone.</br>
 
-2. Follow the directions in the [Updating Loop page](https://loopkit.github.io/loopdocs/build/update/updating/). The only difference in steps for installing on a new iPhone vs. updating on an old iPhone is that you will be prompted to `Register Device` in the signing targets area because the new iPhone needs to be registered with your developer account. Easy, single button press in Xcode's target area will complete the registration.</br>
+2. Follow the directions in the
+   [Updating Loop page](https://loopkit.github.io/loopdocs/build/update/updating/).
+   The only difference in steps for installing on a new iPhone vs. updating on
+   an old iPhone is that you will be prompted to `Register Device` in the
+   signing targets area because the new iPhone needs to be registered with your
+   developer account. Easy, single button press in Xcode's target area will
+   complete the registration.</br>
 
-3. You will need to input your Loop settings and configurations from scratch in the new iPhone.</br>
+3. You will need to input your Loop settings and configurations from scratch in
+   the new iPhone.</br>
 
-4. You will need to slide the RileyLink slider "off" in the old iPhone in order for it to pair with the new iPhone's Loop app.
+4. You will need to slide the RileyLink slider "off" in the old iPhone in order
+   for it to pair with the new iPhone's Loop app.
 
-If you are a Omnipod user...yes, a new phone will mean a new pod will be required when you switch devices. Plan accordingly to time your switch when it is also convenient to change pods.
-
+If you are a Omnipod user...yes, a new phone will mean a new pod will be
+required when you switch devices. Plan accordingly to time your switch when it
+is also convenient to change pods.

--- a/docs/build/overview.md
+++ b/docs/build/overview.md
@@ -1,14 +1,16 @@
 # Overview of Build Process
 
-The overall installation process is pretty simple. We start with checking that you have the compatible gear needed to Loop, do a couple of  preparation steps on the computer, and then move onto building the Loop app.
+The overall installation process is pretty simple. We start with checking that
+you have the compatible gear needed to Loop, do a couple of preparation steps on
+the computer, and then move onto building the Loop app.
 
-While all of this is probably quite intimidating at first, I promise that it is quite doable by the average computer user. 
+While all of this is probably quite intimidating at first, I promise that it is
+quite doable by the average computer user.
 
-!!!info "Take it one step at a time..."
-    If you are worried about how long this will take, you can always stop at one of the steps and come back later. The steps are meant to be nice stopping points to take breaks if needed.
+!!!info "Take it one step at a time..." If you are worried about how long this
+will take, you can always stop at one of the steps and come back later. The
+steps are meant to be nice stopping points to take breaks if needed.
 
 <p align="center">
 <img src="https://media.giphy.com/media/xThta8UkUaoqJoJQC4/giphy.gif" width="400">
 </p>
-
-

--- a/docs/build/step1.md
+++ b/docs/build/step1.md
@@ -1,30 +1,49 @@
 # Step 1: Compatible Computer
 
-!!!danger "Time Estimate"
-    * 5 minutes, if already have Mojave macOS
-    * 30-60 minutes, if need to install macOS updates
+!!!danger "Time Estimate" _ 5 minutes, if already have Mojave macOS _ 30-60
+minutes, if need to install macOS updates
 
-!!!info "Summary"
-    * Check your macOS and make sure it is Mojave.
-    * Do not use any of the beta macOS versions. (If you don't know what that means, don't worry...that means you aren't using one.)
-    * If your macOS is not Mojave, check to see if you can up update your macOS to Mojave and do so.
-    * If you cannot upgrade your existing computer to Mojave, you'll need to check into a borrowed computer, patcher tool, or perhaps a new/used computer compatible with Mojave.
-    * Check the `Software Update` to see if your Mojave version has any updates available since you first installed it.
+!!!info "Summary" _ Check your macOS and make sure it is Mojave. _ Do not use
+any of the beta macOS versions. (If you don't know what that means, don't
+worry...that means you aren't using one.) _ If your macOS is not Mojave, check
+to see if you can up update your macOS to Mojave and do so. _ If you cannot
+upgrade your existing computer to Mojave, you'll need to check into a borrowed
+computer, patcher tool, or perhaps a new/used computer compatible with
+Mojave. \* Check the `Software Update` to see if your Mojave version has any
+updates available since you first installed it.
 
-!!!warning "FAQs"
-    * **"Can I use a PC or Windows computer? I don't own an Apple computer."** Yes...sort of. Please see [this FAQ about using Virtual Machine](https://loopkit.github.io/loopdocs/faqs/FAQs/#can-i-use-a-pc-or-windows-computer-to-build).
-    * **"What can I do if my computer is too old to be upgraded to Mojave?"** You could take a look at using [Mojave Patcher](http://dosdude1.com/mojave/), but this is totally on your own and not part of these instructions. Just offering the answer to the FAQ...it is up to you to read about the patcher tool and what risks it may involve for you.
-    * **"Can I borrow someone else's Apple computer?"** Yes, please see [this FAQ about borrowing a computer](https://loopkit.github.io/loopdocs/faqs/FAQs/#do-i-need-to-own-my-own-apple-computer) to learn more.
-    * **"How often do I need to use the computer?"** Computer access is only required when you are initially installing the Loop app or updating to a newer Loop release. You do NOT need access to an Apple computer in order to troubleshoot or change Loop settings, such as basal profiles or carb ratios.
+!!!warning "FAQs" _ **"Can I use a PC or Windows computer? I don't own an Apple
+computer."** Yes...sort of. Please see
+[this FAQ about using Virtual Machine](https://loopkit.github.io/loopdocs/faqs/FAQs/#can-i-use-a-pc-or-windows-computer-to-build).
+_ **"What can I do if my computer is too old to be upgraded to Mojave?"** You
+could take a look at using [Mojave Patcher](http://dosdude1.com/mojave/), but
+this is totally on your own and not part of these instructions. Just offering
+the answer to the FAQ...it is up to you to read about the patcher tool and what
+risks it may involve for you. _ **"Can I borrow someone else's Apple
+computer?"** Yes, please see
+[this FAQ about borrowing a computer](https://loopkit.github.io/loopdocs/faqs/FAQs/#do-i-need-to-own-my-own-apple-computer)
+to learn more. _ **"How often do I need to use the computer?"** Computer access
+is only required when you are initially installing the Loop app or updating to a
+newer Loop release. You do NOT need access to an Apple computer in order to
+troubleshoot or change Loop settings, such as basal profiles or carb ratios.
 
 ## Check your macOS
-You need an Apple computer that has at least macOS 10.14.3 (or newer) installed. This macOS is called Mojave. To find out if you have Mojave installed, click on the little Apple icon in your computer's upper left corner and select the `About this Mac`. It doesn't matter if the computer is a MacBook, iMac, macMini, etc...just so long as it has macOS Mojave. If your computer does not have Mojave, you'll need to check the `Software Update` button on that screen to see if you can update to Mojave.
+
+You need an Apple computer that has at least macOS 10.14.3 (or newer) installed.
+This macOS is called Mojave. To find out if you have Mojave installed, click on
+the little Apple icon in your computer's upper left corner and select the
+`About this Mac`. It doesn't matter if the computer is a MacBook, iMac, macMini,
+etc...just so long as it has macOS Mojave. If your computer does not have
+Mojave, you'll need to check the `Software Update` button on that screen to see
+if you can update to Mojave.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/macosx.png" width="500">
 </p>
 
-If your computer does not give you the option to upgrade to Mojave...it is quite possible that Apple has decided your computer is too old to run Mojave. How old is too old? That will depend on your computer model and year as shown below:
+If your computer does not give you the option to upgrade to Mojave...it is quite
+possible that Apple has decided your computer is too old to run Mojave. How old
+is too old? That will depend on your computer model and year as shown below:
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/mojave-minimum.png" width="750">
@@ -32,4 +51,5 @@ If your computer does not give you the option to upgrade to Mojave...it is quite
 
 ## Next Step: Compatible iPhone/iPod touch
 
-Now you are ready to move onto Step 2 to check if you have a [Compatible iPhone/iPod touch](https://loopkit.github.io/loopdocs/build/step2/).
+Now you are ready to move onto Step 2 to check if you have a
+[Compatible iPhone/iPod touch](https://loopkit.github.io/loopdocs/build/step2/).

--- a/docs/build/step10.md
+++ b/docs/build/step10.md
@@ -1,28 +1,72 @@
 # Step 10: Test Settings
 
-!!!danger "Time Estimate"
-    * 2 hours to read the web pages thoroughly and thoughtfully
-    * 1-3 days to test settings if you are a normal person who wants to get the most out of Loop
+!!!danger "Time Estimate" _ 2 hours to read the web pages thoroughly and
+thoughtfully _ 1-3 days to test settings if you are a normal person who wants to
+get the most out of Loop
 
-!!!info "Summary"
-    * A small amount of effort to test/validate basals, carb ratios, and ISF (correction factor) will eliminate a lot of uncertainty when you start Looping.
-    * Keep an open mind that settings may need to change just as you start Loop. Hormones, illness, and failed sites can still happen just like always.
+!!!info "Summary" _ A small amount of effort to test/validate basals, carb
+ratios, and ISF (correction factor) will eliminate a lot of uncertainty when you
+start Looping. _ Keep an open mind that settings may need to change just as you
+start Loop. Hormones, illness, and failed sites can still happen just like
+always.
 
-!!!warning "FAQs"
-    * **"My endo makes my pump settings, so do I really need to test them?"** Well, nobody is going to force you...but testing your settings even just a couple days will give you a tremendous advantage going into Loop. Your endo may have very conservative overnight ISF and carb ratios that normally don't get used in traditional pump therapy, but will be used by Loop for sure. So, keep an open mind as you head into Looping on old settings if you haven't tested them recently.
-    * **"I have great control, why would I need to test my settings?"** Awesome for you! However, it is quite possible that your "great control" comes with a lot of little adjustments all the time. We all got used to needing little bumps and nudges of insulin or carbs over time...and sometimes those bumps and nudges are covering for underlying settings that need adjustment. Testing your settings will help...especially if you are coming from a treatment style that involves memorizing your insulin doses for meals...you may not know your actual carb ratio or ISF as a result of "just knowing" your boluses.
-    * **"I can't basal test with my 2-year-old. What can I do?"** I agree, that would be pretty tough. Consult your endo, watch your patterns, and do the best you can...little kiddos are a difficult group to do settings testing with. I feel ya.
+!!!warning "FAQs" _ **"My endo makes my pump settings, so do I really need to
+test them?"** Well, nobody is going to force you...but testing your settings
+even just a couple days will give you a tremendous advantage going into Loop.
+Your endo may have very conservative overnight ISF and carb ratios that normally
+don't get used in traditional pump therapy, but will be used by Loop for sure.
+So, keep an open mind as you head into Looping on old settings if you haven't
+tested them recently. _ **"I have great control, why would I need to test my
+settings?"** Awesome for you! However, it is quite possible that your "great
+control" comes with a lot of little adjustments all the time. We all got used to
+needing little bumps and nudges of insulin or carbs over time...and sometimes
+those bumps and nudges are covering for underlying settings that need
+adjustment. Testing your settings will help...especially if you are coming from
+a treatment style that involves memorizing your insulin doses for meals...you
+may not know your actual carb ratio or ISF as a result of "just knowing" your
+boluses. \* **"I can't basal test with my 2-year-old. What can I do?"** I agree,
+that would be pretty tough. Consult your endo, watch your patterns, and do the
+best you can...little kiddos are a difficult group to do settings testing with.
+I feel ya.
 
-Loop is just a fancy calculator underneath the hood. The math problems that it is solving depend on some settings that you will be providing it. It's a good idea to make sure you do a bit of settings testing before using Loop.
+Loop is just a fancy calculator underneath the hood. The math problems that it
+is solving depend on some settings that you will be providing it. It's a good
+idea to make sure you do a bit of settings testing before using Loop.
 
-**Basal rates**, if properly set, will keep your blood glucose steady without food present. You can test your basals by having a relaxing set of 4-6 hours without eating at least two hours before you begin the test. Does your blood sugar stay steady? Or do you climb and need a correction? Or do you go low and need to eat? Setting basals is a HUGE important step to setting yourself up for Loop success.
+**Basal rates**, if properly set, will keep your blood glucose steady without
+food present. You can test your basals by having a relaxing set of 4-6 hours
+without eating at least two hours before you begin the test. Does your blood
+sugar stay steady? Or do you climb and need a correction? Or do you go low and
+need to eat? Setting basals is a HUGE important step to setting yourself up for
+Loop success.
 
-**Insulin Sensitivity Factor** (sometimes called Correction Factor) is how much one unit of insulin will bring down your blood sugar. The higher the value of this setting, the more sensitive to insulin you are. An ISF of 30 means one unit of insulin brings your blood sugar down 30 mg/dL. You can test this setting after you get good basals set and tested. Simply bring yourself to a higher BG with a glucose tab or other small quick carbs. Wait until you see yourself plateau again at the higher BG, then make a correction. Wait 4-6 hours (again no food) and see where your correction lands your blood sugar. Divide the BG drop by the amount of correction insulin you delivered...that’s your ISF. 
+**Insulin Sensitivity Factor** (sometimes called Correction Factor) is how much
+one unit of insulin will bring down your blood sugar. The higher the value of
+this setting, the more sensitive to insulin you are. An ISF of 30 means one unit
+of insulin brings your blood sugar down 30 mg/dL. You can test this setting
+after you get good basals set and tested. Simply bring yourself to a higher BG
+with a glucose tab or other small quick carbs. Wait until you see yourself
+plateau again at the higher BG, then make a correction. Wait 4-6 hours (again no
+food) and see where your correction lands your blood sugar. Divide the BG drop
+by the amount of correction insulin you delivered...that’s your ISF.
 
-**Carb Ratio** is the amount of carbs covered by one unit of insulin. Ideally a good carb ratio will bring your BG back to starting point within 2-3 hours* of the meal. (*High fat/protein meals may cause BGs to be impacted longer.) If you are spiking higher than you’d like after a meal but still coming back to starting BG, consider prebolusing your meal by 15-20 minutes rather than changing carb ratio. 
+**Carb Ratio** is the amount of carbs covered by one unit of insulin. Ideally a
+good carb ratio will bring your BG back to starting point within 2-3 hours* of
+the meal. (*High fat/protein meals may cause BGs to be impacted longer.) If you
+are spiking higher than you’d like after a meal but still coming back to
+starting BG, consider prebolusing your meal by 15-20 minutes rather than
+changing carb ratio.
 
-Check [LoopTips.org](https://looptips.org) for a discussion on how to [check all these settings](https://kdisimone.github.io/looptips/settings/settings/) and [why they are important](https://kdisimone.github.io/looptips/settings/overview/). If you’re fascinated by this topic, read the book <i>Think Like A Pancreas</i> for a really great discussion. Finally remember settings can change periodically. Hormone cycles, steroids, illness, etc may lead to a [need to change settings](https://kdisimone.github.io/looptips/settings/adjust/).
+Check [LoopTips.org](https://looptips.org) for a discussion on how to
+[check all these settings](https://kdisimone.github.io/looptips/settings/settings/)
+and
+[why they are important](https://kdisimone.github.io/looptips/settings/overview/).
+If you’re fascinated by this topic, read the book <i>Think Like A Pancreas</i>
+for a really great discussion. Finally remember settings can change
+periodically. Hormone cycles, steroids, illness, etc may lead to a
+[need to change settings](https://kdisimone.github.io/looptips/settings/adjust/).
 
 ## Next Step: Make Plans for Loop Data
 
-Now you are ready to move onto Step 11 to [Make Plans for Loop Data](https://loopkit.github.io/loopdocs/build/step11/).
+Now you are ready to move onto Step 11 to
+[Make Plans for Loop Data](https://loopkit.github.io/loopdocs/build/step11/).

--- a/docs/build/step11.md
+++ b/docs/build/step11.md
@@ -1,33 +1,52 @@
 # Step 11: Make Plans for your Loop Data
 
-!!!danger "Time Estimate"
-    * Nightscout: 1-2 hours if you've never done it before and work slowly
-    * Nightscout: 20-30 minutes if you have experience in Github and Heroku previously
-    * Tidepool: 30-40 minutes to set up account and Tidepool Mobile app
-    * Apple Health: 0 minutes
+!!!danger "Time Estimate" _ Nightscout: 1-2 hours if you've never done it before
+and work slowly _ Nightscout: 20-30 minutes if you have experience in Github and
+Heroku previously _ Tidepool: 30-40 minutes to set up account and Tidepool
+Mobile app _ Apple Health: 0 minutes
 
-!!!info "Summary"
-    * Review the three major systems that can store and show your Loop data. 
-    * Set up either Tidepool or Nightscout prior to your next endo appointment in order to provide them Looping data to review.
+!!!info "Summary" _ Review the three major systems that can store and show your
+Loop data. _ Set up either Tidepool or Nightscout prior to your next endo
+appointment in order to provide them Looping data to review.
 
-!!!warning "FAQs"
-    * **"Do I have to set one of these up?"** No. But, your health care provider really does need data. Insurance companies definitely demand data too...so make them happy.
-    * **"Do I need all three?"** No, you can mix-and-match. Apple Health is already built into your iPhone, so there's no setup involved anyways. Nightscout setup is really actually quite easy and Loopdocs has a [complete set of instructions for Loop users](https://loopkit.github.io/loopdocs/nightscout/new_user/). Nightscout has a lot of useful alarms and alerts, too. Tidepool is free and easy to set up, and many clinics already have Tidepool integration.
-    * **Is it worth the time to setup Nightscout? I feel like I'm already doing so much outside my comfort zone."** Yes. The feedback from the thousands of people that have come before you is YES, it is worth the minimal time investment to set up a Nightscout site.
+!!!warning "FAQs" _ **"Do I have to set one of these up?"** No. But, your health
+care provider really does need data. Insurance companies definitely demand data
+too...so make them happy. _ **"Do I need all three?"** No, you can
+mix-and-match. Apple Health is already built into your iPhone, so there's no
+setup involved anyways. Nightscout setup is really actually quite easy and
+Loopdocs has a
+[complete set of instructions for Loop users](https://loopkit.github.io/loopdocs/nightscout/new_user/).
+Nightscout has a lot of useful alarms and alerts, too. Tidepool is free and easy
+to set up, and many clinics already have Tidepool integration. \* **Is it worth
+the time to setup Nightscout? I feel like I'm already doing so much outside my
+comfort zone."** Yes. The feedback from the thousands of people that have come
+before you is YES, it is worth the minimal time investment to set up a
+Nightscout site.
 
-Ok, technically this step could wait until after you build Loop app...but I have your attention now, so I'm taking advantage of it.
+Ok, technically this step could wait until after you build Loop app...but I have
+your attention now, so I'm taking advantage of it.
 
-With Loop use, you will no longer be using your PDM (if you use Omnipods) and your pump (if you use Medtronic) will so full of temp basals that the endos will have nothing to download at your next visit. This [lack of data](https://kdisimone.github.io/looptips/data/overview/) will cause a little friction with the health care industry; not good for your insurance records, not good for your endo to feel comfortable, and not good for you to know how your Loop use might be improved with settings tweaks.
+With Loop use, you will no longer be using your PDM (if you use Omnipods) and
+your pump (if you use Medtronic) will so full of temp basals that the endos will
+have nothing to download at your next visit. This
+[lack of data](https://kdisimone.github.io/looptips/data/overview/) will cause a
+little friction with the health care industry; not good for your insurance
+records, not good for your endo to feel comfortable, and not good for you to
+know how your Loop use might be improved with settings tweaks.
 
-So let's explore options for your Loop data. There are three great options for where your Loop data can be stored and retrieved:
+So let's explore options for your Loop data. There are three great options for
+where your Loop data can be stored and retrieved:
 
-* [Apple Health app](https://kdisimone.github.io/looptips/data/health/)
-* [Nightscout](https://kdisimone.github.io/looptips/data/nightscout/)
-* [Tidepool](https://kdisimone.github.io/looptips/data/tidepool/)
+- [Apple Health app](https://kdisimone.github.io/looptips/data/health/)
+- [Nightscout](https://kdisimone.github.io/looptips/data/nightscout/)
+- [Tidepool](https://kdisimone.github.io/looptips/data/tidepool/)
 
-All of the options are free and easy to setup. Take some time to familiarize yourself with these options and setup your preferred system(s). Personally, I use all three for various aspects of my data's story to me...Nightscout being the most useful day-to-day as a remote caregiver of a young Looper.
+All of the options are free and easy to setup. Take some time to familiarize
+yourself with these options and setup your preferred system(s). Personally, I
+use all three for various aspects of my data's story to me...Nightscout being
+the most useful day-to-day as a remote caregiver of a young Looper.
 
 ## Next Step: Meet Community
 
-Now you are ready to move onto Step 12 to [Meet Community](https://loopkit.github.io/loopdocs/build/step12/).
-
+Now you are ready to move onto Step 12 to
+[Meet Community](https://loopkit.github.io/loopdocs/build/step12/).

--- a/docs/build/step12.md
+++ b/docs/build/step12.md
@@ -1,60 +1,144 @@
 # Step 12: Meet the Community
 
-!!!danger "Time Estimate"
-    * Joining Looped Group: 5 minutes
-    * Joining Zulipchat: 10 minutes
+!!!danger "Time Estimate" _ Joining Looped Group: 5 minutes _ Joining Zulipchat:
+10 minutes
 
-!!!info "Summary"
-    * Use the search tools in Looped, Zulipchat, Loopdocs, and Looptips
-    * If asking for help, remember the motto "Help me help you"...provide information. Avoid vague phrases and the word "it". Aim for details and specifics. Screenshots are gold.
+!!!info "Summary" _ Use the search tools in Looped, Zulipchat, Loopdocs, and
+Looptips _ If asking for help, remember the motto "Help me help you"...provide
+information. Avoid vague phrases and the word "it". Aim for details and
+specifics. Screenshots are gold.
 
-!!!warning "FAQs"
-    * **"I'm worried I'll ask a stupid question"** Don't worry about that...instead just focus on asking a **thorough** question. A thorough question explains what you've already tried or read, has screenshots of what you are confused by, and any other details that you can provide.
+!!!warning "FAQs" \* **"I'm worried I'll ask a stupid question"** Don't worry
+about that...instead just focus on asking a **thorough** question. A thorough
+question explains what you've already tried or read, has screenshots of what you
+are confused by, and any other details that you can provide.
 
 ## Online groups
-There's a whole wonderful community of people already Looping who willing to help you through the process. You can find them in two main areas; [Looped group on Facebook](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf) and [Zulipchat](https://loop.zulipchat.com).
 
-These groups, as with Loop itself, are entirely driven by VOLUNTEERS. None of the people are paid to answer questions or spend time troubleshooting...they do it because they want to help others. Please decrease that support burden by doing some simple steps yourself before turning to others for help. Please click the image below to watch this video full of tips to make the most of your online resources.
+There's a whole wonderful community of people already Looping who willing to
+help you through the process. You can find them in two main areas;
+[Looped group on Facebook](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf)
+and [Zulipchat](https://loop.zulipchat.com).
+
+These groups, as with Loop itself, are entirely driven by VOLUNTEERS. None of
+the people are paid to answer questions or spend time troubleshooting...they do
+it because they want to help others. Please decrease that support burden by
+doing some simple steps yourself before turning to others for help. Please click
+the image below to watch this video full of tips to make the most of your online
+resources.
 
 <a href="https://youtu.be/_vSN6C-Uo04" target="_blank"><img src="../img/looped-group.png"  title="How to use Looped Group effectively" /></a>
 
 ## Screenshots
-One super valuable tool for posting to online groups is the ability to take screenshots of your issue and use them in your posts. On an Apple computer, simply press `shift-command-4` keys at the same time and a little crosshairs tool for taking screenshots will appear. Click-and-drag across the area you'd like to screenshot. When you let go of the button, the screenshot will be saved to your desktop with a file name starting with "screenshot". Use screenshots over cell phone images or words whenever possible...screenshots are higher resolution and easier to read.
 
-Additionally, take a wider screenshot than you may initially think you need. Especially if you are posting asking for help with settings or Xcode build errors. Nightscout and Xcode have lots of valuable information off-to-the-side that many people dismiss, when really it can be valuable for troubleshooters.
+One super valuable tool for posting to online groups is the ability to take
+screenshots of your issue and use them in your posts. On an Apple computer,
+simply press `shift-command-4` keys at the same time and a little crosshairs
+tool for taking screenshots will appear. Click-and-drag across the area you'd
+like to screenshot. When you let go of the button, the screenshot will be saved
+to your desktop with a file name starting with "screenshot". Use screenshots
+over cell phone images or words whenever possible...screenshots are higher
+resolution and easier to read.
+
+Additionally, take a wider screenshot than you may initially think you need.
+Especially if you are posting asking for help with settings or Xcode build
+errors. Nightscout and Xcode have lots of valuable information off-to-the-side
+that many people dismiss, when really it can be valuable for troubleshooters.
 
 ## Descriptive Language
-Descriptive language doesn't mean the four-letter words that get you frowns at the cocktail parties. Instead, this phrase means to use the most accurate, detailed words that you can when asking for help. In summary, try to avoid the word "it" and instead use details and information to help fill in the story about why you're asking for help, what you've already tried, and what happened when you tried those things (including screenshots). Let's illustrate with a couple of examples.
+
+Descriptive language doesn't mean the four-letter words that get you frowns at
+the cocktail parties. Instead, this phrase means to use the most accurate,
+detailed words that you can when asking for help. In summary, try to avoid the
+word "it" and instead use details and information to help fill in the story
+about why you're asking for help, what you've already tried, and what happened
+when you tried those things (including screenshots). Let's illustrate with a
+couple of examples.
 
 ### Example 1
-**Bad:** "It's not working." <----makes me wonder what "it" is? What part of "it" isn't working exactly? The app? The BG control? The pump integration? Alarms? Bolusing? Their Dexcom?
 
-**Ok:** "My Loop app won't open." <---- Ok, so now I know the Loop app itself seems to be the problem, but still don't know if this is a build error or an error that has happened after building. The solutions would be different potentially. 
+**Bad:** "It's not working." <----makes me wonder what "it" is? What part of
+"it" isn't working exactly? The app? The BG control? The pump integration?
+Alarms? Bolusing? Their Dexcom?
 
-**Better:** "My Loop app was working yesterday just fine, and now today it's not doing the things like I expect." <----- Getting closer. Now I know this is not a build error and that it sounds like a more recent issue. I'm starting to narrow down the potential causes...this is about as much detail as it takes for me, as a volunteer, to consider to start helping. I might not have to ask 42 questions but instead only 4 questions now to find the remaining information for troubleshooting. But, if there were more details...I'd be more likely to wade in to help because more details saves me from questions.
+**Ok:** "My Loop app won't open." <---- Ok, so now I know the Loop app itself
+seems to be the problem, but still don't know if this is a build error or an
+error that has happened after building. The solutions would be different
+potentially.
 
-**Awesome:** "My Loop app was working yesterday just fine. Around lunch time, I went into the settings screen and made some adjustments and ever since it just turns white and closes no matter what I try." <---- DEFINITELY getting closer. Now I have a strong suspicion about where the bug is happening and can help with a couple links.
+**Better:** "My Loop app was working yesterday just fine, and now today it's not
+doing the things like I expect." <----- Getting closer. Now I know this is not a
+build error and that it sounds like a more recent issue. I'm starting to narrow
+down the potential causes...this is about as much detail as it takes for me, as
+a volunteer, to consider to start helping. I might not have to ask 42 questions
+but instead only 4 questions now to find the remaining information for
+troubleshooting. But, if there were more details...I'd be more likely to wade in
+to help because more details saves me from questions.
 
-**GOLD MEDAL WORTHY:** "My Loop app was working yesterday just fine. Around lunch time, I went into the settings screen and made some adjustments to correction ranges. Ever since I did that, the app immediately turns white and shuts down. I have tried restarting my phone, but it has not fixed the problem. I tried searching the docs for 'loop closing' but didn't see results that matched my issue." <----- This person is doing an outstanding job of describing the problem. Lots of good details. Has shown initiative to try to use the resources already. Throw in a screenshot, if it was appropriate, and this person will have done an excellent job of helping all of us help him/her.
+**Awesome:** "My Loop app was working yesterday just fine. Around lunch time, I
+went into the settings screen and made some adjustments and ever since it just
+turns white and closes no matter what I try." <---- DEFINITELY getting closer.
+Now I have a strong suspicion about where the bug is happening and can help with
+a couple links.
+
+**GOLD MEDAL WORTHY:** "My Loop app was working yesterday just fine. Around
+lunch time, I went into the settings screen and made some adjustments to
+correction ranges. Ever since I did that, the app immediately turns white and
+shuts down. I have tried restarting my phone, but it has not fixed the problem.
+I tried searching the docs for 'loop closing' but didn't see results that
+matched my issue." <----- This person is doing an outstanding job of describing
+the problem. Lots of good details. Has shown initiative to try to use the
+resources already. Throw in a screenshot, if it was appropriate, and this person
+will have done an excellent job of helping all of us help him/her.
 
 ### Example 2
-**Bad:** "My Loop app won't build." <----- What step are you on? What kind of computer are you using? What macOS? What Xcode version? Have you built successfully before or is this new?
 
-**Ok:** "I'm trying to update my Loop app to the new omnipod-testing branch, and am getting a few errors that I don't understand." <----- Wow, sure would be nice to know what those error messages are. Are they red or yellow? A screenshot sure would help here.
+**Bad:** "My Loop app won't build." <----- What step are you on? What kind of
+computer are you using? What macOS? What Xcode version? Have you built
+successfully before or is this new?
 
-**Better:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3. Downloaded Loop-omnipod-testing branch this morning and I'm getting some red errors about an exit code that I don't understand." <----- Cool, now I don't have to ask if they updated their macOS like the directions say to do, and I can rule out Xcode being old. Still would be great to have screenshots so I can see the exact error message.
+**Ok:** "I'm trying to update my Loop app to the new omnipod-testing branch, and
+am getting a few errors that I don't understand." <----- Wow, sure would be nice
+to know what those error messages are. Are they red or yellow? A screenshot sure
+would help here.
 
-**Awesome:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3. Downloaded Loop-omnipod-testing branch this morning and I'm getting some red errors about an exit code that I don't understand. I've tried everything in the docs and nothing worked." <---- While I'm super happy they "tried everything", I'm no closer to knowing what the exact error message is nor which "stuff" exactly they tried. 
+**Better:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3. Downloaded
+Loop-omnipod-testing branch this morning and I'm getting some red errors about
+an exit code that I don't understand." <----- Cool, now I don't have to ask if
+they updated their macOS like the directions say to do, and I can rule out Xcode
+being old. Still would be great to have screenshots so I can see the exact error
+message.
 
-**GOLD MEDAL WORTHY:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3. Downloaded Loop-omnipod-testing branch this morning and I'm getting some red errors about an exit code 645 that I don't understand. Here's the screenshot of the error message. I tried searching the docs for "exit code 645" and didn't see any responses that helped. I tried the "carthage update" solution but got an error message during that too...here's the screenshot for that as well." <---- OH BABY I love you. This is the kind of detail that will get you to an answer very fast.
+**Awesome:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3. Downloaded
+Loop-omnipod-testing branch this morning and I'm getting some red errors about
+an exit code that I don't understand. I've tried everything in the docs and
+nothing worked." <---- While I'm super happy they "tried everything", I'm no
+closer to knowing what the exact error message is nor which "stuff" exactly they
+tried.
+
+**GOLD MEDAL WORTHY:** "I have a macOS Mojave 10.14.5 computer with Xcode 10.3.
+Downloaded Loop-omnipod-testing branch this morning and I'm getting some red
+errors about an exit code 645 that I don't understand. Here's the screenshot of
+the error message. I tried searching the docs for "exit code 645" and didn't see
+any responses that helped. I tried the "carthage update" solution but got an
+error message during that too...here's the screenshot for that as well." <----
+OH BABY I love you. This is the kind of detail that will get you to an answer
+very fast.
 
 ## Be ok with links
 
-A lot of time, the answer to your question for help will be answered with a link. Please don't take offense to getting a quick link back to LoopDocs or LoopTips. This is most often because the question is already answered there and the person is simply saving time by not typing out what already exists elsewhere. 
+A lot of time, the answer to your question for help will be answered with a
+link. Please don't take offense to getting a quick link back to LoopDocs or
+LoopTips. This is most often because the question is already answered there and
+the person is simply saving time by not typing out what already exists
+elsewhere.
 
-If you've searched the docs and read the info already, then please include that in your post. That way you don't get linked back to the same part you're already confused about. Plus, letting us know when these docs can be improved is very useful. 
+If you've searched the docs and read the info already, then please include that
+in your post. That way you don't get linked back to the same part you're already
+confused about. Plus, letting us know when these docs can be improved is very
+useful.
 
 ## Next Step: Download Loop Code
 
-Now you are ready to move onto Step 13 to [Download Loop Code](https://loopkit.github.io/loopdocs/build/step13/).
-
+Now you are ready to move onto Step 13 to
+[Download Loop Code](https://loopkit.github.io/loopdocs/build/step13/).

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -1,22 +1,41 @@
 # Step 13: Download Loop code
 
-!!!danger "Time Estimate"
-    * 1 minute to download Loop code
-    * 10 minutes to read this page
-    
-!!!info "Summary"
-    * If you want to use Omnipod Loop, you should use the omnipod-testing branch
-    * Dev branch technically has Omnipod support now, but is still considered less stable than omnipod-testing branch for the average user
-    * Medtronic pumps are supported on all branches of Loop
-    
-!!!warning "FAQs"
-    * **"What the heck is a branch?"** Let's use an analogy of when a book is published, sometimes a little later the author decides to make edits to the published book. They will have a "mark-up" copy of the original version and make edits. In this analogy, `master branch` is a published book. It is considered a stable, well-reviewed and tested version of the Loop app. As new features and improvements are made, they are made into the "mark-up copy" called `dev branch`. The dev branch will likely have some bugs and changes on a more frequent basis as the new edits are tested and revised. Other people may also have their own branches, based on the original published book since this is an open-source project, beyond just the Loop developers. There are no documents that track all the "unofficial" branches of Loop that others may have...there could be an endless amount, updated randomly, and not all of them in good working order so would be pointless to try to track them all.
-    * **"How can I tell which version I have downloaded if I'm unsure?"** The downloaded Loop folder's name will give you an indication of which branch you downloaded. The folder name will be in the format `Loop-BranchName`. 
-    * **"When do I need to download new Loop code?"** Anytime you want to update your Loop app to get new features, you'll simply download the code again by clicking on the links below. The links always go to the most recent version of each of the branches. It's a good idea is to delete your old downloads before making a new one, just to avoid confusion.
+!!!danger "Time Estimate" _ 1 minute to download Loop code _ 10 minutes to read
+this page
 
-You’ll need to download the Loop code in order to build the app on your computer.  Wondering which to choose? Read the discussion below **BEFORE** clicking on one of the links to download.
+!!!info "Summary" _ If you want to use Omnipod Loop, you should use the
+omnipod-testing branch _ Dev branch technically has Omnipod support now, but is
+still considered less stable than omnipod-testing branch for the average user \_
+Medtronic pumps are supported on all branches of Loop
+
+!!!warning "FAQs" _ **"What the heck is a branch?"** Let's use an analogy of
+when a book is published, sometimes a little later the author decides to make
+edits to the published book. They will have a "mark-up" copy of the original
+version and make edits. In this analogy, `master branch` is a published book. It
+is considered a stable, well-reviewed and tested version of the Loop app. As new
+features and improvements are made, they are made into the "mark-up copy" called
+`dev branch`. The dev branch will likely have some bugs and changes on a more
+frequent basis as the new edits are tested and revised. Other people may also
+have their own branches, based on the original published book since this is an
+open-source project, beyond just the Loop developers. There are no documents
+that track all the "unofficial" branches of Loop that others may have...there
+could be an endless amount, updated randomly, and not all of them in good
+working order so would be pointless to try to track them all. _ **"How can I
+tell which version I have downloaded if I'm unsure?"** The downloaded Loop
+folder's name will give you an indication of which branch you downloaded. The
+folder name will be in the format `Loop-BranchName`. \_ **"When do I need to
+download new Loop code?"** Anytime you want to update your Loop app to get new
+features, you'll simply download the code again by clicking on the links below.
+The links always go to the most recent version of each of the branches. It's a
+good idea is to delete your old downloads before making a new one, just to avoid
+confusion.
+
+You’ll need to download the Loop code in order to build the app on your
+computer. Wondering which to choose? Read the discussion below **BEFORE**
+clicking on one of the links to download.
 
 </br></br>
+
 <p align="center">
 [Loop: Master branch](https://github.com/LoopKit/Loop/archive/master.zip)</br></br>
 [Loop: Dev branch](https://github.com/LoopKit/Loop/archive/dev.zip)</br></br>
@@ -24,33 +43,92 @@ You’ll need to download the Loop code in order to build the app on your comput
 </p></br>
 
 ## Loop Branches
-Master vs Dev? The Loop code resides in a website called [GitHub](https://github.com/LoopKit/Loop). The various projects in GitHub use "repositories". A repository is kind of like a project's bookshelf, holding various books versions (aka branches) of a project. The master branch is considered a stable version of the project. Any new features or options are first tested in a public feature branch or dev (short for "development") branch of the Loop. If you hear of "new features" being tested, these are things that may eventually be merged into the master branch once any bugs are worked out. 
 
-**If you want to build a version of Loop that supports Omnipod, you should select the Omnipod-testing branch download above.** Technically the dev branch can work for Omnipod loopers now, but there are a lot of bugs actively being addressed in dev branch. It is considered more unstable than omnipod-testing branch at this time. You should only choose dev branch if you are able to watch your Loop carefully and have no problem updating often (like several times a week at the moment). 
+Master vs Dev? The Loop code resides in a website called
+[GitHub](https://github.com/LoopKit/Loop). The various projects in GitHub use
+"repositories". A repository is kind of like a project's bookshelf, holding
+various books versions (aka branches) of a project. The master branch is
+considered a stable version of the project. Any new features or options are
+first tested in a public feature branch or dev (short for "development") branch
+of the Loop. If you hear of "new features" being tested, these are things that
+may eventually be merged into the master branch once any bugs are worked out.
 
-If you are choosing to use a testing branch, such as dev or omnipod-testing, please be prepared to update your Loop app to get bug fixes as they are released. As you encounter any bugs or glitches, please check the docs first to see if that issue is already answered. If you think you truly are seeing strange behavior, report the bug to Loop's GitHub by [creating a "New Issue" here](https://github.com/loopkit/loop/issues). You can also look through the list of known issues already reported, as there is a chance your issue has already been seen by others. 
+**If you want to build a version of Loop that supports Omnipod, you should
+select the Omnipod-testing branch download above.** Technically the dev branch
+can work for Omnipod loopers now, but there are a lot of bugs actively being
+addressed in dev branch. It is considered more unstable than omnipod-testing
+branch at this time. You should only choose dev branch if you are able to watch
+your Loop carefully and have no problem updating often (like several times a
+week at the moment).
 
-Ok, now that you've read about the various branches, go ahead and pick a link to download.
+If you are choosing to use a testing branch, such as dev or omnipod-testing,
+please be prepared to update your Loop app to get bug fixes as they are
+released. As you encounter any bugs or glitches, please check the docs first to
+see if that issue is already answered. If you think you truly are seeing strange
+behavior, report the bug to Loop's GitHub by
+[creating a "New Issue" here](https://github.com/loopkit/loop/issues). You can
+also look through the list of known issues already reported, as there is a
+chance your issue has already been seen by others.
+
+Ok, now that you've read about the various branches, go ahead and pick a link to
+download.
 
 ## What about "other branches"
 
-There are other branches and features (JoJo, IRC, Spike-Loop, etc) that other Loop users may develop from time to time. Those users may choose to share their work publicly or keep their work more quietly on their Github accounts. If someone develops a new feature for their own Loop use and they think it has wider value to others, they may submit a "Pull Request" asking the Loop developers to consider the new feature/code into Loop officially. Submittal of a Pull Request does not guarantee that the feature/code will eventually be incorporated into the main Loop versions.
+There are other branches and features (JoJo, IRC, Spike-Loop, etc) that other
+Loop users may develop from time to time. Those users may choose to share their
+work publicly or keep their work more quietly on their Github accounts. If
+someone develops a new feature for their own Loop use and they think it has
+wider value to others, they may submit a "Pull Request" asking the Loop
+developers to consider the new feature/code into Loop officially. Submittal of a
+Pull Request does not guarantee that the feature/code will eventually be
+incorporated into the main Loop versions.
 
-These docs only refer to Loop branches maintained and reviewed by the Loop developers. It would be too difficult to track and index (much less test and explain) all the possible customized personal branches that could be out there for all the Loop users. **If you are interested in one of the non-official Loop branches, PLEASE use the search tool in Looped Group to find links where you can learn about those personal branches.**
+These docs only refer to Loop branches maintained and reviewed by the Loop
+developers. It would be too difficult to track and index (much less test and
+explain) all the possible customized personal branches that could be out there
+for all the Loop users. **If you are interested in one of the non-official Loop
+branches, PLEASE use the search tool in Looped Group to find links where you can
+learn about those personal branches.**
 
-One note: I (Katie) have shared my JoJo branches in Looped Group on Facebook for quite some time.  JoJo branches have features that other people have created and I've simply packaged them together for my own personal use. I do expect that soon there will be no more JoJo branches and they will be retired, as the important core features will hopefully be available in Loop official branches. No promises, but we are working towards that. It will be so much easier to have no JoJo branch in the future...I'm really looking forward to that.
+One note: I (Katie) have shared my JoJo branches in Looped Group on Facebook for
+quite some time. JoJo branches have features that other people have created and
+I've simply packaged them together for my own personal use. I do expect that
+soon there will be no more JoJo branches and they will be retired, as the
+important core features will hopefully be available in Loop official branches.
+No promises, but we are working towards that. It will be so much easier to have
+no JoJo branch in the future...I'm really looking forward to that.
 
 ## Store and name your download properly
-It is best practice to leave your Loop code in your Downloads folder. If you store your Loop code in a different folder than Downloads (such as your Documents folder or Desktop), make sure the specified folder is **not** an iCloud drive. Storing your Loop code in an iCloud drive folder will prevent Loop from building successfully.  How do you know if a folder is an iCloud drive? Check your System Preferences. If your System Preferences for iCloud is set as shown below, your Documents and Desktop folders are iCloud drives and **NOT** appropriate places to save your Loop download.
+
+It is best practice to leave your Loop code in your Downloads folder. If you
+store your Loop code in a different folder than Downloads (such as your
+Documents folder or Desktop), make sure the specified folder is **not** an
+iCloud drive. Storing your Loop code in an iCloud drive folder will prevent Loop
+from building successfully. How do you know if a folder is an iCloud drive?
+Check your System Preferences. If your System Preferences for iCloud is set as
+shown below, your Documents and Desktop folders are iCloud drives and **NOT**
+appropriate places to save your Loop download.
+
 <p align="center">
 <img src="../img/icloud-drive.png" width="650">
 </p></br>
 
-Depending on your browser and settings, your Loop download may or may not automatically unzip. If it does not unzip automatically, you can right-click on the zip file and choose to "Open With" Archive Utility. This will create a blue folder called `Loop-master`.  HOWEVER, if you already have an existing `Loop-master` folder from a previous download, the name of the next download will be something like `Loop-master (1)`.  The problem with that folder name is that it contains a space...and spaces in the name will cause your Loop build to fail. So, either delete old copies of Loop before downloading/unzipping -OR- rename the folder(s) to ensure that NO SPACES are in the folder name.
+Depending on your browser and settings, your Loop download may or may not
+automatically unzip. If it does not unzip automatically, you can right-click on
+the zip file and choose to "Open With" Archive Utility. This will create a blue
+folder called `Loop-master`. HOWEVER, if you already have an existing
+`Loop-master` folder from a previous download, the name of the next download
+will be something like `Loop-master (1)`. The problem with that folder name is
+that it contains a space...and spaces in the name will cause your Loop build to
+fail. So, either delete old copies of Loop before downloading/unzipping -OR-
+rename the folder(s) to ensure that NO SPACES are in the folder name.
+
 <p align="center">
 <img src="../img/folder-name.png" width="650">
 </p>
 
 ## Next Step: Build Loop app
 
-Now you are ready to move onto Step 14 to [Build Loop app](https://loopkit.github.io/loopdocs/build/step14/).
+Now you are ready to move onto Step 14 to
+[Build Loop app](https://loopkit.github.io/loopdocs/build/step14/).

--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -1,71 +1,99 @@
 # Step 14: Build Loop app
 
-!!!danger "Time Estimate"
-    * 60-80 minutes if first time builder
-    * 10-15 minutes if a repeat builder
+!!!danger "Time Estimate" _ 60-80 minutes if first time builder _ 10-15 minutes
+if a repeat builder
 
-!!!info "Summary"
-    * Open the Loop code you downloaded in Step 13
-    * Connect the phone to the computer
-    * Set the phone to not lock for awhile
-    * Trust the computer (on the phone)
-    * Select your phone from the device list
-    * Register the device
-    * Sign the 4 targets
-    * Press the build button
-    * Enter computer password four times during the build
-    * Watch in awe as you just built your very own Loop app
+!!!info "Summary" _ Open the Loop code you downloaded in Step 13 _ Connect the
+phone to the computer _ Set the phone to not lock for awhile _ Trust the
+computer (on the phone) _ Select your phone from the device list _ Register the
+device _ Sign the 4 targets _ Press the build button _ Enter computer password
+four times during the build _ Watch in awe as you just built your very own Loop
+app
 
-!!!warning "FAQs"
-    * **"I got a build error! YIKES...what do I do?"** Check out the Build Errors page for all the solutions you'd need.
-    * **"The build seems to take a long time, is that normal?"** Yes, the first build of a new download will take quite a long time. Just be patient...one of the build steps to take *much* longer than all the others. The build process does always end in a success or failure message, so just wait it out until you see one of those displayed.
+!!!warning "FAQs" _ **"I got a build error! YIKES...what do I do?"** Check out
+the Build Errors page for all the solutions you'd need. _ **"The build seems to
+take a long time, is that normal?"** Yes, the first build of a new download will
+take quite a long time. Just be patient...one of the build steps to take _much_
+longer than all the others. The build process does always end in a success or
+failure message, so just wait it out until you see one of those displayed.
 
 ## Open Loop project in Xcode
 
-Go to your Downloads folder, open your downloaded Loop code folder and double click on Loop.xcodeproj. For Omnipod Loop, the downloaded Loop code folder will likely be named `Loop-omnipod-testing`. If you downloaded dev branch, your folder would be named `Loop-dev` and similar for `Loop-master` download.
+Go to your Downloads folder, open your downloaded Loop code folder and double
+click on Loop.xcodeproj. For Omnipod Loop, the downloaded Loop code folder will
+likely be named `Loop-omnipod-testing`. If you downloaded dev branch, your
+folder would be named `Loop-dev` and similar for `Loop-master` download.
 
 <p align="center">
 <img src="../../build/img/loop_code.png" width="750">
 </p>
 
-A warning may appear asking if you really want to open it, click Open. Xcode will get itself organized, this may take a few minutes.  
+A warning may appear asking if you really want to open it, click Open. Xcode
+will get itself organized, this may take a few minutes.
 
 <p align="center">
 <img src="../../build/img/loop_open.jpg" width="450">
 </p>
 
-Once Xcode has finished indexing, the Loop project's various folders and files will appear in the far left column. We are now going to make three important clicks:
+Once Xcode has finished indexing, the Loop project's various folders and files
+will appear in the far left column. We are now going to make three important
+clicks:
 
-1. First click: At the very top of all the folders and files listed, click on the blue "Loop". This will populate the middle part of the Xcode window with some information. **If a couple of little boxes appear saying "The folder “DerivedWatchAssets.xcassets” doesn’t exist."...just click the ok buttons and ignore those. They will come up a couple of times during your build if you are using dev branch right now...don't worry, won't be a problem.**
+1. First click: At the very top of all the folders and files listed, click on
+   the blue "Loop". This will populate the middle part of the Xcode window with
+   some information. **If a couple of little boxes appear saying "The folder
+   “DerivedWatchAssets.xcassets” doesn’t exist."...just click the ok buttons and
+   ignore those. They will come up a couple of times during your build if you
+   are using dev branch right now...don't worry, won't be a problem.**
 
 
     <p align="center">
     <img src="../../build/img/loop-first-click.png" width="550">
     </p>
 
-2. Second click: Now click on the box in the middle screen to reveal the targets column underneath that box. The four targets we will sign in the upcoming steps are now easily viewable.
+2. Second click: Now click on the box in the middle screen to reveal the targets
+   column underneath that box. The four targets we will sign in the upcoming
+   steps are now easily viewable.
 
-    <p align="center">
-    <img src="../../build/img/loop-second-click.png" width="550">
-    </p>
+   <p align="center">
+   <img src="../../build/img/loop-second-click.png" width="550">
+   </p>
 
-3. Third Click: Click on the "Signing & Capabilities" up near the top of the screen. After you click on that, you should see a "Signing" section occupying the bulk of your middle window. If you are missing the "Signing & Capabilities" section and didn't have to click somewhere else to see that part...that means you have missed updating to Xcode 11 from an older version of Xcode. Please go back and update Xcode now. Thanks.
+3. Third Click: Click on the "Signing & Capabilities" up near the top of the
+   screen. After you click on that, you should see a "Signing" section occupying
+   the bulk of your middle window. If you are missing the "Signing &
+   Capabilities" section and didn't have to click somewhere else to see that
+   part...that means you have missed updating to Xcode 11 from an older version
+   of Xcode. Please go back and update Xcode now. Thanks.
 
-    <p align="center">
-    <img src="../../build/img/loop-third-click.png" width="550">
-    </p>
-
+   <p align="center">
+   <img src="../../build/img/loop-third-click.png" width="550">
+   </p>
 
 ## Connect your iPhone to Computer
 
-Connect your iPhone via cable to the computer, select your iPhone from the very top of the drop-down list.  Your **<u>iPhone’s personal name</u>** should be at the top of the list. Don't accidentally select the generic iOS simulators listed below your iPhone's name.  
+Connect your iPhone via cable to the computer, select your iPhone from the very
+top of the drop-down list. Your **<u>iPhone’s personal name</u>** should be at
+the top of the list. Don't accidentally select the generic iOS simulators listed
+below your iPhone's name.
 
-!!!info "Helpful Tips"
-    * If your iPhone has a lock enabled, Xcode will not be able to install Loop app once your phone locks during the build progress.  Please temporarily disable the lock until you finish building Loop app.  Go to your iPhone Settings >> Display & Brightness >> Auto-Lock and set it to `Never`.  You can reset your lock once Loop is done building onto the phone. If you can't or don't want to set the auto-lock to never, then please remember to tap your phone screen periodically during the build process later to keep it "awake".</br></br>
-    * If this is the first time your iPhone has been plugged into this computer, you will need to open the iPhone and select "Trust this Computer" before your device will be useable in the menu selection.</br></br>
-    
-!!!danger "Most Common Mistake"
-    * The most common mistake in this step is not selecting your actual phone as shown in the second screenshot below. The default list is just a name of general phone models under a subheading called "iOS Simulators"...don't be fooled by those. Your ACTUAL phone will be up above that list of all the various simulator phone models. Make sure you select your actual phone, not just a simulator phone model.
+!!!info "Helpful Tips" _ If your iPhone has a lock enabled, Xcode will not be
+able to install Loop app once your phone locks during the build progress. Please
+temporarily disable the lock until you finish building Loop app. Go to your
+iPhone Settings >> Display & Brightness >> Auto-Lock and set it to `Never`. You
+can reset your lock once Loop is done building onto the phone. If you can't or
+don't want to set the auto-lock to never, then please remember to tap your phone
+screen periodically during the build process later to keep it "awake".</br></br>
+_ If this is the first time your iPhone has been plugged into this computer, you
+will need to open the iPhone and select "Trust this Computer" before your device
+will be useable in the menu selection.</br></br>
+
+!!!danger "Most Common Mistake" \* The most common mistake in this step is not
+selecting your actual phone as shown in the second screenshot below. The default
+list is just a name of general phone models under a subheading called "iOS
+Simulators"...don't be fooled by those. Your ACTUAL phone will be up above that
+list of all the various simulator phone models. Make sure you select your actual
+phone, not just a simulator phone model.
 
 <p align="center">
 <img src="../img/select_device.png" width="750">
@@ -77,25 +105,45 @@ Connect your iPhone via cable to the computer, select your iPhone from the very 
 
 ## Sign Four Targets
 
-Once you select your device (your iPhone's name), we are ready to start signing the four targets. We will start with the Loop target, the first one on the target list.  Under the "Signing" area, select the dropdown menu where it currently says "none". Choose your team that you'd like to sign with. If you select a team name with (personal team), your app will expire after 7 days. If you select a team name without that (personal team), your app will last a full year.  If you never signed up for a free developer account, you will not have a (personal team) showing. Make sure you keep the "automatically manage signing" box checked above the team selection area.
+Once you select your device (your iPhone's name), we are ready to start signing
+the four targets. We will start with the Loop target, the first one on the
+target list. Under the "Signing" area, select the dropdown menu where it
+currently says "none". Choose your team that you'd like to sign with. If you
+select a team name with (personal team), your app will expire after 7 days. If
+you select a team name without that (personal team), your app will last a full
+year. If you never signed up for a free developer account, you will not have a
+(personal team) showing. Make sure you keep the "automatically manage signing"
+box checked above the team selection area.
 
 <p align="center">
 <img src="../img/team.png" width="750">
 </p>
 
-Once you choose your signing team, Xcode will automatically generate provisioning profiles and signing certificates.  If this is the first time you are building on this iPhone with this developer account, you may be prompted to register the device.  Simply click on the "Register Device" button to confirm.
+Once you choose your signing team, Xcode will automatically generate
+provisioning profiles and signing certificates. If this is the first time you
+are building on this iPhone with this developer account, you may be prompted to
+register the device. Simply click on the "Register Device" button to confirm.
 
 <p align="center">
 <img src="../img/register_device.png" width="750">
 </p>
 
-!!!danger "Free Developer Account Users: READ ME"
-    If you are using a free developer account to sign your targets, you will need to do an extra step. As a free developer, you are restricted from building apps that have Siri capabilities built-in. Loop has Siri capabilities...so you will need to disable them before proceeding on with signing and building your app. Click on the small x next to the Siri line located at the bottom of your Signing & Capabilities page. You need to do this in both the Loop and WatchApp Extension targets.
-    <p align="center">
-    <img src="../img/siri-errors.png" width="750">
-    </p>
+!!!danger "Free Developer Account Users: READ ME" If you are using a free
+developer account to sign your targets, you will need to do an extra step. As a
+free developer, you are restricted from building apps that have Siri
+capabilities built-in. Loop has Siri capabilities...so you will need to disable
+them before proceeding on with signing and building your app. Click on the small
+x next to the Siri line located at the bottom of your Signing & Capabilities
+page. You need to do this in both the Loop and WatchApp Extension targets.
 
-A successfully signed target will have a provisioning profile and signing certificate similar to the screenshot below.  Click on each of the three remaining targets, and repeat the signing steps by choosing the same team name as you selected in the first target.
+<p align="center">
+<img src="../img/siri-errors.png" width="750">
+</p>
+
+A successfully signed target will have a provisioning profile and signing
+certificate similar to the screenshot below. Click on each of the three
+remaining targets, and repeat the signing steps by choosing the same team name
+as you selected in the first target.
 
 <p align="center">
 <img src="../img/success.png" width="750">
@@ -103,23 +151,44 @@ A successfully signed target will have a provisioning profile and signing certif
 
 ## Code Customizations
 
-**New Loop users**: Customizations are not a required part of any Loop build. As you gain experience in how you use your Loop app, you may want to customize some of the features. You can always update your Loop app to add customizations at a later time. Really though, building with the standard, the default installation is JUST FINE.
+**New Loop users**: Customizations are not a required part of any Loop build. As
+you gain experience in how you use your Loop app, you may want to customize some
+of the features. You can always update your Loop app to add customizations at a
+later time. Really though, building with the standard, the default installation
+is JUST FINE.
 
-If you want any custom configurations to your Loop or Loop Apple Watch apps, now is the time to make them before you finish with the last step of Loop installation on your iPhone. Follow the step-by-step instructions on the [Code Customizations](code_customization.md) page. If you are a person familiar with Apple's Swift language, feel free to make your own customizations as well.
+If you want any custom configurations to your Loop or Loop Apple Watch apps, now
+is the time to make them before you finish with the last step of Loop
+installation on your iPhone. Follow the step-by-step instructions on the
+[Code Customizations](code_customization.md) page. If you are a person familiar
+with Apple's Swift language, feel free to make your own customizations as well.
 
-When you've finished your customizations, come on back to this section and continue on with the rest of the build.
+When you've finished your customizations, come on back to this section and
+continue on with the rest of the build.
 
 ## Pair your Apple Watch
 
-**New Apple Watch users**: If you have an unopened Apple watch and want to use it with Loop, first pair the watch with the iPhone before continuing to the next steps.  If you get a new watch after building the Loop app, you'll need to redo your Loop build. (Don't worry, it's as easy as pressing play on your saved Loop project.)</br>
+**New Apple Watch users**: If you have an unopened Apple watch and want to use
+it with Loop, first pair the watch with the iPhone before continuing to the next
+steps. If you get a new watch after building the Loop app, you'll need to redo
+your Loop build. (Don't worry, it's as easy as pressing play on your saved Loop
+project.)</br>
 
-**Existing Apple Watch users**: Please update your watchOS prior to building the Loop app.  The current version of Loop requires watchOS 4.1 or newer.
+**Existing Apple Watch users**: Please update your watchOS prior to building the
+Loop app. The current version of Loop requires watchOS 4.1 or newer.
 
-!!!info "Series 0 Apple Watch users: Read Me"
-    **Series 0 Apple Watch users**: Please you will need to do a minor change in Loop code for your watch to use Loop. Select the WatchApp Extension target and under the 'Linked Frameworks and Libraries' section, click the '+' and type 'ClockKit' and press 'Add'. In the 'Status' column of the new row where ClockKit been added, change 'Required' to 'Optional'. You can move on with the rest of the instructions below now that you've completed that step. Whew, that old Apple Watch is still gonna work with this modern app.
-    <p align="center">
-    <img src="../img/series0-watch-change.png" width="750">
-    </p>
+!!!info "Series 0 Apple Watch users: Read Me" **Series 0 Apple Watch users**:
+Please you will need to do a minor change in Loop code for your watch to use
+Loop. Select the WatchApp Extension target and under the 'Linked Frameworks and
+Libraries' section, click the '+' and type 'ClockKit' and press 'Add'. In the
+'Status' column of the new row where ClockKit been added, change 'Required' to
+'Optional'. You can move on with the rest of the instructions below now that
+you've completed that step. Whew, that old Apple Watch is still gonna work with
+this modern app.
+
+<p align="center">
+<img src="../img/series0-watch-change.png" width="750">
+</p>
 
 ## INTERMISSION
 
@@ -127,48 +196,83 @@ STOP STOP STOP
 
 You guys...this is about safety.
 
-People keep ignoring this advice and I'm frankly a little stumped as to why. So, I'm moving this advice up in the process so that you don't ignore it.
+People keep ignoring this advice and I'm frankly a little stumped as to why. So,
+I'm moving this advice up in the process so that you don't ignore it.
 
 <p align="center">
 <img src="https://media.giphy.com/media/xT9DPJVjlYHwWsZRxm/source.gif" width="400">
 </p>
 
-!!!warning "DO NOT WING THE SETUP"
-    I have warnings all over these instructions to **continue to use these docs to finish setting up your app after it builds. DO NOT IGNORE THAT ADVICE. DO NOT ENTER ONE LOOP APP SETTING WITHOUT HAVING THE DOCS OPEN AND FOLLOWING ALONG AT THE SAME TIME.**
+!!!warning "DO NOT WING THE SETUP" I have warnings all over these instructions
+to **continue to use these docs to finish setting up your app after it builds.
+DO NOT IGNORE THAT ADVICE. DO NOT ENTER ONE LOOP APP SETTING WITHOUT HAVING THE
+DOCS OPEN AND FOLLOWING ALONG AT THE SAME TIME.**
 
-The section in these docs called "Set up App" (See it? Look for it now...at the top of your webpage) needs to be used to input all the settings in your Loop app when it is done building. READ ALONG WITH THE DOCS to enter those settings. There are important safety tips and advice in there. And then after you finish setup, you need to read the "Operate" section...like BEFORE YOU OPERATE LOOP. Don't bolus for a meal, or enter a meal, until you've read through the Operate section. 
+The section in these docs called "Set up App" (See it? Look for it now...at the
+top of your webpage) needs to be used to input all the settings in your Loop app
+when it is done building. READ ALONG WITH THE DOCS to enter those settings.
+There are important safety tips and advice in there. And then after you finish
+setup, you need to read the "Operate" section...like BEFORE YOU OPERATE LOOP.
+Don't bolus for a meal, or enter a meal, until you've read through the Operate
+section.
 
-I'm worried you will fail to heed the advice about using the setup and operate sections. People have ignored it before. They skim read and think that's good enough. DO NOT BE LIKE THAT. Read each section. 
+I'm worried you will fail to heed the advice about using the setup and operate
+sections. People have ignored it before. They skim read and think that's good
+enough. DO NOT BE LIKE THAT. Read each section.
 
-BUT, to mitigate the inevitable people who will ignore that advice....here's the two most important safety tips that I feel obliged to present out of order because (damn it), people will ignore my advice still.
+BUT, to mitigate the inevitable people who will ignore that advice....here's the
+two most important safety tips that I feel obliged to present out of order
+because (damn it), people will ignore my advice still.
 
-!!!warning "TOP TWO SAFETY MISTAKES YOU SHOULD AVOID"
-    1. DO NOT ENTER SETTINGS YOU ARE UNSURE OF. If you don't know your settings or know what the terms mean, stop. Read the docs, all the settings entries are explained there. Ask your endo if you don't have established values for those settings. Don't just guess an ISF, carb ratio, basal rate, or maximum delivery limits.</br></br>
+!!!warning "TOP TWO SAFETY MISTAKES YOU SHOULD AVOID" 1. DO NOT ENTER SETTINGS
+YOU ARE UNSURE OF. If you don't know your settings or know what the terms mean,
+stop. Read the docs, all the settings entries are explained there. Ask your endo
+if you don't have established values for those settings. Don't just guess an
+ISF, carb ratio, basal rate, or maximum delivery limits.</br></br>
 
     2. DO NOT ENTER ACCIDENTAL DUPLICATE CARB ENTRIES. When you enter a meal in Loop and press the `save` button...those carbs are saved. Let me repeat: THOSE CARBS ARE SAVED...even if you cancel the bolus for them. This is an automated insulin delivery system and if it thinks you have carbs on board, it will try to give you appropriate insulin for those carbs. Most common new user mistake: enters a meal, saves the carbs, has a change of heart or gets confused, and cancels the bolus screen...thinking they've just canceled the entire meal entry. Then they enter in a new carb entry. AND NOW, when you go to bolus...you'll be bolusing for the meal you wanted AND the meal you are mistakenly thinking you had "canceled". You didn't cancel that carb entry though, you had only canceled the bolus...you didn't "unsave" the carbs. If you make a mistake or change your mind on a carb entry after you pressed save, then tap the green carb chart in Loop's main display and edit or delete that entry. **CANCELING A BOLUS DOES NOT CANCEL THE CARB ENTRY THAT GOT YOU THERE. You must delete or edit a saved carb entry if you no longer want Loop to provide insulin for it.**
 
-Ok, so now that I've got your attention, you can continue on with the last step in building you app...but remember, we just pinky swore that you would use the setup and operate sections to finish this all? Don't break my heart, keep your promise.
+Ok, so now that I've got your attention, you can continue on with the last step
+in building you app...but remember, we just pinky swore that you would use the
+setup and operate sections to finish this all? Don't break my heart, keep your
+promise.
 
 ## Build Loop
 
-Have you signed the four targets? Are you all done with any customizations? Has your Apple watch been paired and updated? Is your iPhone unlocked and plugged into the computer?
+Have you signed the four targets? Are you all done with any customizations? Has
+your Apple watch been paired and updated? Is your iPhone unlocked and plugged
+into the computer?
 
-Let’s finish the installation of the Loop app onto your iPhone. Double-check to make sure your iPhone's name is still selected and then press the “build” button to start Xcode on its way. 
+Let’s finish the installation of the Loop app onto your iPhone. Double-check to
+make sure your iPhone's name is still selected and then press the “build” button
+to start Xcode on its way.
 
 <p align="center">
 <img src="../img/build_button.png" width="750">
 </p>
 
-You’ll see the progression of the build in the status window (top middle of Xcode). New builds can take about 40-60 minutes depending on the speed of the computer and the internet.  **Just be patient.**  The progress will get "stuck" on one step/task for a very long time, and then the others will fly by when that one slow step is done. Not every step is equal in duration. Do not give up on the build. <u>**Xcode will ALWAYS tell you eventually that the build either succeeded or failed...it will not just leave you hanging without an answer.**</u>  
+You’ll see the progression of the build in the status window (top middle of
+Xcode). New builds can take about 40-60 minutes depending on the speed of the
+computer and the internet. **Just be patient.** The progress will get "stuck" on
+one step/task for a very long time, and then the others will fly by when that
+one slow step is done. Not every step is equal in duration. Do not give up on
+the build. <u>**Xcode will ALWAYS tell you eventually that the build either
+succeeded or failed...it will not just leave you hanging without an
+answer.**</u>
 
-!!!danger "Are you the impatient type?"
-    If you just simply can't bear the uncertainty of not seeing that things are progressing, you can take a peek "under the hood" and watch the individual build steps by clicking on the report navigator icon and then the build row at the top of the list. You can watch the slow list of scheme building while you wait.
-    <p align="center">
-    <img src="../img/build-scheme.png" width="650">
-    </p></br>
+!!!danger "Are you the impatient type?" If you just simply can't bear the
+uncertainty of not seeing that things are progressing, you can take a peek
+"under the hood" and watch the individual build steps by clicking on the report
+navigator icon and then the build row at the top of the list. You can watch the
+slow list of scheme building while you wait.
 
-!!!info "First-time builders"
-    Be aware though! Sometime during your first ever build on a computer, be ready for a codesign/keychain access prompt that you will see part-way through the build process.</br></br>
+<p align="center">
+<img src="../img/build-scheme.png" width="650">
+</p></br>
+
+!!!info "First-time builders" Be aware though! Sometime during your first ever
+build on a computer, be ready for a codesign/keychain access prompt that you
+will see part-way through the build process.</br></br>
 
     <p align="center">
     <img src="../img/keychain-prompt.png" width="350">
@@ -178,34 +282,51 @@ You’ll see the progression of the build in the status window (top middle of Xc
 
 ## Build Finished
 
-!!! info "First time building on a new device?"
-    If this is the first time you have installed an app on your iPhone using your developer account, you may get a warning like below after a successful build. Don't worry, Loop installed just fine on the phone but needs you to do an extra step on the phone before Loop app can open. Just follow the directions shown in the warning for what you need to do on your iPhone, and the issue resolves very quickly. Click ok and you can safely disconnect your iPhone from the computer.  (If you don’t get a warning and the Loop app installs but does not open, you may still need to go to Settings->General->Device Management and enable trust for your Developer Account.)
-    <p align="center">
-    <img src="../img/trust_device.jpg" width="750">
-    </p>
+!!! info "First time building on a new device?" If this is the first time you
+have installed an app on your iPhone using your developer account, you may get a
+warning like below after a successful build. Don't worry, Loop installed just
+fine on the phone but needs you to do an extra step on the phone before Loop app
+can open. Just follow the directions shown in the warning for what you need to
+do on your iPhone, and the issue resolves very quickly. Click ok and you can
+safely disconnect your iPhone from the computer. (If you don’t get a warning and
+the Loop app installs but does not open, you may still need to go to
+Settings->General->Device Management and enable trust for your Developer
+Account.)
 
-!!!danger "BUILD SUCCEEDED"
-    Congrats! If the build is successful, your brand new Loop app will have a screen open immediately on the iPhone asking about allowing Loop notifications and Health App access. `Allow` Loop to send you notifications. In the next screen that follows that, click on the `Turn All Categories On` line and then click `Allow` in the upper right corner. 
-    
-    <p align="center">
-    <img src="../img/health-start.JPEG" width="450">
-    </p></br></br>
-     
-     You can unplug your phone from the computer now. And like we promised earlier, you will use the [Setup App section of this website](https://loopkit.github.io/loopdocs/operation/loop-settings/settings/) to keep proceeding safely.
+<p align="center">
+<img src="../img/trust_device.jpg" width="750">
+</p>
 
-!!!warning "FAQ: But what about those yellow alerts that remain in Xcode? Should I worry about them?"
-    If you see yellow alerts after your build is done...those are not an issue. Whether your build succeeded or failed...the yellow warnings play no role in either outcome. Don't try to resolve them or fret about them. They mean nothing to the successful use of your Loop app.
-    <p align="center">
-    <img src="../img/yellow-warnings.png" width="750">
-     </p>
+!!!danger "BUILD SUCCEEDED" Congrats! If the build is successful, your brand new
+Loop app will have a screen open immediately on the iPhone asking about allowing
+Loop notifications and Health App access. `Allow` Loop to send you
+notifications. In the next screen that follows that, click on the
+`Turn All Categories On` line and then click `Allow` in the upper right corner.
 
-!!!danger "BUILD FAILED"
-    Don't despair. Build failures are pretty easily fixed. If you get a message that your build failed and see **RED ERROR** messages, just go to the [Build Errors](build_errors.md) page to find the steps to fix your build error based on the message displayed.
+ <p align="center">
+<img src="../img/health-start.JPEG" width="450">
+</p></br></br>
+  
+ You can unplug your phone from the computer now. And like we promised earlier, you will use the [Setup App section of this website](https://loopkit.github.io/loopdocs/operation/loop-settings/settings/) to keep proceeding safely.
+
+!!!warning "FAQ: But what about those yellow alerts that remain in Xcode? Should
+I worry about them?" If you see yellow alerts after your build is done...those
+are not an issue. Whether your build succeeded or failed...the yellow warnings
+play no role in either outcome. Don't try to resolve them or fret about them.
+They mean nothing to the successful use of your Loop app.
+
+<p align="center">
+<img src="../img/yellow-warnings.png" width="750">
+</p>
+
+!!!danger "BUILD FAILED" Don't despair. Build failures are pretty easily fixed.
+If you get a message that your build failed and see **RED ERROR** messages, just
+go to the [Build Errors](build_errors.md) page to find the steps to fix your
+build error based on the message displayed.
 
     <p align="center">
     <img src="../img/general-error.jpg" width="750">
     </p>
-
 
 ## Next Step: Loop App Setup
 
@@ -215,9 +336,6 @@ You're done building your Loop app...
 <img src="https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif" width="400">
 </p>
 
-
-Remember your promise though? You still owe me that you will use the [`Setup App`](https://loopkit.github.io/loopdocs/operation/overview/) section of this website now to keep proceeding safely.
-
-
-
-
+Remember your promise though? You still owe me that you will use the
+[`Setup App`](https://loopkit.github.io/loopdocs/operation/overview/) section of
+this website now to keep proceeding safely.

--- a/docs/build/step2.md
+++ b/docs/build/step2.md
@@ -1,46 +1,61 @@
 # Step 2: Compatible iPhone or iPod touch
 
-!!!danger "Time Estimate"
-    * 5 minutes, if already have iOS 12.2 or newer
-    * 20 minutes, if need to update your compatible device to iOS 12.2 or newer
-    * 10 minutes, if you need to order a device from Apple website
-    * 0 minutes, if you own an Android and won't buy Apple products...that's fine, too.
+!!!danger "Time Estimate" _ 5 minutes, if already have iOS 12.2 or newer _ 20
+minutes, if need to update your compatible device to iOS 12.2 or newer _ 10
+minutes, if you need to order a device from Apple website _ 0 minutes, if you
+own an Android and won't buy Apple products...that's fine, too.
 
-!!!info "Summary"
-    * Check your iOS version and make sure you have 12.2 minimum.
-    * Do not use any of the beta iOS versions. (Don't worry...if you don't know what that means, then you aren't using one.)
-    * If using Dexcom CGM, your Looping iPhone/iPod touch will need the Dexcom app installed on it in order to Loop without an internet connection.
+!!!info "Summary" _ Check your iOS version and make sure you have 12.2 minimum.
+_ Do not use any of the beta iOS versions. (Don't worry...if you don't know what
+that means, then you aren't using one.) \* If using Dexcom CGM, your Looping
+iPhone/iPod touch will need the Dexcom app installed on it in order to Loop
+without an internet connection.
 
-!!!warning "FAQs"
-    * **"Can I use an android?"** No.
-    * **"But why not?"** Because Loop is written in Apple's Swift language, which does not compile onto Android operating systems.
-    * **"Can I use an iPad?"** No. iPads do not support Apple Health and that is an important part of Loop's inner workings.
-    * **"Does my iPhone need cell plan?"** No. Loop will work without an internet connection...however you will not have Dexcom Follow data or Nightscout data if you choose to use a device that doesn't have an internet connection. In other words Loop will work, but remotely watching followers won't see Looping data unless the Loop device has an internet connection.
+!!!warning "FAQs" _ **"Can I use an android?"** No. _ **"But why not?"** Because
+Loop is written in Apple's Swift language, which does not compile onto Android
+operating systems. _ **"Can I use an iPad?"** No. iPads do not support Apple
+Health and that is an important part of Loop's inner workings. _ **"Does my
+iPhone need cell plan?"** No. Loop will work without an internet
+connection...however you will not have Dexcom Follow data or Nightscout data if
+you choose to use a device that doesn't have an internet connection. In other
+words Loop will work, but remotely watching followers won't see Looping data
+unless the Loop device has an internet connection.
 
 ## iOS check
-Loop is compatible with iPhone and iPod touch devices that can run iOS 12.2 or newer. Therefore, compatible devices include:
 
-* iPhone X, XS, XR, XS Max
+Loop is compatible with iPhone and iPod touch devices that can run iOS 12.2 or
+newer. Therefore, compatible devices include:
 
-* iPhone 8, 8+
+- iPhone X, XS, XR, XS Max
 
-* iPhone 7, 7+
+- iPhone 8, 8+
 
-* iPhone 6, 6+, 6s, 6s+
+- iPhone 7, 7+
 
-* iPhone SE
+- iPhone 6, 6+, 6s, 6s+
 
-* iPhone 5s
+- iPhone SE
 
-* iPod Touch, 6th generation or newer
+- iPhone 5s
+
+- iPod Touch, 6th generation or newer
 
 ## iOS 13 update
 
-On September 19, 2019, iOS 13 will be released. The iPhone 5s, 6, 6+ models will not be able to update to iOS 13. This does not pose a problem currently. You can still build Loop. HOWEVER, there are upcoming Loop changes that will require users to have iOS 13 on their devices. There is no timeframe for when these Loop changes will be coming, but just be aware that we do anticipate all Loopers will need to be using iOS 13 in the future if they want the new versions of Loop.
+On September 19, 2019, iOS 13 will be released. The iPhone 5s, 6, 6+ models will
+not be able to update to iOS 13. This does not pose a problem currently. You can
+still build Loop. HOWEVER, there are upcoming Loop changes that will require
+users to have iOS 13 on their devices. There is no timeframe for when these Loop
+changes will be coming, but just be aware that we do anticipate all Loopers will
+need to be using iOS 13 in the future if they want the new versions of Loop.
 
-Until then, you can use iOS 12.2 (or newer through iOS 13) without issue. Updating to iOS 13 is optional as far as Loop is concerned. Your Loop app on your phone will continue to run fine if you choose to update to iOS 13. It will also continue to run fine if you do not update to iOS 13. 
+Until then, you can use iOS 12.2 (or newer through iOS 13) without issue.
+Updating to iOS 13 is optional as far as Loop is concerned. Your Loop app on
+your phone will continue to run fine if you choose to update to iOS 13. It will
+also continue to run fine if you do not update to iOS 13.
 
-Your phone's iOS version can be found under the Settings app, General, About as shown below.
+Your phone's iOS version can be found under the Settings app, General, About as
+shown below.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/ios.jpg" width="300">
@@ -48,4 +63,5 @@ Your phone's iOS version can be found under the Settings app, General, About as 
 
 ## Next Step: Compatible Pump
 
-Now you are ready to move onto Step 3 to check if you have a [Compatible pump](https://loopkit.github.io/loopdocs/build/step3/).
+Now you are ready to move onto Step 3 to check if you have a
+[Compatible pump](https://loopkit.github.io/loopdocs/build/step3/).

--- a/docs/build/step3.md
+++ b/docs/build/step3.md
@@ -1,30 +1,42 @@
 # Step 3: Compatible Pump
-    
-!!!danger "Time Estimate"
-    * Omnipod users: 3 seconds to remember which PDM you've been using.
-    * Medtronic users: 10 minutes to put a battery in and look at model and firmware
-    * Other pump users: 5 days to email friends asking them to check closets for their old Medtronic pump or call your insurance to start prior authorization for Omnipod
 
-!!!info "Summary"
-    * If you have a big clunky PDM with built-in BG meter...you can use your pods for Loop.
-    * If you have a slim touch screen android-looking PDM...you can NOT use your pods for Loop.
-    * If you have a Medtronic, check the list to ensure compatible model/firmware.    
+!!!danger "Time Estimate" _ Omnipod users: 3 seconds to remember which PDM
+you've been using. _ Medtronic users: 10 minutes to put a battery in and look at
+model and firmware \* Other pump users: 5 days to email friends asking them to
+check closets for their old Medtronic pump or call your insurance to start prior
+authorization for Omnipod
 
-!!!warning "FAQs"
-    * **"How can I find a compatible Medtronic pump?"** That question is answered in the Extra Details section below.
-    * **"What are the differences between Medtronic pump models?"** This question is also answered in the Extra Details section below.
-    * **"But what about the other types of pumps?"** Too bad, so sad...unless it is a DanaRS, DanaR, Accu-Chek Insight, Accu-Chek Combo. If you have one of those pumps, you could check out [AndroidAPS looping system](https://androidaps.readthedocs.io/en/latest/index.html) instead of Loop. If you have a Medtronic 512 or 712, you could check out [OpenAPS](https://openaps.readthedocs.io/en/latest/) as that system supports the 512 and 712 models in addition to the other Loop-compatible Medtronic pumps. Neither of those systems currently support Omnipod for looping.
-    * **"Can I change the firmware of my Medtronic pump?"** Do you work at Medtronic with insider access to the secret tools and firmware versions to do that? Might lose your job, but I'd bet you could do it then. We don't have access to that though.
+!!!info "Summary" _ If you have a big clunky PDM with built-in BG meter...you
+can use your pods for Loop. _ If you have a slim touch screen android-looking
+PDM...you can NOT use your pods for Loop. \* If you have a Medtronic, check the
+list to ensure compatible model/firmware.
+
+!!!warning "FAQs" _ **"How can I find a compatible Medtronic pump?"** That
+question is answered in the Extra Details section below. _ **"What are the
+differences between Medtronic pump models?"** This question is also answered in
+the Extra Details section below. _ **"But what about the other types of
+pumps?"** Too bad, so sad...unless it is a DanaRS, DanaR, Accu-Chek Insight,
+Accu-Chek Combo. If you have one of those pumps, you could check out
+[AndroidAPS looping system](https://androidaps.readthedocs.io/en/latest/index.html)
+instead of Loop. If you have a Medtronic 512 or 712, you could check out
+[OpenAPS](https://openaps.readthedocs.io/en/latest/) as that system supports the
+512 and 712 models in addition to the other Loop-compatible Medtronic pumps.
+Neither of those systems currently support Omnipod for looping. _ **"Can I
+change the firmware of my Medtronic pump?"** Do you work at Medtronic with
+insider access to the secret tools and firmware versions to do that? Might lose
+your job, but I'd bet you could do it then. We don't have access to that though.
 
 ## Check pump version
-This is a pretty simple step...check that you have a compatible pump to use Loop:
 
-* Medtronic 515 or 715 (any firmware)
-* Medtronic 522 or 722 (any firmware)
-* Medtronic 523 or 723 (firmware 2.4 or older)
-* Medtronic Worldwide Veo 554 or 754 (firmware 2.6A or lower)
-* Medtronic Canadian/Australian Veo 554 or 754 (firmware 2.7A or lower)
-* Omnipod "Eros" pods
+This is a pretty simple step...check that you have a compatible pump to use
+Loop:
+
+- Medtronic 515 or 715 (any firmware)
+- Medtronic 522 or 722 (any firmware)
+- Medtronic 523 or 723 (firmware 2.4 or older)
+- Medtronic Worldwide Veo 554 or 754 (firmware 2.6A or lower)
+- Medtronic Canadian/Australian Veo 554 or 754 (firmware 2.7A or lower)
+- Omnipod "Eros" pods
 
 If you have one of the pumps listed above, you are good to go on Loop! Congrats!
 
@@ -32,54 +44,88 @@ If you have one of the pumps listed above, you are good to go on Loop! Congrats!
 
 ![insulin pumps](img/pump.png)
 
-There are a number of Medtronic insulin pumps manufactured between 2006 – 2012 which are Loop compatible.  Compatibility has two requirements; (1) pump model and (2) firmware.
+There are a number of Medtronic insulin pumps manufactured between 2006 – 2012
+which are Loop compatible. Compatibility has two requirements; (1) pump model
+and (2) firmware.
 
 ### Medtronic Pump Model
 
-To determine your pump model, look at the backside of your pump.  There should be a sticker on the underside of the pump.  On the right-hand side of the sticker, it says REF MMT-XXXXXX
+To determine your pump model, look at the backside of your pump. There should be
+a sticker on the underside of the pump. On the right-hand side of the sticker,
+it says REF MMT-XXXXXX
 
 ![Pump](img/pump_model.jpg)
 
-!!!note ""
-    MMT ---> Pump Manufacturer Model (MiniMed Medtronic)</br>
-    722 ---> Pump Model Number</br>
-    NA ---> Pump Region (NA=North America, CA=Canada/Australia, WW=Worldwide)</br>
-    S ---> Pump Color (S=Smoke, L=Clear/Lucite, B=Blue, P=Pink/Purple)</br>
+!!!note "" MMT ---> Pump Manufacturer Model (MiniMed Medtronic)</br> 722 --->
+Pump Model Number</br> NA ---> Pump Region (NA=North America,
+CA=Canada/Australia, WW=Worldwide)</br> S ---> Pump Color (S=Smoke,
+L=Clear/Lucite, B=Blue, P=Pink/Purple)</br>
 
-Some pumps may have an “L” or “S” or "R" before the pump region, e.g. a model number like MMT-722LNAS.  This does not affect Loop compatibility.
+Some pumps may have an “L” or “S” or "R" before the pump region, e.g. a model
+number like MMT-722LNAS. This does not affect Loop compatibility.
 
 ### Medtronic Pump Firmware
 
-A pump’s firmware is the internal software that runs your pump.  Older Medtronic firmware allows Loop to act as a “remote control” to set temp basals and report back pump data.  Newer firmware disabled that “remote control” access and therefore cannot be used with these DIY closed-loop systems.  There is currently no ability to downgrade a pump’s firmware or replace it with older firmware.  Before you buy a used pump, make sure you are getting one with compatible firmware.
+A pump’s firmware is the internal software that runs your pump. Older Medtronic
+firmware allows Loop to act as a “remote control” to set temp basals and report
+back pump data. Newer firmware disabled that “remote control” access and
+therefore cannot be used with these DIY closed-loop systems. There is currently
+no ability to downgrade a pump’s firmware or replace it with older firmware.
+Before you buy a used pump, make sure you are getting one with compatible
+firmware.
 
-!!!note ""
-    The firmware on all 515/715 and 522/722 model Medtronic pumps are all compatible with Loop. You will only need to check the firmware version for 523/723 and 554/754 model Medtronic pumps.</br></br>
-    + Medtronic 515 or 715 --> any firmware</br>
-    + Medtronic 522 or 722  --> any firmware</br>
-    + Medtronic 523 or 723 --> firmware 2.4 or older</br>
-    + Medtronic Worldwide Veo 554 or 754 --> firmware 2.6A or lower</br>
-    + Medtronic Canadian/Australian Veo 554 or 754 --> firmware 2.7A or lower</br>
+!!!note "" The firmware on all 515/715 and 522/722 model Medtronic pumps are all
+compatible with Loop. You will only need to check the firmware version for
+523/723 and 554/754 model Medtronic pumps.</br></br> + Medtronic 515 or 715 -->
+any firmware</br> + Medtronic 522 or 722 --> any firmware</br> + Medtronic 523
+or 723 --> firmware 2.4 or older</br> + Medtronic Worldwide Veo 554 or 754 -->
+firmware 2.6A or lower</br> + Medtronic Canadian/Australian Veo 554 or 754 -->
+firmware 2.7A or lower</br>
 
-To find your pump’s firmware you will need to power it on. If the pump has not been powered on for some time (i.e., has been in storage without a battery for a while), it will run through a start-up count and the firmware version will appear on the bottom right of the pump’s screen.  Don’t turn away, as the version number will only be displayed for a little while before the screen moves onto other information displays.  
+To find your pump’s firmware you will need to power it on. If the pump has not
+been powered on for some time (i.e., has been in storage without a battery for a
+while), it will run through a start-up count and the firmware version will
+appear on the bottom right of the pump’s screen. Don’t turn away, as the version
+number will only be displayed for a little while before the screen moves onto
+other information displays.
 
-If the pump has been active recently or has a reservoir installed, follow these steps:
+If the pump has been active recently or has a reservoir installed, follow these
+steps:
 
-1. Press the <img src="../img/esc.png" width="40" alt="ESC"> button on your pump.  
+1. Press the <img src="../img/esc.png" width="40" alt="ESC"> button on your
+   pump.
 
-2. Scroll down with the <img src="../img/light_button.png" width="40" alt="Down Arrow"> button to the bottom of the status display.  
+2. Scroll down with the
+   <img src="../img/light_button.png" width="40" alt="Down Arrow"> button to the
+   bottom of the status display.
 
 3. Read the bottom line of the display.
 
 ![Firmware](img/pump_firmware.png)
 
 ### Medtronic Pump Differences
-If you are in the position of being able to shop around for different pump models, there are some slight differences between the Loop-compatible Medtronic pumps.
 
-<font color ="orange">500 vs 700</font>:  The difference between the Medtronic 500 series and the 700 series pumps is the size of the insulin reservoirs.  The 500 series pumps use a 180 unit reservoir, and the 700 series pumps use a 300 unit reservoir (or smaller 180 unit reservoir, if you want).
+If you are in the position of being able to shop around for different pump
+models, there are some slight differences between the Loop-compatible Medtronic
+pumps.
 
-<font color ="orange">x15/x22 vs x23/x54</font>:  The difference between the x15 and x22 pumps versus the x23 and x54 series pumps has only a few notable mentions:
+<font color ="orange">500 vs 700</font>: The difference between the Medtronic
+500 series and the 700 series pumps is the size of the insulin reservoirs. The
+500 series pumps use a 180 unit reservoir, and the 700 series pumps use a 300
+unit reservoir (or smaller 180 unit reservoir, if you want).
 
-* The x23/x54 pumps will allow for smaller insulin deliveries in certain situations, if the smaller scroll rate is selected in the Bolus>Setup>Scroll Rate menu.  **Loop will have the insulin delivery automatically rounded by the pump to the units available in the pump model, and any smaller adjustments (to make up for the rounding) will be made through Loop’s use of temp basals.  If you want the smaller increments of basal rates, you can still enter those values in Loop app's settings and Loop will use those values for the purposes of insulin delivery calculations.**
+<font color ="orange">x15/x22 vs x23/x54</font>: The difference between the x15
+and x22 pumps versus the x23 and x54 series pumps has only a few notable
+mentions:
+
+- The x23/x54 pumps will allow for smaller insulin deliveries in certain
+  situations, if the smaller scroll rate is selected in the Bolus>Setup>Scroll
+  Rate menu. **Loop will have the insulin delivery automatically rounded by the
+  pump to the units available in the pump model, and any smaller adjustments (to
+  make up for the rounding) will be made through Loop’s use of temp basals. If
+  you want the smaller increments of basal rates, you can still enter those
+  values in Loop app's settings and Loop will use those values for the purposes
+  of insulin delivery calculations.**
 
 <table>
 <thead>
@@ -106,68 +152,130 @@ If you are in the position of being able to shop around for different pump model
 </tbody>
 </table>
 
-* Additionally, because of the way Loop fetches information from the pump, the x23/x54 series of pumps are slightly better at conserving battery life through the use of the MySentry packets to collect information from the pump.  x22 pumps do not use MySentry.
+- Additionally, because of the way Loop fetches information from the pump, the
+  x23/x54 series of pumps are slightly better at conserving battery life through
+  the use of the MySentry packets to collect information from the pump. x22
+  pumps do not use MySentry.
 
-* The x23/x54 series pumps are also faster at delivering boluses greater than 10 units.  On an x23 pump, a 13-unit bolus takes 5:00 minutes to complete.  On an x22 pump, a 13-unit bolus takes 8:40 minutes to complete.
+- The x23/x54 series pumps are also faster at delivering boluses greater than 10
+  units. On an x23 pump, a 13-unit bolus takes 5:00 minutes to complete. On an
+  x22 pump, a 13-unit bolus takes 8:40 minutes to complete.
 
 ### Finding a Medtronic pump
 
-Finding a compatible Medtronic pump is probably the most difficult part for most new Loopers.  Our suggestion:
+Finding a compatible Medtronic pump is probably the most difficult part for most
+new Loopers. Our suggestion:
 
-* Talk to friends in the diabetic community.
+- Talk to friends in the diabetic community.
 
-* Ask your endocrinologist.  
+- Ask your endocrinologist.
 
-* Ask at a local JDRF chapter meeting if someone has an old backup pump they'd be willing to donate to you.  
+- Ask at a local JDRF chapter meeting if someone has an old backup pump they'd
+  be willing to donate to you.
 
-* Join diabetic supply groups on Facebook; both for-trade and for-sale groups.  
+- Join diabetic supply groups on Facebook; both for-trade and for-sale groups.
 
-* Check Craigslist often and be willing to expand your search area to include larger cities.
+- Check Craigslist often and be willing to expand your search area to include
+  larger cities.
 
-* Check out the **HelpAround, NextDoor, OfferUp, and/or LetGo** apps for pumps.
+- Check out the **HelpAround, NextDoor, OfferUp, and/or LetGo** apps for pumps.
 
-* Search [Medwow](http://medwow.com) for used Medtronic pumps.
+- Search [Medwow](http://medwow.com) for used Medtronic pumps.
 
-Medwow has been fairly frustrating for most people; poor response rate and high prices.  The most success appears to come from either one-on-one discussions with fellow diabetics/doctors or using apps (Craigslist, NextDoor, LetGo, HelpAround).  If you are using Craigslist, you may wish to use an app on your iPhone to make the searching easier.  There are apps to search multiple cities at once for your keywords and set up alerts.
+Medwow has been fairly frustrating for most people; poor response rate and high
+prices. The most success appears to come from either one-on-one discussions with
+fellow diabetics/doctors or using apps (Craigslist, NextDoor, LetGo,
+HelpAround). If you are using Craigslist, you may wish to use an app on your
+iPhone to make the searching easier. There are apps to search multiple cities at
+once for your keywords and set up alerts.
 
 ![Craigslist](img/craigslist.png)
 
 ### Safe Purchasing
 
-If you choose to purchase from a remote or unknown seller, here are some tips for safe purchasing:
+If you choose to purchase from a remote or unknown seller, here are some tips
+for safe purchasing:
 
-* Use PayPal and purchase using the "Goods and Services" payment option. This costs nothing for the buyer, but the seller will lose 2.95% of the sale to PayPal fees. PayPal offers some protection for both buyer and seller in the event of fraud.  
+- Use PayPal and purchase using the "Goods and Services" payment option. This
+  costs nothing for the buyer, but the seller will lose 2.95% of the sale to
+  PayPal fees. PayPal offers some protection for both buyer and seller in the
+  event of fraud.
 
-* Ask for photos of the pump. Check to make sure the serial number of the pump on the backside matches the serial number of the pump showing in the display menu. Ask for a short video of the pump, or at least a photo of the pump turned on, so that you can see the pump's firmware and model number. Cracks and some wear on these pumps are expected. These pumps are not usually free of marks. Many people are successfully looping on pumps that have cracks and rub marks, but you may want to ask if you are concerned about any you see in photos.
+- Ask for photos of the pump. Check to make sure the serial number of the pump
+  on the backside matches the serial number of the pump showing in the display
+  menu. Ask for a short video of the pump, or at least a photo of the pump
+  turned on, so that you can see the pump's firmware and model number. Cracks
+  and some wear on these pumps are expected. These pumps are not usually free of
+  marks. Many people are successfully looping on pumps that have cracks and rub
+  marks, but you may want to ask if you are concerned about any you see in
+  photos.
 
-* Beware if the bottom of the reservoir/motor sleeve has the drive support cap pushed out, as shown [here](https://loopkit.github.io/loopdocs/troubleshooting/pump-errors/#motor-error). Those pumps will generally not work (or only work intermittently), however some people have successfully repaired those pumps as shown in that link. Just be aware that it should be checked in advance.
+- Beware if the bottom of the reservoir/motor sleeve has the drive support cap
+  pushed out, as shown
+  [here](https://loopkit.github.io/loopdocs/troubleshooting/pump-errors/#motor-error).
+  Those pumps will generally not work (or only work intermittently), however
+  some people have successfully repaired those pumps as shown in that link. Just
+  be aware that it should be checked in advance.
 
-* Repairs to cracks or missing bits of plastic on battery cap area and reservoir caps are possible and not very difficult in most situations. You can read more about how to repair those [here](https://loopkit.github.io/loopdocs/troubleshooting/pump-errors/#crackmissing-piece-repairs).
+- Repairs to cracks or missing bits of plastic on battery cap area and reservoir
+  caps are possible and not very difficult in most situations. You can read more
+  about how to repair those
+  [here](https://loopkit.github.io/loopdocs/troubleshooting/pump-errors/#crackmissing-piece-repairs).
 
-* Ask for shipping that includes a tracking number. USPS Priority Mail's smallest box is a great option.  It's only $7.20 domestically in the US and includes tracking. Ask the seller to add a small bit of packing protection such as bubble wrap around the pump to keep it safe during shipping. Make sure you get a tracking number within a reasonable period of time after you have paid.  
+- Ask for shipping that includes a tracking number. USPS Priority Mail's
+  smallest box is a great option. It's only \$7.20 domestically in the US and
+  includes tracking. Ask the seller to add a small bit of packing protection
+  such as bubble wrap around the pump to keep it safe during shipping. Make sure
+  you get a tracking number within a reasonable period of time after you have
+  paid.
 
 Red flags that may indicate a scam:
 
-* Asking for payment through "friends and family" on PayPal, especially if you don't know the person or have any solid references for them. Paying in that way offers you no buyer protection. It's just like giving the seller cash, so you had better trust the seller.  
+- Asking for payment through "friends and family" on PayPal, especially if you
+  don't know the person or have any solid references for them. Paying in that
+  way offers you no buyer protection. It's just like giving the seller cash, so
+  you had better trust the seller.
 
-* Offering an "almost new" pump is a big red flag. These pumps should be at least 5-years-old by now. Do you really think a 5 year old pump should be unused and sitting in shrink wrap at this point? This seems highly suspicious. There are some out there, but they are very infrequent.  
+- Offering an "almost new" pump is a big red flag. These pumps should be at
+  least 5-years-old by now. Do you really think a 5 year old pump should be
+  unused and sitting in shrink wrap at this point? This seems highly suspicious.
+  There are some out there, but they are very infrequent.
 
-* Not able to provide new pictures of the pump when requested. Sure they posted some pictures with the ad, but what if they just downloaded them from other people's ads? The seller should be able to furnish a couple of "new" photos at your request. A good one to ask for is the battery and reservoir tops so you can see the condition of those.
+- Not able to provide new pictures of the pump when requested. Sure they posted
+  some pictures with the ad, but what if they just downloaded them from other
+  people's ads? The seller should be able to furnish a couple of "new" photos at
+  your request. A good one to ask for is the battery and reservoir tops so you
+  can see the condition of those.
 
 ### Pump Supplies
 
-Medtronic will not typically sell pump supplies directly to customers who have not previously purchased a registered Medtronic pump. Ask your insurance about purchasing pump supplies through a durable medical equipment (DME) provider. Typically, the DME provider will coordinate with your insurance and doctor's office to get the necessary insurance approval and prescriptions for the supplies. If you are brand new to Medtronic infusion sites, you may want to ask for help from friends to try a variety of infusion sets before purchasing a full 90-day supply of any type in particular.
+Medtronic will not typically sell pump supplies directly to customers who have
+not previously purchased a registered Medtronic pump. Ask your insurance about
+purchasing pump supplies through a durable medical equipment (DME) provider.
+Typically, the DME provider will coordinate with your insurance and doctor's
+office to get the necessary insurance approval and prescriptions for the
+supplies. If you are brand new to Medtronic infusion sites, you may want to ask
+for help from friends to try a variety of infusion sets before purchasing a full
+90-day supply of any type in particular.
 
 ## Extra Details on Omnipods
 
-!!!warning "Reminder and Disclaimer"
-    Through the work of the DIY community, Insulet's Omnipod (Eros) system is now Loop compatible. Using Eros pods with Loop is not supported by Insulet. Do not call Insulet asking for help with your Loop build, setup, or operation. This project is not FDA-approved and you are using this project under your own responsibility and risk. Please read the documents and familiarize yourself with Loop before using. 
+!!!warning "Reminder and Disclaimer" Through the work of the DIY community,
+Insulet's Omnipod (Eros) system is now Loop compatible. Using Eros pods with
+Loop is not supported by Insulet. Do not call Insulet asking for help with your
+Loop build, setup, or operation. This project is not FDA-approved and you are
+using this project under your own responsibility and risk. Please read the
+documents and familiarize yourself with Loop before using.
 
 ### Eros
 
 **Loop will work with these pods**
 
-Eros pods were launched in 2013 and continue to be sold by Insulet. As far as we know, there have been no plans or timelines announced for the discontinuation of Eros pods for existing customers. Insulet doesn't specifically call these "Eros" anymore, they just use the term "omnipod system". For clarity, from [Insulet's webpage](https://www.myomnipod.com/about):
+Eros pods were launched in 2013 and continue to be sold by Insulet. As far as we
+know, there have been no plans or timelines announced for the discontinuation of
+Eros pods for existing customers. Insulet doesn't specifically call these "Eros"
+anymore, they just use the term "omnipod system". For clarity, from
+[Insulet's webpage](https://www.myomnipod.com/about):
 
 Eros system has that PDM we all recognize from the last several years.
 
@@ -179,7 +287,11 @@ Eros system has that PDM we all recognize from the last several years.
 
 **Loop will not work with DASH pods**
 
-Insulet has announced their DASH system as an eventual replacement for Eros/Omnipod System. There has already been a limited release of DASH to a select group of users, with a wider public rollout of DASH expected in 2019. The DASH system has the newer, slimmer locked-android PDM and built-in BLE communications in POD. Loop will not be compatible with the DASH system.
+Insulet has announced their DASH system as an eventual replacement for
+Eros/Omnipod System. There has already been a limited release of DASH to a
+select group of users, with a wider public rollout of DASH expected in 2019. The
+DASH system has the newer, slimmer locked-android PDM and built-in BLE
+communications in POD. Loop will not be compatible with the DASH system.
 
 <p align="center">
 <img src="../img/dash.png" width="750">
@@ -187,5 +299,5 @@ Insulet has announced their DASH system as an eventual replacement for Eros/Omni
 
 ## Next Step: Compatible CGM
 
-Now you are ready to move onto Step 4 to check if you have a [Compatible CGM](https://loopkit.github.io/loopdocs/build/step4/).
-
+Now you are ready to move onto Step 4 to check if you have a
+[Compatible CGM](https://loopkit.github.io/loopdocs/build/step4/).

--- a/docs/build/step4.md
+++ b/docs/build/step4.md
@@ -1,44 +1,83 @@
 # Step 4: Compatible CGM
 
-!!!danger "Time Estimate"
-    * 10 minutes to read through this page
-    
-!!!info "Summary"
-    * If you use a Dexcom G4 Share, G5, or G6 CGM system...you are good to use Loop.
-    * If you use a Medtronic sensor compatible with a Loop-compatble Medtronic pump...you are good to use Loop.
-    * If you have an Eversense...you cannot use Loop with that CGM.
-    * If you use Libre...you will need to seek out a modified Loop
+!!!danger "Time Estimate" \_ 10 minutes to read through this page
 
-!!!warning "FAQs"
-    * **"What about Libre sensors?"** Libre sensors are not designed to be continuous glucose monitors. All use of Libre sensors as continuous glucose monitors involves the use of third-party applications (Xdrip or Spike) and reader devices (BluCon or Miao Miao). Loop developers have not seen data demonstrating sufficient safeguards from those readers and applications to feel comfortable adding main line Loop integration for those devices. If you use a Libre sensor, you'll have to use a "not-main line" branch of Loop that someone (or yourself) has modified to allow for use with those sensors/applications.
-    * **"What about Eversense?"** Eversense's application does not integrate with Apple Health, nor has the communications protocols for Eversense been reverse engineered. Therefore, Eversense is not compatible with Loop use currently.
+!!!info "Summary" _ If you use a Dexcom G4 Share, G5, or G6 CGM system...you are
+good to use Loop. _ If you use a Medtronic sensor compatible with a
+Loop-compatble Medtronic pump...you are good to use Loop. \_ If you have an
+Eversense...you cannot use Loop with that CGM. \* If you use Libre...you will
+need to seek out a modified Loop
 
-A continuous glucose monitor (CGM) provides Loop with current blood glucose readings. These readings allow Loop to predict what the current glucose trend is, and predict future blood glucose based on carbohydrate input and your Loop settings. The following are the types of CGMs compatible with Loop. CGM readings are a required part of looping. If your Loop is unable to retrieve BG data, it will not be able to loop.
+!!!warning "FAQs" _ **"What about Libre sensors?"** Libre sensors are not
+designed to be continuous glucose monitors. All use of Libre sensors as
+continuous glucose monitors involves the use of third-party applications (Xdrip
+or Spike) and reader devices (BluCon or Miao Miao). Loop developers have not
+seen data demonstrating sufficient safeguards from those readers and
+applications to feel comfortable adding main line Loop integration for those
+devices. If you use a Libre sensor, you'll have to use a "not-main line" branch
+of Loop that someone (or yourself) has modified to allow for use with those
+sensors/applications. _ **"What about Eversense?"** Eversense's application does
+not integrate with Apple Health, nor has the communications protocols for
+Eversense been reverse engineered. Therefore, Eversense is not compatible with
+Loop use currently.
+
+A continuous glucose monitor (CGM) provides Loop with current blood glucose
+readings. These readings allow Loop to predict what the current glucose trend
+is, and predict future blood glucose based on carbohydrate input and your Loop
+settings. The following are the types of CGMs compatible with Loop. CGM readings
+are a required part of looping. If your Loop is unable to retrieve BG data, it
+will not be able to loop.
 
 ## Dexcom G5 and G6 CGM <img src="../img/g5.jpg" width="150" alt="G5">
 
-Dexcom G5 and G6 receives CGM data directly to the Dexcom app on your iPhone via Bluetooth. Neither of these two systems require the use of a stand-alone receiver. For Loop to function, you will need the Dexcom app running.
+Dexcom G5 and G6 receives CGM data directly to the Dexcom app on your iPhone via
+Bluetooth. Neither of these two systems require the use of a stand-alone
+receiver. For Loop to function, you will need the Dexcom app running.
 
 ## Dexcom G4 CGM with Share Receiver <img src="../img/g4_receiver.png" width="150" alt="G4 With Receiver">
 
-Dexcom G4 Share system transmits CGM data from the transmitter to a Dexcom G4 Share Receiver. The receiver, in turn, connects to the Dexcom Share2 app on your iPhone via Bluetooth. The Share2 app uploads CGM data to the Dexcom servers. For Loop to function, you will need the Dexcom app running.
+Dexcom G4 Share system transmits CGM data from the transmitter to a Dexcom G4
+Share Receiver. The receiver, in turn, connects to the Dexcom Share2 app on your
+iPhone via Bluetooth. The Share2 app uploads CGM data to the Dexcom servers. For
+Loop to function, you will need the Dexcom app running.
 
 ## Medtronic CGM <img src="../img/enlite.png" width="150" alt="Enlite">
 
-The Minimed Enlite CGM, available with the Medtronic 522/722, 523/723, and 554/754, wirelessly sends blood glucose readings to the pump. Loop can read the Medtronic CGM data directly from the pump using the RileyLink.
+The Minimed Enlite CGM, available with the Medtronic 522/722, 523/723, and
+554/754, wirelessly sends blood glucose readings to the pump. Loop can read the
+Medtronic CGM data directly from the pump using the RileyLink.
 
 ## Offline Use
 
-Offline use means using Loop when there is no cell data or internet available. Loop does not require any special setup to operate offline. You will not need to do anything special if you go camping or find yourself out in the wilderness. For offline Loop use, the iPhone's Bluetooth still needs to be active; and for Dexcom system's, the Share2, G5, or G6 app also still needs to be open (but don't have to be actively "sharing" to the internet). If you put your iPhone into Airplane mode, remember to turn Bluetooth back on to keep your Loop running. If your offline use is failing, chances are you have forgotten to update your transmitter ID in Loop settings when you changed transmitters.
+Offline use means using Loop when there is no cell data or internet available.
+Loop does not require any special setup to operate offline. You will not need to
+do anything special if you go camping or find yourself out in the wilderness.
+For offline Loop use, the iPhone's Bluetooth still needs to be active; and for
+Dexcom system's, the Share2, G5, or G6 app also still needs to be open (but
+don't have to be actively "sharing" to the internet). If you put your iPhone
+into Airplane mode, remember to turn Bluetooth back on to keep your Loop
+running. If your offline use is failing, chances are you have forgotten to
+update your transmitter ID in Loop settings when you changed transmitters.
 
 ## Dexcom Servers
 
-In some rare instances, the Loop may fail to eavesdrop on the Bluetooth transmissions of the CGM systems.  When that happens, the Loop can pull directly from Dexcom Servers to get the data (assuming you have entered your Share account information in the Loop settings and have Share turned on). When Loop is operating in this mode, you will see a small cloud in the CGM reading in the Loop app. Operating in this mode requires a working internet or cell connection.
+In some rare instances, the Loop may fail to eavesdrop on the Bluetooth
+transmissions of the CGM systems. When that happens, the Loop can pull directly
+from Dexcom Servers to get the data (assuming you have entered your Share
+account information in the Loop settings and have Share turned on). When Loop is
+operating in this mode, you will see a small cloud in the CGM reading in the
+Loop app. Operating in this mode requires a working internet or cell connection.
 
 ## CGMs not natively supported in Loop
 
-Libre (with BluCon or Miao Miao), Eversense, Medtronic Guardian sensors, etc.  Yes, there are other CGM systems available out there. Loop does not natively support those CGMs.  If you would like to use one of those alternate CGMs and Loop...you will need to look into third-party integrations to allow Loop to access the blood glucose data.  These docs do not cover the alternate methods of unsupported CGM systems or apps like Spike.
+Libre (with BluCon or Miao Miao), Eversense, Medtronic Guardian sensors, etc.
+Yes, there are other CGM systems available out there. Loop does not natively
+support those CGMs. If you would like to use one of those alternate CGMs and
+Loop...you will need to look into third-party integrations to allow Loop to
+access the blood glucose data. These docs do not cover the alternate methods of
+unsupported CGM systems or apps like Spike.
 
 ## Next Step: Order a RileyLink
 
-Now you are ready to move onto Step 5 to [Order a RileyLink](https://loopkit.github.io/loopdocs/build/step5/).
+Now you are ready to move onto Step 5 to
+[Order a RileyLink](https://loopkit.github.io/loopdocs/build/step5/).

--- a/docs/build/step5.md
+++ b/docs/build/step5.md
@@ -1,26 +1,48 @@
 # Step 5: Order a RileyLink
 
-!!!danger "Time Estimate"
-    * 15 minutes to order a RileyLink
-    * 15-20 minutes to assemble the RileyLink once you get it in the mail
-    * 15-20 minutes to read about the RileyLink
+!!!danger "Time Estimate" _ 15 minutes to order a RileyLink _ 15-20 minutes to
+assemble the RileyLink once you get it in the mail \* 15-20 minutes to read
+about the RileyLink
 
-!!!info "Summary"
-    * Order your [Omnipod RileyLink](https://getrileylink.org/product/rileylink433) or [Medtronic RileyLink](https://getrileylink.org/product/rileylink916).
-    * Assemble the RileyLink, after hugging the postman
-    * Read the "extra details" to learn about RileyLink lights, charging, range, etc.
+!!!info "Summary" _ Order your
+[Omnipod RileyLink](https://getrileylink.org/product/rileylink433) or
+[Medtronic RileyLink](https://getrileylink.org/product/rileylink916). _ Assemble
+the RileyLink, after hugging the postman \* Read the "extra details" to learn
+about RileyLink lights, charging, range, etc.
 
-!!!warning "FAQs"
-    * **"Do I need a RileyLink?"** Yes. Loop will not work without a RileyLink. Omnipod users will not be able to bolus from their looping pod without a RileyLink.
-    * **"What happens if I lose my RileyLink or walk away from it?"** Good question...answered [here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#what-happens-if-i-walk-away-from-my-rileylink).
-    * **"Can I use an Omnipod RileyLink with a Medtronic pump? or vice versa?"** Good question...answered [here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#what-will-happen-if-you-use-a-916mhz-antenna-rileylink-with-an-omnipod-or-vice-versa).
-    * **"Can I swap out RileyLinks at any time?"** Yes, you can. RileyLinks can be replaced quite simply without needing to start a new pod or rebuild Loop app. There's a place in Loop settings that you'd simply find your new RileyLink's name and turn "on" the Bluetooth connection to start using it.
-    * **"How close does the RileyLink need to be to me? Do I have to carry it with me?"** Good questions...answered [here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#do-i-have-to-carry-the-rileylink-everywhere).
-    * **"Why is it named RileyLink?"** Riley is the name of Pete Schwamb's daughter and he's the guy that created the RileyLink.
-    * **"Can I make my own RileyLink?"** Technically yes, however it is not an easy project. You'll need specialized tools and patience. If you want to explore doing that, I'd highly recommend checking out [Zulipchat](https://loop.zulipchat.com/#narrow/stream/148542-RileyLink) from the other people who have done their own builds successfully over the last several years. Only 3 people have built their own RileyLinks so far...but I guess that technically means it is possible. The PCB files and software, with instructions on how to build your own hardware module can be found at the [RileyLink Github repo](https://github.com/ps2/rileylink).
+!!!warning "FAQs" _ **"Do I need a RileyLink?"** Yes. Loop will not work without
+a RileyLink. Omnipod users will not be able to bolus from their looping pod
+without a RileyLink. _ **"What happens if I lose my RileyLink or walk away from
+it?"** Good question...answered
+[here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#what-happens-if-i-walk-away-from-my-rileylink).
+_ **"Can I use an Omnipod RileyLink with a Medtronic pump? or vice versa?"**
+Good question...answered
+[here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#what-will-happen-if-you-use-a-916mhz-antenna-rileylink-with-an-omnipod-or-vice-versa).
+_ **"Can I swap out RileyLinks at any time?"** Yes, you can. RileyLinks can be
+replaced quite simply without needing to start a new pod or rebuild Loop app.
+There's a place in Loop settings that you'd simply find your new RileyLink's
+name and turn "on" the Bluetooth connection to start using it. _ **"How close
+does the RileyLink need to be to me? Do I have to carry it with me?"** Good
+questions...answered
+[here](https://loopkit.github.io/loopdocs/faqs/rileylink-faqs/#do-i-have-to-carry-the-rileylink-everywhere).
+_ **"Why is it named RileyLink?"** Riley is the name of Pete Schwamb's daughter
+and he's the guy that created the RileyLink. \* **"Can I make my own
+RileyLink?"** Technically yes, however it is not an easy project. You'll need
+specialized tools and patience. If you want to explore doing that, I'd highly
+recommend checking out
+[Zulipchat](https://loop.zulipchat.com/#narrow/stream/148542-RileyLink) from the
+other people who have done their own builds successfully over the last several
+years. Only 3 people have built their own RileyLinks so far...but I guess that
+technically means it is possible. The PCB files and software, with instructions
+on how to build your own hardware module can be found at the
+[RileyLink Github repo](https://github.com/ps2/rileylink).
 
 ## What is RileyLink
-The RileyLink (RL) is an open-source hardware device that can bridge Bluetooth Low Energy (BLE) to 916MHz or 433MHz wireless communication. What does that mean to you? It means RileyLink is the communication highway between your insulin pump, CGM, and iPhone.</br></br>
+
+The RileyLink (RL) is an open-source hardware device that can bridge Bluetooth
+Low Energy (BLE) to 916MHz or 433MHz wireless communication. What does that mean
+to you? It means RileyLink is the communication highway between your insulin
+pump, CGM, and iPhone.</br></br>
 
 <p align="center">Loop will not work without the RileyLink.</b></p></br></br>
 
@@ -29,25 +51,39 @@ The RileyLink (RL) is an open-source hardware device that can bridge Bluetooth L
 </p>
 
 ## Order RileyLink
-This is an easy step. You need to order a RileyLink from the [GetRiley website](https://getrileylink.org). 
 
-There are two types of RileyLinks; [one for Omnipod](https://getrileylink.org/product/rileylink433) users and [one for Medtronic](https://getrileylink.org/product/rileylink916) users. Order the RileyLink specifically for the pump you'll be Looping with. 
+This is an easy step. You need to order a RileyLink from the
+[GetRiley website](https://getrileylink.org).
+
+There are two types of RileyLinks;
+[one for Omnipod](https://getrileylink.org/product/rileylink433) users and
+[one for Medtronic](https://getrileylink.org/product/rileylink916) users. Order
+the RileyLink specifically for the pump you'll be Looping with.
 
 ## Assemble RileyLink
 
-Your RL will come with the battery disconnected and the parts not already inside the case. It will be up to you to put the RL in the case and attach the battery.
+Your RL will come with the battery disconnected and the parts not already inside
+the case. It will be up to you to put the RL in the case and attach the battery.
 
-Make sure the lipo battery is well-plugged into the connection. Line up the little ridge appropriately, and push fairly firmly to get the connection tight.  Poor battery cable connection can make the Loop communications fail.  See photos below, for example.
+Make sure the lipo battery is well-plugged into the connection. Line up the
+little ridge appropriately, and push fairly firmly to get the connection tight.
+Poor battery cable connection can make the Loop communications fail. See photos
+below, for example.
 
-!!!info "Common new user errors"
-    The most common two errors for new RL owners are (1) not fully pushing in the lipo battery cable connection and (2) failing to charge the RL. Compare your lipo battery cable with the photos; it takes a bit of oomph to push that plug fully in like the photos shown below. Remember to charge your RL each night.
+!!!info "Common new user errors" The most common two errors for new RL owners
+are (1) not fully pushing in the lipo battery cable connection and (2) failing
+to charge the RL. Compare your lipo battery cable with the photos; it takes a
+bit of oomph to push that plug fully in like the photos shown below. Remember to
+charge your RL each night.
 
 <p><figure align="center">
 <img src="../img/battery-cables.jpg" width="400">
 <figcaption>Loose battery cable on left, Proper battery cable on right</figcaption>
 </figure></p>
 
-Finally, the board and the battery fit into the slim case fairly tightly as well.  Click on the image below to watch a helpful [assembly video](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be).
+Finally, the board and the battery fit into the slim case fairly tightly as
+well. Click on the image below to watch a helpful
+[assembly video](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be).
 
 <a href="https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be" target="_blank"><img src="../img/slimcase.png"  title="RileyLink assembly video" /></a>
 
@@ -55,17 +91,40 @@ Finally, the board and the battery fit into the slim case fairly tightly as well
 
 ### Radio communications
 
-The RL communicates with the pump through radio frequency communications.  Numerous factors can influence how well those communications can function...interferences from other devices, temperature, physical blocking, etc.
+The RL communicates with the pump through radio frequency communications.
+Numerous factors can influence how well those communications can
+function...interferences from other devices, temperature, physical blocking,
+etc.
 
-When your RL and pump are first paired, Loop performs a series of tests that you won't see...they are tuning tests. Basically, RL sends little test messages to the pump and waits for a response. The RL tries this same "ping" to the pump a range of various radio frequencies. The range of radio frequencies it tries is based on the pump you've told RL to expect (Omnipod, Medtronic NA/CA, or Medtronic WW).  RL will then record the radio frequencies that provided the strongest response and use that frequency for future pump communications.
+When your RL and pump are first paired, Loop performs a series of tests that you
+won't see...they are tuning tests. Basically, RL sends little test messages to
+the pump and waits for a response. The RL tries this same "ping" to the pump a
+range of various radio frequencies. The range of radio frequencies it tries is
+based on the pump you've told RL to expect (Omnipod, Medtronic NA/CA, or
+Medtronic WW). RL will then record the radio frequencies that provided the
+strongest response and use that frequency for future pump communications.
 
-Usually this best frequency is pretty constant for any given pump+RL, but during temperature changes it may be that the best frequency is not the one currently set. In the event that RL has problems communicating with the pump, Loop has code built-in that will automatically tell the RL "Hey, try that tuning pump thing again...maybe there's a better frequency we need to try." This retuning is started automatically if pump communications fail for 14 minutes (in other words, two looping cycles).
+Usually this best frequency is pretty constant for any given pump+RL, but during
+temperature changes it may be that the best frequency is not the one currently
+set. In the event that RL has problems communicating with the pump, Loop has
+code built-in that will automatically tell the RL "Hey, try that tuning pump
+thing again...maybe there's a better frequency we need to try." This retuning is
+started automatically if pump communications fail for 14 minutes (in other
+words, two looping cycles).
 
 ### Bluetooth communications
 
-RL communicates with your iPhone and Loop app through Bluetooth (BT).  If your iPhone has BT issues, your Loop will have failures.  There have been reports of BT audio devices (such as BT pairings in your car or home audio BT speakers) interfering with the Loop.  If you are finding Loop failures frequently happening at a particular location, you may try to troubleshoot if there are BT problems in the area.
+RL communicates with your iPhone and Loop app through Bluetooth (BT). If your
+iPhone has BT issues, your Loop will have failures. There have been reports of
+BT audio devices (such as BT pairings in your car or home audio BT speakers)
+interfering with the Loop. If you are finding Loop failures frequently happening
+at a particular location, you may try to troubleshoot if there are BT problems
+in the area.
 
-Your BT signal strength can be seen in the Loop settings, under the RL menu, on the `Signal Strength` line. As you move closer and further away from your phone, you can watch that number dynamically change. This line is **not** displaying the signal strength of your pump communications discussed above.
+Your BT signal strength can be seen in the Loop settings, under the RL menu, on
+the `Signal Strength` line. As you move closer and further away from your phone,
+you can watch that number dynamically change. This line is **not** displaying
+the signal strength of your pump communications discussed above.
 
 <p align="center">
 <img src="../img/RL_bt.jpg" width="400">
@@ -73,50 +132,104 @@ Your BT signal strength can be seen in the Loop settings, under the RL menu, on 
 
 ### Lights
 
-RL has several lights that you may notice from time to time. There is no 'power' light. If you suspect that your RL is not being powered, try turning it off and on using the small sliding switch. You should see lights in the middle of the board flash when you do this.  If they flash, that means the board has power.
+RL has several lights that you may notice from time to time. There is no 'power'
+light. If you suspect that your RL is not being powered, try turning it off and
+on using the small sliding switch. You should see lights in the middle of the
+board flash when you do this. If they flash, that means the board has power.
 
-* Red light: Charging light. The red light will remain on while RL is charging, and it will turn off when charging is complete. You may notice the red light turn on periodically even after charging is complete...it's just "topping off".
+- Red light: Charging light. The red light will remain on while RL is charging,
+  and it will turn off when charging is complete. You may notice the red light
+  turn on periodically even after charging is complete...it's just "topping
+  off".
 
-* Green light: Bluetooth connection light. The green light will remain on while you have a BT connection with your iPhone.  If that green light fails to stay on, you should troubleshoot your BT connections. Try restarting BT on your iPhone and/or turning the RL off/on by its power switch.
+- Green light: Bluetooth connection light. The green light will remain on while
+  you have a BT connection with your iPhone. If that green light fails to stay
+  on, you should troubleshoot your BT connections. Try restarting BT on your
+  iPhone and/or turning the RL off/on by its power switch.
 
-* Blue light: Pump communications.  If you have an older firmware on your RL, some of the blue lights will flash periodically as it communicates with the pump. It's just letting you know that it is busy talking and collecting info. You will also see increased blue flashes if you have "Enabled Diagnostic LEDs" for MDT users that have the RLs with updated firmware (shipping since late August 2018).
+- Blue light: Pump communications. If you have an older firmware on your RL,
+  some of the blue lights will flash periodically as it communicates with the
+  pump. It's just letting you know that it is busy talking and collecting info.
+  You will also see increased blue flashes if you have "Enabled Diagnostic LEDs"
+  for MDT users that have the RLs with updated firmware (shipping since late
+  August 2018).
 
-A solid blue light that consistently remains lit on the board could mean one of two things:
+A solid blue light that consistently remains lit on the board could mean one of
+two things:
 
-* A temporary issue that can be resolved by rebooting the RL physically (turning the switch off/on), or
+- A temporary issue that can be resolved by rebooting the RL physically (turning
+  the switch off/on), or
 
-* An electrical short or damage to the board.  Sweat and moisture are most likely culprits, so try to keep case free from those environments. Don't keep RL in sports bras or waistband next to skin, for example, while exercising.
+- An electrical short or damage to the board. Sweat and moisture are most likely
+  culprits, so try to keep case free from those environments. Don't keep RL in
+  sports bras or waistband next to skin, for example, while exercising.
 
-If your blue light remains on despite trying a restart, it is time to pull out your backup RL.
+If your blue light remains on despite trying a restart, it is time to pull out
+your backup RL.
 
 ### Charging
 
-The battery that comes with RL is not likely charged completely when it is shipped, so feel free to charge it up.  You'll need a [mini-USB cable](https://www.amazon.com/AmazonBasics-USB-2-0-Cable--Male/dp/B00NH13S44) and [0.5A USB charging power supply](https://www.amazon.com/Cellet-Powered-Charger-iPhones-Smartphones-/dp/B00FE8WFCO) like your iPhone power supply.  RL takes about 2 hours to fully charge (the red light will turn off when fully charged, read note above about red light patterns) and should easily last at least a full day of constant Loop use.  Typically, it can go into the 30-hour range without any problems.  Most people charge their RL each night when they are sleeping.  You don't have to worry about leaving the RL plugged in "too long" for charging.  It will automatically stop charging the battery when it is fully charged.
+The battery that comes with RL is not likely charged completely when it is
+shipped, so feel free to charge it up. You'll need a
+[mini-USB cable](https://www.amazon.com/AmazonBasics-USB-2-0-Cable--Male/dp/B00NH13S44)
+and
+[0.5A USB charging power supply](https://www.amazon.com/Cellet-Powered-Charger-iPhones-Smartphones-/dp/B00FE8WFCO)
+like your iPhone power supply. RL takes about 2 hours to fully charge (the red
+light will turn off when fully charged, read note above about red light
+patterns) and should easily last at least a full day of constant Loop use.
+Typically, it can go into the 30-hour range without any problems. Most people
+charge their RL each night when they are sleeping. You don't have to worry about
+leaving the RL plugged in "too long" for charging. It will automatically stop
+charging the battery when it is fully charged.
 
-Since the best practice is to charge your RL overnight while you sleep, and the battery lasts safely over 24 hours, there is no battery level indicator for the RL.  The RL's charge level is not viewable on Nightscout, nor within the Loop app.  If you forget to charge your RL overnight, you can recharge it with a portable USB battery in a pinch.  A [short mini-USB cable](https://www.adafruit.com/product/899) could be a good addition to a small gear bag.
+Since the best practice is to charge your RL overnight while you sleep, and the
+battery lasts safely over 24 hours, there is no battery level indicator for the
+RL. The RL's charge level is not viewable on Nightscout, nor within the Loop
+app. If you forget to charge your RL overnight, you can recharge it with a
+portable USB battery in a pinch. A
+[short mini-USB cable](https://www.adafruit.com/product/899) could be a good
+addition to a small gear bag.
 
 ### Range
 
-The range that your RL will function is **heavily** dependent on the environment that you are in. Most people wear the RL in a pocket or carry a belt holster during the day. The radio frequency communications will have a shorter range than the BT communications, therefore RL will do better closer to the pump rather than the iPhone if you are deciding on options for carrying gear. 
+The range that your RL will function is **heavily** dependent on the environment
+that you are in. Most people wear the RL in a pocket or carry a belt holster
+during the day. The radio frequency communications will have a shorter range
+than the BT communications, therefore RL will do better closer to the pump
+rather than the iPhone if you are deciding on options for carrying gear.
 
-Problematic environments will be places like technical conferences, sports arenas, and other places where wireless communications are heavy and plenty.
+Problematic environments will be places like technical conferences, sports
+arenas, and other places where wireless communications are heavy and plenty.
 
 ### Lipo Battery
 
-Keep your RL and lipo battery protected from damage.  Lipo batteries are unsafe when damaged or punctured, so the case is an important part of safe Looping. If your battery is damaged in some way, please disconnect it immediately, and dispose of it (they should be recycled). You can order new batteries on the [GetRileyLink website](http://getrileylink.org/)
+Keep your RL and lipo battery protected from damage. Lipo batteries are unsafe
+when damaged or punctured, so the case is an important part of safe Looping. If
+your battery is damaged in some way, please disconnect it immediately, and
+dispose of it (they should be recycled). You can order new batteries on the
+[GetRileyLink website](http://getrileylink.org/)
 
 ### Removing Lipo Battery
 
-To remove the lipo battery from the RL, please do so slowly and patiently. Work the battery connection side to side slowly to loosen it from the plug. Some people have reported success using small, curved needle-nose pliers such as hemostats. Others have used small flathead screwdrivers as shown in [this video](https://youtu.be/s2qNPLpfwww).
+To remove the lipo battery from the RL, please do so slowly and patiently. Work
+the battery connection side to side slowly to loosen it from the plug. Some
+people have reported success using small, curved needle-nose pliers such as
+hemostats. Others have used small flathead screwdrivers as shown in
+[this video](https://youtu.be/s2qNPLpfwww).
 
 <a href="https://youtu.be/s2qNPLpfwww" target="_blank"><img src="../img/rileylink_battery_removal.png"  title="RileyLink assembly video" /></a>
 
 ## Waiting for RileyLink
 
-Yes, waiting for RL to arrive is extremely difficult if they are backorder.  PLEASE be patient, since Loop CANNOT work without RL.
+Yes, waiting for RL to arrive is extremely difficult if they are backorder.
+PLEASE be patient, since Loop CANNOT work without RL.
 
-If you're really dying to do something while RL ships, you can proceed with finishing these build directions all the way through Step 14...but after that you'll have to wait for the RileyLink.  You can't properly enter any settings or pump info in Loop app without the RileyLink.
+If you're really dying to do something while RL ships, you can proceed with
+finishing these build directions all the way through Step 14...but after that
+you'll have to wait for the RileyLink. You can't properly enter any settings or
+pump info in Loop app without the RileyLink.
 
 ## Next Step: Enroll in Apple Developer Program
 
-Now you are ready to move onto Step 6 to [enroll in the Apple Developer Program](https://loopkit.github.io/loopdocs/build/step6/).
+Now you are ready to move onto Step 6 to
+[enroll in the Apple Developer Program](https://loopkit.github.io/loopdocs/build/step6/).

--- a/docs/build/step6.md
+++ b/docs/build/step6.md
@@ -1,49 +1,94 @@
 # Step 6: Enroll in Apple Developer Program
 
+!!!danger "Time Estimate" _ 15-20 minutes to complete the enrollment forms _ up
+to 2 days to wait for confirmation email that enrollment has been activated
 
-!!!danger "Time Estimate"
-    * 15-20 minutes to complete the enrollment forms
-    * up to 2 days to wait for confirmation email that enrollment has been activated
+!!!info "Summary" _ If you've decided to you'd like to use a paid developer
+account, you need to enroll now. Go to the
+[Apple Developer website](https://developer.apple.com/programs/enroll/) to
+enroll in an individual account. _ If you've decided you'd like too use a free
+developer account, you don't need to do anything now. We'll get you covered
+later.
 
-!!!info "Summary"
-    * If you've decided to you'd like to use a paid developer account, you need to enroll now. Go to the [Apple Developer website](https://developer.apple.com/programs/enroll/) to enroll in an individual account.
-    * If you've decided you'd like too use a free developer account, you don't need to do anything now. We'll get you covered later.
+!!!warning "FAQs" _ **"Can I use someone else's Apple Developer account?"**
+Great question...answer is
+[here](https://loopkit.github.io/loopdocs/faqs/FAQs/#can-i-use-someone-elses-apple-developer-account).
+_ **"Do I use my Apple ID or my kid's Apple ID to enroll in the Apple Developer
+program?"** The Apple ID you use to enroll in the developer program does not
+need to be the same Apple ID as the Loop iPhone or Looper uses, for example a
+parent installing Loop on kid's iPhone. Typically for the developer enrollment,
+use the Apple ID of the person who will be doing the Loop app building. \*
+**"How long does it take to have my Apple Development account active after I
+enroll?"** After you enroll, make sure you look for a confirmation email. Apple
+says it can take up to 24-48 hours to confirm and setup a new Apple developer
+account, however some people have had the process only take minutes. It can
+vary. One SURE way to make it take longer? Use a different credit card to pay
+for the Apple Developer account enrollment than is already associated with the
+Apple ID you'll be enrolling with. When you do that, I've heard Apple makes you
+send in a xerox copy of your driver's license and a bunch of other hassle.
 
-!!!warning "FAQs"
-    * **"Can I use someone else's Apple Developer account?"** Great question...answer is [here](https://loopkit.github.io/loopdocs/faqs/FAQs/#can-i-use-someone-elses-apple-developer-account).
-    * **"Do I use my Apple ID or my kid's Apple ID to enroll in the Apple Developer program?"** The Apple ID you use to enroll in the developer program does not need to be the same Apple ID as the Loop iPhone or Looper uses, for example a parent installing Loop on kid's iPhone. Typically for the developer enrollment, use the Apple ID of the person who will be doing the Loop app building. 
-    * **"How long does it take to have my Apple Development account active after I enroll?"** After you enroll, make sure you look for a confirmation email. Apple says it can take up to 24-48 hours to confirm and setup a new Apple developer account, however some people have had the process only take minutes. It can vary. One SURE way to make it take longer? Use a different credit card to pay for the Apple Developer account enrollment than is already associated with the Apple ID you'll be enrolling with. When you do that, I've heard Apple makes you send in a xerox copy of your driver's license and a bunch of other hassle.
-    
-In order to build your own Loop app, you will need to use an Apple developer account.  You will have two options for an individual account; free or paid.
+In order to build your own Loop app, you will need to use an Apple developer
+account. You will have two options for an individual account; free or paid.
 
 ## Free Developer Account
 
 If you decide to use a **FREE** developer account, here's what you need to know:
 
-1. Loop apps signed with a free developer team will expire after 7 days.  On the 7th day, your Loop app will simply turn white when you open it and then immediately close. To rebuild the Loop app, you will have to find a computer and rebuild the app onto your iPhone again. You cannot rebuild the app on day 5 (when it is convenient, for example)...hoping to reset the 7-day clock.  The app will still expire on the 7th day from when it was first signed and created.</br></br>
-2. If you decide to switch to a paid account after trying out the free account, you will need to rebuild your Loop app in order to sign it with the new paid account.</br></br>
-3. You will have to do an extra step during the build process to remove Siri capabilities in order to build with free accounts.</br></br>
+1. Loop apps signed with a free developer team will expire after 7 days. On the
+   7th day, your Loop app will simply turn white when you open it and then
+   immediately close. To rebuild the Loop app, you will have to find a computer
+   and rebuild the app onto your iPhone again. You cannot rebuild the app on day
+   5 (when it is convenient, for example)...hoping to reset the 7-day clock. The
+   app will still expire on the 7th day from when it was first signed and
+   created.</br></br>
+2. If you decide to switch to a paid account after trying out the free account,
+   you will need to rebuild your Loop app in order to sign it with the new paid
+   account.</br></br>
+3. You will have to do an extra step during the build process to remove Siri
+   capabilities in order to build with free accounts.</br></br>
 
 ## Paid Developer Account
 
 If you decide to use a **PAID** developer account, here's what you need to know:
 
-1. Loop apps signed with a paid developer team will last for a full year.</br></br>
-2. The paid developer account is $99 per year and is default set to auto-renew annually. You can change that selection in your developer account settings at any time.</br></br>
-3. If your household has multiple Loop users, only one developer account is needed.  That one developer account can be used to sign multiple Loop apps.</br></br>
+1. Loop apps signed with a paid developer team will last for a full
+   year.</br></br>
+2. The paid developer account is \$99 per year and is default set to auto-renew
+   annually. You can change that selection in your developer account settings at
+   any time.</br></br>
+3. If your household has multiple Loop users, only one developer account is
+   needed. That one developer account can be used to sign multiple Loop
+   apps.</br></br>
 
 ## Switching from Free to Paid Memberships
 
-In summary: This is no problem trying a free account first before you decide to buy a paid developer account. If you start with a free account, you'll build a Loop app (let's call it FreeLoop). When you switch to a paid account, you'll be building a totally new and separate Loop app onto your phone (let's call it PaidLoop). The two apps will look identical on your phone, but they will be functionally separate from each other...ideally you want to delete the FreeLoop app before using the PaidLoop app.
+In summary: This is no problem trying a free account first before you decide to
+buy a paid developer account. If you start with a free account, you'll build a
+Loop app (let's call it FreeLoop). When you switch to a paid account, you'll be
+building a totally new and separate Loop app onto your phone (let's call it
+PaidLoop). The two apps will look identical on your phone, but they will be
+functionally separate from each other...ideally you want to delete the FreeLoop
+app before using the PaidLoop app.
 
-PaidLoop will know nothing about the settings and information you had stored in FreeLoop, so you will need to re-enter all your settings (basal rates, ISF, carb ratios, etc.) and configurations into the new PaidLoop. It will also not connect or control any pods you are currently using with the old FreeLoop you had installed.
+PaidLoop will know nothing about the settings and information you had stored in
+FreeLoop, so you will need to re-enter all your settings (basal rates, ISF, carb
+ratios, etc.) and configurations into the new PaidLoop. It will also not connect
+or control any pods you are currently using with the old FreeLoop you had
+installed.
 
-So, when switching from Free to Paid Loop builds...try to remember that you'll have the best luck by (1) timing it at pod change time and (2) take screenshots of your old app's settings so that you can enter them into the new app.
+So, when switching from Free to Paid Loop builds...try to remember that you'll
+have the best luck by (1) timing it at pod change time and (2) take screenshots
+of your old app's settings so that you can enter them into the new app.
 
 ## Enrolling
 
-Paid account enrollment is all through Apple's Developer Program website. Go to the [Apple Developer website](https://developer.apple.com/programs/enroll/) to enroll in an individual paid account. If you instead want the free account, you don't have to do anything on that website. You'll just wait for Step 8 Xcode Preferences and we will get your free account then.
+Paid account enrollment is all through Apple's Developer Program website. Go to
+the [Apple Developer website](https://developer.apple.com/programs/enroll/) to
+enroll in an individual paid account. If you instead want the free account, you
+don't have to do anything on that website. You'll just wait for Step 8 Xcode
+Preferences and we will get your free account then.
 
 ## Next Step: Install Homebrew
 
-Now you are ready to move onto Step 7 to [install Hombrew](https://loopkit.github.io/loopdocs/build/step7/).
+Now you are ready to move onto Step 7 to
+[install Hombrew](https://loopkit.github.io/loopdocs/build/step7/).

--- a/docs/build/step7.md
+++ b/docs/build/step7.md
@@ -1,47 +1,74 @@
 # Step 7: Install Homebrew
 
-!!!danger "Time Estimate"
-    * 10-15 minutes assuming you know your computer's password
-    * 35 minutes if you can't remember your password and have to guess
-    
-!!!info "Summary"
-    * Install Homebrew by simply copying and pasting a long line of gibberish into the ugly Terminal application.
+!!!danger "Time Estimate" _ 10-15 minutes assuming you know your computer's
+password _ 35 minutes if you can't remember your password and have to guess
 
-!!!warning "FAQs"
-    * **"What if I don't get an "Installation successful" message?"** If you don't see a successful installation message, please try the copy-paste again. If you fail to get Homebrew installed, your Loop build will also fail. You can't just skip this step. The most common cause of errors is failing to copy the ENTIRE line of code ...people sometimes fail to get that last `"` at the end of the line. Also, you need to be using a user account on the computer that has "admin" rights, since this process is installing a program on the computer.
+!!!info "Summary" \* Install Homebrew by simply copying and pasting a long line
+of gibberish into the ugly Terminal application.
 
-Breath deep...this step looks kind of "programmer code" weirdness. BUT, it isn't. Well, it is...but we will be just simply copying and pasting one line of the weirdness and then walking away. We don't actually have to know much about Homebrew itself or what the line of code means exactly.
+!!!warning "FAQs" \* **"What if I don't get an "Installation successful"
+message?"** If you don't see a successful installation message, please try the
+copy-paste again. If you fail to get Homebrew installed, your Loop build will
+also fail. You can't just skip this step. The most common cause of errors is
+failing to copy the ENTIRE line of code ...people sometimes fail to get that
+last `"` at the end of the line. Also, you need to be using a user account on
+the computer that has "admin" rights, since this process is installing a program
+on the computer.
 
-Homebrew is a program that will allow us to install the needed packages to build Loop. Open the Terminal application on your computer. It is located in your Applications folder and then look in the Utilities subfolder...the Terminal application is in there like shown in the screenshot below.
+Breath deep...this step looks kind of "programmer code" weirdness. BUT, it
+isn't. Well, it is...but we will be just simply copying and pasting one line of
+the weirdness and then walking away. We don't actually have to know much about
+Homebrew itself or what the line of code means exactly.
+
+Homebrew is a program that will allow us to install the needed packages to build
+Loop. Open the Terminal application on your computer. It is located in your
+Applications folder and then look in the Utilities subfolder...the Terminal
+application is in there like shown in the screenshot below.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/terminal.png" width="550">
 </p>
 
-The Terminal app is very plain looking when you open it. That is normal. Copy and paste the line in the little grey box below into Terminal prompt. 
+The Terminal app is very plain looking when you open it. That is normal. Copy
+and paste the line in the little grey box below into Terminal prompt.
 
 `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 
-Your screen should look like something like this after you copy it in...if it does, then go ahead and press return to continue on with the installation command. 
+Your screen should look like something like this after you copy it in...if it
+does, then go ahead and press return to continue on with the installation
+command.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/homebrew-copy-line.png" width="450">
 </p>
 </br>
 
-There will be a prompt asking if you want to continue.  Press return to continue, then it will prompt for your password.  <u>The password is your computer's password.</u>
+There will be a prompt asking if you want to continue. Press return to continue,
+then it will prompt for your password. <u>The password is your computer's
+password.</u>
 
-**<u><font color = "red">Don't freak out that you can't see your password while you type. That is normal. The Terminal app doesn't show keystrokes when you enter passwords, but it is still recording your password entry. If you think you messed up because you were confused, press the delete key a bunch of times and then start fresh with the password entry.</font></u>**  
+**<u><font color = "red">Don't freak out that you can't see your password while
+you type. That is normal. The Terminal app doesn't show keystrokes when you
+enter passwords, but it is still recording your password entry. If you think you
+messed up because you were confused, press the delete key a bunch of times and
+then start fresh with the password entry.</font></u>**
 
-Wait while the script does its thing...you’ll see info scroll by and then it will pause for a while. Eventually, it will be done and you’ll see something that says “Installation successful” and you’ll have a ready Terminal prompt again.</br></br>
+Wait while the script does its thing...you’ll see info scroll by and then it
+will pause for a while. Eventually, it will be done and you’ll see something
+that says “Installation successful” and you’ll have a ready Terminal prompt
+again.</br></br>
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/carthage.jpg" width="450">
 </p>
 </br>
 
-You can close the Terminal application now. You’re done with it. You do not need to do these steps again for any subsequent Loop builds. This is one of those "just do it once" installations. If you get a new computer though, you will have to repeat this step for the new computer.
+You can close the Terminal application now. You’re done with it. You do not need
+to do these steps again for any subsequent Loop builds. This is one of those
+"just do it once" installations. If you get a new computer though, you will have
+to repeat this step for the new computer.
 
 ## Next Step: Download Xcode
 
-Now you are ready to move onto Step 8 to [download Xcode](https://loopkit.github.io/loopdocs/build/step8/).
+Now you are ready to move onto Step 8 to
+[download Xcode](https://loopkit.github.io/loopdocs/build/step8/).

--- a/docs/build/step8.md
+++ b/docs/build/step8.md
@@ -1,19 +1,36 @@
 # Step 8: Download Xcode
 
-!!!danger "Time Estimate"
-    * 45 minutes to 2 hours, depending on internet connection...but you don't need to babysit the download.
+!!!danger "Time Estimate" \* 45 minutes to 2 hours, depending on internet
+connection...but you don't need to babysit the download.
 
-!!!info "Summary"
-    * After making sure your Mojave is up-to-date, download Xcode from your computer's App Store application.
+!!!info "Summary" \* After making sure your Mojave is up-to-date, download Xcode
+from your computer's App Store application.
 
-!!!warning "FAQs"
-    * **"Why isn't my Xcode installing?"** I can't see your computer to know exactly why...but the two most common reasons are (1) lack of internet connection or (2) not enough free space on the computer's hard drive. Xcode is a pretty beefy-sized download...and needs even a little more space to properly unpack and install itself. Best to try to have about 12-15GB of free space on your hard drive before starting to be on the safe side. If you get low on free space, I've seen installation failures. You can check your free space by clicking on the `About this Mac` (like in Step 1) and clicking the `Storage` tab.
+!!!warning "FAQs" \* **"Why isn't my Xcode installing?"** I can't see your
+computer to know exactly why...but the two most common reasons are (1) lack of
+internet connection or (2) not enough free space on the computer's hard drive.
+Xcode is a pretty beefy-sized download...and needs even a little more space to
+properly unpack and install itself. Best to try to have about 12-15GB of free
+space on your hard drive before starting to be on the safe side. If you get low
+on free space, I've seen installation failures. You can check your free space by
+clicking on the `About this Mac` (like in Step 1) and clicking the `Storage`
+tab.
 
-Today is an easy one, but probably takes the longest of most of any of the days in terms of time...only because the download takes a while. The good news is that you don't have to watch this. Instead, you can start the download and simply walk away for the rest of it.
+Today is an easy one, but probably takes the longest of most of any of the days
+in terms of time...only because the download takes a while. The good news is
+that you don't have to watch this. Instead, you can start the download and
+simply walk away for the rest of it.
 
-Xcode is a free application for Apple computers. Xcode will turn the Loop "raw" code into an iOS application and install it onto your iPhone/iPod. **Make sure you have updated your macOS to Mojave AND checked the `Software Updates` button before proceeding...in other words, make sure you did Step 1's work.**
+Xcode is a free application for Apple computers. Xcode will turn the Loop "raw"
+code into an iOS application and install it onto your iPhone/iPod. **Make sure
+you have updated your macOS to Mojave AND checked the `Software Updates` button
+before proceeding...in other words, make sure you did Step 1's work.**
 
-Open your App Store in your computer and search for Xcode...you'll either be downloading it brand new or updating an existing installation. The version you are looking for is Xcode 11 at the minimum. It should be showing in the "what's new" description as shown in the image below. This is a big download (over 7GB) so don't expected this to be fast.
+Open your App Store in your computer and search for Xcode...you'll either be
+downloading it brand new or updating an existing installation. The version you
+are looking for is Xcode 11 at the minimum. It should be showing in the "what's
+new" description as shown in the image below. This is a big download (over 7GB)
+so don't expected this to be fast.
 
 <p align="center">
 <img src="../img/xcode.png" width="750">
@@ -21,5 +38,5 @@ Open your App Store in your computer and search for Xcode...you'll either be dow
 
 ## Next Step: Xcode Preferences
 
-Now you are ready to move onto Step 9 to [work on Xcode Preferences](https://loopkit.github.io/loopdocs/build/step9/).
-
+Now you are ready to move onto Step 9 to
+[work on Xcode Preferences](https://loopkit.github.io/loopdocs/build/step9/).

--- a/docs/build/step9.md
+++ b/docs/build/step9.md
@@ -1,42 +1,71 @@
 # Step 9: Xcode Preferences
 
-!!!danger "Time Estimate"
-    * about 10-15 minutes to install the Command Line Tools
-    * 5 minutes to add your Apple ID, assuming you remember your password
+!!!danger "Time Estimate" _ about 10-15 minutes to install the Command Line
+Tools _ 5 minutes to add your Apple ID, assuming you remember your password
 
-!!!info "Summary"
-    * Open Xcode Preferences and add your Apple ID under the Accounts tab.
-    * Verify that Command Line Tools has been properly installed under Xcode Preferences under the Locations tab.
+!!!info "Summary" _ Open Xcode Preferences and add your Apple ID under the
+Accounts tab. _ Verify that Command Line Tools has been properly installed under
+Xcode Preferences under the Locations tab.
 
-!!!warning "FAQs"
-    * **"I still only see an account with `(personal team)` beside it even though I enrolled in the paid Developer Account program...what should I do?"** You should check your spam email box in case Apple sent you an email there. Make sure you've waited the 48 hours that Apple says it may take to get your account approved. If it's been 48 hours and you still don't see anything in your email, contact Apple support and ask them about the status of your enrollment. It may be held up by something on their end.
+!!!warning "FAQs" \* **"I still only see an account with `(personal team)`
+beside it even though I enrolled in the paid Developer Account program...what
+should I do?"** You should check your spam email box in case Apple sent you an
+email there. Make sure you've waited the 48 hours that Apple says it may take to
+get your account approved. If it's been 48 hours and you still don't see
+anything in your email, contact Apple support and ask them about the status of
+your enrollment. It may be held up by something on their end.
 
-Since you've been working in order, you will now have Xcode installed on your computer from Step 8. You will also have enrolled in the Apple Developer program with a paid account, if that was your selection, in Step 6. Now we need to tell Xcode about your Developer Account.
+Since you've been working in order, you will now have Xcode installed on your
+computer from Step 8. You will also have enrolled in the Apple Developer program
+with a paid account, if that was your selection, in Step 6. Now we need to tell
+Xcode about your Developer Account.
 
-Open Xcode from your Applications folder. 
+Open Xcode from your Applications folder.
 
 ## Command Line Tools
-There may be a short delay the very first time you open Xcode because it will install a package of tools. Don't close that window out, let it finish...we will need those Command Line Tools. Helpful tip: When the Command Line Tools installation is done and the pop-up window closes, check that your Command Line Tools installed correctly. Open Xcode's Preferences by clicking on the word **`Xcode` ** in the top menu bar (just to the right of the Apple icon in the upper-left corner) and selecting `Preferences` in the drop-down menu. The keyboard shortcut to open Xcode Preferences is `command-comma` if that's easier for you. Then select the `Locations` tab of Preferences window and you'll see the dropdown menu for Command Line Tools. Make sure that Xcode 11 (or newer) is selected there.
+
+There may be a short delay the very first time you open Xcode because it will
+install a package of tools. Don't close that window out, let it finish...we will
+need those Command Line Tools. Helpful tip: When the Command Line Tools
+installation is done and the pop-up window closes, check that your Command Line
+Tools installed correctly. Open Xcode's Preferences by clicking on the word
+**`Xcode` ** in the top menu bar (just to the right of the Apple icon in the
+upper-left corner) and selecting `Preferences` in the drop-down menu. The
+keyboard shortcut to open Xcode Preferences is `command-comma` if that's easier
+for you. Then select the `Locations` tab of Preferences window and you'll see
+the dropdown menu for Command Line Tools. Make sure that Xcode 11 (or newer) is
+selected there.
+
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/command-line-error-3.png" width="550">
 </p>
 
 ## Add Apple ID
-Go to the Xcode Preferences window from above, click on the `Accounts` tab and then press the `+` in the lower-left corner to add an Apple ID account.
+
+Go to the Xcode Preferences window from above, click on the `Accounts` tab and
+then press the `+` in the lower-left corner to add an Apple ID account.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/xcode_account.png" width="750">
 </p>
 
-If you want to use a free developer account, you will simply enter your Apple ID in this section and Xcode will automatically enroll your Apple ID in the free developer program. If you enrolled in the paid account already and have confirmation that your account is active, enter the Apple ID of the paid developer account. The screenshot below shows the labeling of team names based on whether from free account vs. paid account. Free teams will have `(personal team)` after the name.
+If you want to use a free developer account, you will simply enter your Apple ID
+in this section and Xcode will automatically enroll your Apple ID in the free
+developer program. If you enrolled in the paid account already and have
+confirmation that your account is active, enter the Apple ID of the paid
+developer account. The screenshot below shows the labeling of team names based
+on whether from free account vs. paid account. Free teams will have
+`(personal team)` after the name.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/apple_id.png" width="750">
 </p>
 
-You are now done setting up Xcode.  Great job!  You will not need to redo the account setup steps on any subsequent builds or updates of your Loop app.  Xcode will remember these settings.
+You are now done setting up Xcode. Great job! You will not need to redo the
+account setup steps on any subsequent builds or updates of your Loop app. Xcode
+will remember these settings.
 
 ## Next Step: Test Settings
 
-Now you are ready to move onto Step 10 to [Test Your Settings](https://loopkit.github.io/loopdocs/build/step10/).
-
+Now you are ready to move onto Step 10 to
+[Test Your Settings](https://loopkit.github.io/loopdocs/build/step10/).

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -1,61 +1,95 @@
 # Updating Loop
 
-!!!danger "Time Estimate"
-    * 25 minutes, if already have updates done
-    * 40-90 minutes, if need to install Apple update(s)
+!!!danger "Time Estimate" _ 25 minutes, if already have updates done _ 40-90
+minutes, if need to install Apple update(s)
 
-!!!info "Summary"
-    1. Update macOS, Xcode, iOS, and/or watchOS
-    2. Download updated Loop code
-    3. Open in Xcode, sign targets
-    4. Add optional code customizations
-    5. Build onto your iPhone
-    6. Resolve Build Errors
+!!!info "Summary" 1. Update macOS, Xcode, iOS, and/or watchOS 2. Download
+updated Loop code 3. Open in Xcode, sign targets 4. Add optional code
+customizations 5. Build onto your iPhone 6. Resolve Build Errors
 
-!!!warning "FAQs"
-    * **"What is an update?"** Anytime you want to change branches (i.e., go from omnipod-testing to dev branch), change customizations, or grab updates to the same branch you built with before...that is an "update" of your Loop app.
-    * **"Do I delete my old Loop app first?"** Definitely not! If you keep your Loop app on your phone, your Loop settings (and existing pod) will continue to work the same after the update. Seamless.
-    * **"What if I'm using a new/different developer account?"** If you aren't building with the same developer account as your existing app was built with (this includes going from free to paid), then you will be installing a brand new (second) Loop app on your phone. Your existing pod won't work with the new app, so you might want to time this transition when you are due to change pods. Delete the old app once you get the new one all set up.
-    * **"What if it is a new computer but the same developer account?"** No big deal...you just want to make sure the computer has Homebrew installed already and you've added your developer account to Xcode preferences.
-    * **"Where can I find the list of features in a new release?"** When a new version of Loop is released, you can click [HERE](https://github.com/LoopKit/Loop/releases) to read what features or fixes were a part of the new release.
+!!!warning "FAQs" _ **"What is an update?"** Anytime you want to change branches
+(i.e., go from omnipod-testing to dev branch), change customizations, or grab
+updates to the same branch you built with before...that is an "update" of your
+Loop app. _ **"Do I delete my old Loop app first?"** Definitely not! If you keep
+your Loop app on your phone, your Loop settings (and existing pod) will continue
+to work the same after the update. Seamless. _ **"What if I'm using a
+new/different developer account?"** If you aren't building with the same
+developer account as your existing app was built with (this includes going from
+free to paid), then you will be installing a brand new (second) Loop app on your
+phone. Your existing pod won't work with the new app, so you might want to time
+this transition when you are due to change pods. Delete the old app once you get
+the new one all set up. _ **"What if it is a new computer but the same developer
+account?"** No big deal...you just want to make sure the computer has Homebrew
+installed already and you've added your developer account to Xcode
+preferences. \* **"Where can I find the list of features in a new release?"**
+When a new version of Loop is released, you can click
+[HERE](https://github.com/LoopKit/Loop/releases) to read what features or fixes
+were a part of the new release.
 
 ## When to Update
 
-You will have to rebuild your Loop app at a minimum once every 12 months. The apps built and signed by you in Xcode with a paid developer account will only last for 12 months before they expire and need rebuilding. So, at least once per year you will have to rebuild your app and go through this update process.
+You will have to rebuild your Loop app at a minimum once every 12 months. The
+apps built and signed by you in Xcode with a paid developer account will only
+last for 12 months before they expire and need rebuilding. So, at least once per
+year you will have to rebuild your app and go through this update process.
 
-Under ordinary circumstances, you do not *have to* update your Loop app until you are ready to grab new features. However, we encourage regular updates when a new version is released because they often contain bug fixes or improvements which may increase operational stability.
+Under ordinary circumstances, you do not _have to_ update your Loop app until
+you are ready to grab new features. However, we encourage regular updates when a
+new version is released because they often contain bug fixes or improvements
+which may increase operational stability.
 
 ## Step 1: Update macOS and Xcode
 
-!!!danger "Minimum Requirements"
-    Between Loop app builds, there's a high likelihood that Apple has updated one or more of the systems involved in your Loop app. <u>If you miss macOS or Xcode updates, you may run into build problems. Do not skip these steps before updating Loop.</u>  You will need the following minimum versions:</br></br>
-    
-    * macOS 10.14.3 (Mojave)</br></br>
-    * iOS 12.2</br></br>
-    * Xcode 11</br></br>
-    
-    But why be a minimalist? Go ahead and install any available updates in all areas; macOS, Xcode, iOS, and watchOS.
-    
-    (You can only use macOS 10.13.6 High Sierra if you are building with Loop master branch <u>and</u> have at least iOS 12 or 12.1. The next version of Loop master branch will require Mojave at a minimum, so keep that in your planning for the future. If building dev, omnipod-testing, or any other branch that supports omnipod users, then you will need the minimum versions listed above.)
+!!!danger "Minimum Requirements" Between Loop app builds, there's a high
+likelihood that Apple has updated one or more of the systems involved in your
+Loop app. <u>If you miss macOS or Xcode updates, you may run into build
+problems. Do not skip these steps before updating Loop.</u> You will need the
+following minimum versions:</br></br>
 
-!!!info "Download Xcode 11 from the App store"
-    Yes, this is important. If you downloaded Xcode 11 GM previously in the last couple weeks, go to the App store and get the Xcode update waiting for you now. Xcode 11 GM is not what you need anymore...you need to get Xcode 11 from the App store.
-        
-!!!warning "Restart computer after updating Xcode"
-        Make sure to restart your computer after updating Xcode. There's a known issue that happens often enough to be frustrating if you don't reboot. Either a build error about missing simultors or a "device not connected" (even when phone is connected). Just restart computer. It's easy enough.
+_ macOS 10.14.3 (Mojave)</br></br> _ iOS 12.2</br></br> \* Xcode 11</br></br>
 
-!!!danger "Check Homebrew and Carthage"
-    Depending on when you last built, you may need to update Homebrew and Carthage. Please open Terminal app and copy & paste  `carthage version` into Terminal. If you see 0.33.0 returned, then you don't need to do anything additional.
-    
-    If you got a number other than 0.33.0 for your carthage version, then copy & paste `brew update && brew upgrade carthage` into Terminal app. When the update finishes, you should have carthage 0.33.0 (or later) installed.</br>
-    
-    If you don't have 0.33.0 installed after that update, then you will need to use `brew link --overwrite carthage` and then repeat the `brew update && brew upgrade carthage` command. That should succeed in updating you properly.
+But why be a minimalist? Go ahead and install any available updates in all
+areas; macOS, Xcode, iOS, and watchOS.
 
+(You can only use macOS 10.13.6 High Sierra if you are building with Loop master
+branch <u>and</u> have at least iOS 12 or 12.1. The next version of Loop master
+branch will require Mojave at a minimum, so keep that in your planning for the
+future. If building dev, omnipod-testing, or any other branch that supports
+omnipod users, then you will need the minimum versions listed above.)
+
+!!!info "Download Xcode 11 from the App store" Yes, this is important. If you
+downloaded Xcode 11 GM previously in the last couple weeks, go to the App store
+and get the Xcode update waiting for you now. Xcode 11 GM is not what you need
+anymore...you need to get Xcode 11 from the App store.
+
+!!!warning "Restart computer after updating Xcode" Make sure to restart your
+computer after updating Xcode. There's a known issue that happens often enough
+to be frustrating if you don't reboot. Either a build error about missing
+simultors or a "device not connected" (even when phone is connected). Just
+restart computer. It's easy enough.
+
+!!!danger "Check Homebrew and Carthage" Depending on when you last built, you
+may need to update Homebrew and Carthage. Please open Terminal app and copy &
+paste `carthage version` into Terminal. If you see 0.33.0 returned, then you
+don't need to do anything additional.
+
+If you got a number other than 0.33.0 for your carthage version, then copy &
+paste `brew update && brew upgrade carthage` into Terminal app. When the update
+finishes, you should have carthage 0.33.0 (or later) installed.</br>
+
+If you don't have 0.33.0 installed after that update, then you will need to use
+`brew link --overwrite carthage` and then repeat the
+`brew update && brew upgrade carthage` command. That should succeed in updating
+you properly.
 
 ## Step 2: Download Updated Loop Code
 
-After you've finished the updates to your devices listed above, you can move onto downloading updated Loop code. You will not be simply using your old downloaded Loop code (and in fact, you can delete those old folders now if you want). Click on **ONE** of the links below to download an updated version of the Loop code:
-</br></br>
+After you've finished the updates to your devices listed above, you can move
+onto downloading updated Loop code. You will not be simply using your old
+downloaded Loop code (and in fact, you can delete those old folders now if you
+want). Click on **ONE** of the links below to download an updated version of the
+Loop code: </br></br>
+
 <p align="center">
 [Loop: Master branch](https://github.com/LoopKit/Loop/archive/master.zip)
 </p></br>
@@ -68,25 +102,40 @@ After you've finished the updates to your devices listed above, you can move ont
 [Loop: Omnipod-testing branch](https://github.com/LoopKit/Loop/archive/omnipod-testing.zip)
 </p></br>
 
-!!!info "Reminder"
-    It is best practice is to leave your Loop code in your Downloads folder.  If you store your Loop code a different folder than Downloads (such as your Documents folder or Desktop), make sure the specified folder is **not** an iCloud drive.  Storing your Loop code in an iCloud drive folder will prevent Loop from building successfully.  How do you know if a folder is an iCloud drive?  Check your System Preferences.  If your System Preferences for iCloud is set as shown below, your Documents and Desktop folders are iCloud drives and **NOT** appropriate places to save your Loop download.
-    <p align="center">
-    <img src="../img/icloud-drive.png" width="550">
-    </p></br>
-    Depending on your browser and settings, your Loop download may or may not automatically unzip.  If it does not unzip automatically, you can right-click on the zip file and choose to "Open With" Archive Utility.  This will create a blue folder called `Loop-master`.  HOWEVER, if you already have an existing `Loop-master` folder from a previous download, the name of the next download will be something like `Loop-master (1)`.  The problem with that folder name is that it contains a space...and spaces in the name will cause your Loop build to fail.  So, either delete old copies of Loop before downloading/unzipping or rename the folder(s) to ensure that NO SPACES are in the folder name.
-    <p align="center">
-    <img src="../img/folder-name.png" width="550">
-    </p>
+!!!info "Reminder" It is best practice is to leave your Loop code in your
+Downloads folder. If you store your Loop code a different folder than Downloads
+(such as your Documents folder or Desktop), make sure the specified folder is
+**not** an iCloud drive. Storing your Loop code in an iCloud drive folder will
+prevent Loop from building successfully. How do you know if a folder is an
+iCloud drive? Check your System Preferences. If your System Preferences for
+iCloud is set as shown below, your Documents and Desktop folders are iCloud
+drives and **NOT** appropriate places to save your Loop download.
+
+<p align="center">
+<img src="../img/icloud-drive.png" width="550">
+</p></br>
+Depending on your browser and settings, your Loop download may or may not automatically unzip. If it does not unzip automatically, you can right-click on the zip file and choose to "Open With" Archive Utility. This will create a blue folder called `Loop-master`. HOWEVER, if you already have an existing `Loop-master` folder from a previous download, the name of the next download will be something like `Loop-master (1)`. The problem with that folder name is that it contains a space...and spaces in the name will cause your Loop build to fail. So, either delete old copies of Loop before downloading/unzipping or rename the folder(s) to ensure that NO SPACES are in the folder name.
+<p align="center">
+<img src="../img/folder-name.png" width="550">
+</p>
 
 ## Step 3: Build Like Normal
 
-From here it is just like the old directions...you can go straight to [Step 14 Build Loop app](https://loopkit.github.io/loopdocs/build/step14/) and do just like you did the first time. Open the project, plug in the phone, sign four targets, code customizations (if wanted), and then build button. Easy peasy.
+From here it is just like the old directions...you can go straight to
+[Step 14 Build Loop app](https://loopkit.github.io/loopdocs/build/step14/) and
+do just like you did the first time. Open the project, plug in the phone, sign
+four targets, code customizations (if wanted), and then build button. Easy
+peasy.
 
-Note: If this is a computer that hasn't built Loop before, you would want to make sure to do [Step 7: install Homebrew](https://loopkit.github.io/loopdocs/build/step7/) before doing your build on that computer.
+Note: If this is a computer that hasn't built Loop before, you would want to
+make sure to do
+[Step 7: install Homebrew](https://loopkit.github.io/loopdocs/build/step7/)
+before doing your build on that computer.
 
 ## Step 4: Check Build Errors page if needed
-    
-!!!danger "CHECK BUILD ERRORS PAGE"
-    If you get a build error...still check the [Build Errors page](https://loopkit.github.io/loopdocs/build/build_errors/). Because even if your exact error isn't there...the information you NEED to provide when asking for help is listed out on that page. And that information is critical. CRITICAL to be able to troubleshoot your build error.
 
-
+!!!danger "CHECK BUILD ERRORS PAGE" If you get a build error...still check the
+[Build Errors page](https://loopkit.github.io/loopdocs/build/build_errors/).
+Because even if your exact error isn't there...the information you NEED to
+provide when asking for help is listed out on that page. And that information is
+critical. CRITICAL to be able to troubleshoot your build error.

--- a/docs/css/admonitions.css
+++ b/docs/css/admonitions.css
@@ -5,14 +5,16 @@
   border: 1px solid #eee;
   border-left-width: 8px;
   border-radius: 3px;
-  background-color: #fCfCfc;
+  background-color: #fcfcfc;
 }
 .admonition .admonition-title {
   margin-top: 0;
   padding-top: 0;
   margin-bottom: 5px;
 }
-.admonition p:last-child, .admonition ul:last-child, .admonition ol:last-child {
+.admonition p:last-child,
+.admonition ul:last-child,
+.admonition ol:last-child {
   margin-bottom: 0;
 }
 .admonition code {
@@ -39,27 +41,27 @@
 }
 .admonition.warning {
   border-left-color: #f0ad4e;
-  background-color: #FFD8A0;
-  border-bottom-color: #FFD8A0;
-  border-right-color: #FFD8A0;
-  border-top-color: #FFD8A0;
+  background-color: #ffd8a0;
+  border-bottom-color: #ffd8a0;
+  border-right-color: #ffd8a0;
+  border-top-color: #ffd8a0;
 }
 .admonition.warning .admonition-title {
-  color: #AD6D11;
-  background-color: #FFD8A0;
-  border-bottom-color: #FFD8A0;
+  color: #ad6d11;
+  background-color: #ffd8a0;
+  border-bottom-color: #ffd8a0;
 }
 .admonition.info {
   border-left-color: #5bc0de;
-  background-color: #BAEAF8;
-  border-bottom-color: #BAEAF8;
-  border-right-color: #BAEAF8;
-  border-top-color: #BAEAF8;
+  background-color: #baeaf8;
+  border-bottom-color: #baeaf8;
+  border-right-color: #baeaf8;
+  border-top-color: #baeaf8;
 }
 .admonition.info .admonition-title {
-  color: #1993B6;
-  background-color: #BAEAF8;
-  border-bottom-color: #BAEAF8;
+  color: #1993b6;
+  background-color: #baeaf8;
+  border-bottom-color: #baeaf8;
 }
 
 /* Title */

--- a/docs/faqs/FAQs.md
+++ b/docs/faqs/FAQs.md
@@ -4,15 +4,18 @@ Welcome to LoopDocs place for all things Frequently Asked.
 
 ## What is Loop?
 
-Click on the image below to watch a short [Introduction to Loop video](https://youtu.be/qw_u1lqboCs).
+Click on the image below to watch a short
+[Introduction to Loop video](https://youtu.be/qw_u1lqboCs).
 
 <a href="https://youtu.be/qw_u1lqboCs" target="_blank"><img src="../img/intro-to-loop.png"  title="Introduction to Loop video" /></a>
 
 ## What do I need to Loop?
 
-Loop has both hardware and software requirements. In general, to use Loop you need to have seven components.
+Loop has both hardware and software requirements. In general, to use Loop you
+need to have seven components.
 
-- Compatible insulin pump: [Medtronic or Omnipod](https://loopkit.github.io/loopdocs/build/step3/)
+- Compatible insulin pump:
+  [Medtronic or Omnipod](https://loopkit.github.io/loopdocs/build/step3/)
 - [Compatible CGM](https://loopkit.github.io/loopdocs/build/step4/)
 - [RileyLink](https://loopkit.github.io/loopdocs/build/step5/)
 - [Compatible iPhone/iPod Touch](https://loopkit.github.io/loopdocs/build/step2/)
@@ -28,9 +31,15 @@ Loop has both hardware and software requirements. In general, to use Loop you ne
 
 No. Loop is not available for download. You must build your own Loop app.
 
-But don't worry, building your Loop app is actually quite easy and that's what these docs are all about. The harder part will be having the patience to read all the documents before you start. New Loop users are so excited to get started that they skip reading all the great info that these docs contain. So, as you begin the build...please include time to read the documents that follow what happens AFTER you successfully build your Loop app.
+But don't worry, building your Loop app is actually quite easy and that's what
+these docs are all about. The harder part will be having the patience to read
+all the documents before you start. New Loop users are so excited to get started
+that they skip reading all the great info that these docs contain. So, as you
+begin the build...please include time to read the documents that follow what
+happens AFTER you successfully build your Loop app.
 
-If you have any questions, these docs have a nice search feature in the dark blue top menu bar that may help you find your answers pretty quickly too.
+If you have any questions, these docs have a nice search feature in the dark
+blue top menu bar that may help you find your answers pretty quickly too.
 
 ## Can I use an android phone for Loop?
 
@@ -38,98 +47,193 @@ No, this is purely iPhone or iPod touch.
 
 ## Do I have to be "tech-smart" to build Loop?
 
-No. You do not need any experience in code or computers to build Loop. If you have already owned an Apple computer and iPhone, you already have the required level of experience. Beyond that, simply read the directions slowly and diligently...all the information you will need are in these documents.
+No. You do not need any experience in code or computers to build Loop. If you
+have already owned an Apple computer and iPhone, you already have the required
+level of experience. Beyond that, simply read the directions slowly and
+diligently...all the information you will need are in these documents.
 
-Often times the non-tech people do better than the tech people in building Loop. Why? Because the non-tech people take the time to read slowly and look at the screenshots in the directions. The tech people often skim read and miss sentences...which then leads to build errors that have to be retraced and fixed.
+Often times the non-tech people do better than the tech people in building Loop.
+Why? Because the non-tech people take the time to read slowly and look at the
+screenshots in the directions. The tech people often skim read and miss
+sentences...which then leads to build errors that have to be retraced and fixed.
 
 ## Is there a cheat sheet for a school nurse to use?
 
-Sure, you can give this one a try. [School nurse's cheat sheet download](https://github.com/Kdisimone/images/raw/master/school_nurse.pdf)
+Sure, you can give this one a try.
+[School nurse's cheat sheet download](https://github.com/Kdisimone/images/raw/master/school_nurse.pdf)
 
 ## How long does it take to build Loop?
 
-The answer is varied, but a few hours from start to finish, depending on where you are starting and how comfortable you are with your computer.
+The answer is varied, but a few hours from start to finish, depending on where
+you are starting and how comfortable you are with your computer.
 
-If you'd rather break it up into several shorter bits of effort, the `Build App` section is divided into convenient stopping points with Time Estimates for each step. You can do one or more steps depending on what kind of time you have available.
+If you'd rather break it up into several shorter bits of effort, the `Build App`
+section is divided into convenient stopping points with Time Estimates for each
+step. You can do one or more steps depending on what kind of time you have
+available.
 
 ## Does Loop cost money?
 
 Yes, there are some costs, beyond the obvious costs of owning a pump and CGM.
 
-The [RileyLink kit](https://getrileylink.org/) costs $150. This is a one-time cost and many people still have their original RileyLinks from nearly 3 years ago running just fine. I highly recommend purchasing two RileyLinks when financially feasible, to have one as a backup in case of accidental damage.
+The [RileyLink kit](https://getrileylink.org/) costs \$150. This is a one-time
+cost and many people still have their original RileyLinks from nearly 3 years
+ago running just fine. I highly recommend purchasing two RileyLinks when
+financially feasible, to have one as a backup in case of accidental damage.
 
-The Apple Developer License can be done for free, however, you will have to rebuild your Loop app every 7 days. That could get very tedious. The $99 annual Apple Developer program enrollment is an excellent investment.
+The Apple Developer License can be done for free, however, you will have to
+rebuild your Loop app every 7 days. That could get very tedious. The \$99 annual
+Apple Developer program enrollment is an excellent investment.
 
 There are no other costs, ongoing or initial, to use Loop.
 
 ## Do I need to own my own Apple computer?
 
-You don't have to own your own Apple computer, but you do need to at least borrow one. It would be really good to have longer term ability to borrow that computer again for [updating Loop](https://loopkit.github.io/loopdocs/build/updating/#when-to-update) later, when needed.
+You don't have to own your own Apple computer, but you do need to at least
+borrow one. It would be really good to have longer term ability to borrow that
+computer again for
+[updating Loop](https://loopkit.github.io/loopdocs/build/updating/#when-to-update)
+later, when needed.
 
-If you are borrowing an Apple computer, you should ask the person to (1) update to Mojave and (2) [download Xcode for free](https://developer.apple.com/xcode/) before you get together to build your Loop app. The updates and download of Xcode can take a couple hours depending on the person's internet speed...so best to do those steps well ahead of time to save trouble.
+If you are borrowing an Apple computer, you should ask the person to (1) update
+to Mojave and (2) [download Xcode for free](https://developer.apple.com/xcode/)
+before you get together to build your Loop app. The updates and download of
+Xcode can take a couple hours depending on the person's internet speed...so best
+to do those steps well ahead of time to save trouble.
 
 ## Can I use a PC or Windows computer to build?
 
-Yes, you can...sort of. There is a hacked way of installing macOS on a Windows computer called "Virtual Machine". [This link](https://macosvmware.tech.blog/) may provide some helpful information for that if you want to learn more...but it's up to you and Google if you hit a road block. These docs do not provide troubleshooting tips for Virtual Machine installation or use.
+Yes, you can...sort of. There is a hacked way of installing macOS on a Windows
+computer called "Virtual Machine". [This link](https://macosvmware.tech.blog/)
+may provide some helpful information for that if you want to learn more...but
+it's up to you and Google if you hit a road block. These docs do not provide
+troubleshooting tips for Virtual Machine installation or use.
 
 ## How often do I need to get on the computer for Loop?
 
-The short answer is (1) when you first build and (2) once per year minimum after that. (If you decide to use a free Apple Developer Account, you will need to get on the computer every 7 days.)
+The short answer is (1) when you first build and (2) once per year minimum after
+that. (If you decide to use a free Apple Developer Account, you will need to get
+on the computer every 7 days.)
 
-The longer answer is that Loop code is updated periodically to include new features and bug fixes. When those updates are released, you'll need access to an Apple computer again to update your Loop app.  Loop updates are not available through the iPhone's app store...instead you do the app update yourself with [update instructions here](https://loopkit.github.io/loopdocs/build/updating/). In general, probably a few times a year there are updates to Loop released that you'd want to take the time to install.
+The longer answer is that Loop code is updated periodically to include new
+features and bug fixes. When those updates are released, you'll need access to
+an Apple computer again to update your Loop app. Loop updates are not available
+through the iPhone's app store...instead you do the app update yourself with
+[update instructions here](https://loopkit.github.io/loopdocs/build/updating/).
+In general, probably a few times a year there are updates to Loop released that
+you'd want to take the time to install.
 
 ## Will I need to build a new Loop if I switch between Medtronic and Omnipod?
 
-No. Loop will have the option to move between different pump types from within the same Loop app. You'll simply use the "Switch from Omnipods" or "Delete Pump" options to move to the other kind of pump.
+No. Loop will have the option to move between different pump types from within
+the same Loop app. You'll simply use the "Switch from Omnipods" or "Delete Pump"
+options to move to the other kind of pump.
 
 ## Can I use someone else's Apple Developer account for my Loop build?
 
-Technically, yes...however there are major drawbacks. The person's developer account can only be "linked" to a limited number of build computers. So one person "loaning out" their developer license to a lot of people will quickly exceed the number of allowed computers. In those cases, that person will be told they need to revoke the certificates on some computers (essentially dropping old ones to make room for new ones). When they do that, they may have forgotten about your Loop app on your computer. When they revoke your computer's certificate (and they can do that without you knowing through their developer portal), your Loop app will immediately stop working and not even open.
+Technically, yes...however there are major drawbacks. The person's developer
+account can only be "linked" to a limited number of build computers. So one
+person "loaning out" their developer license to a lot of people will quickly
+exceed the number of allowed computers. In those cases, that person will be told
+they need to revoke the certificates on some computers (essentially dropping old
+ones to make room for new ones). When they do that, they may have forgotten
+about your Loop app on your computer. When they revoke your computer's
+certificate (and they can do that without you knowing through their developer
+portal), your Loop app will immediately stop working and not even open.
 
-Your Loop app will also die immediately if their developer account is not renewed or expires. Your Loop updates will also not be able to be built unless that person maintains the developer license agreement updates.
+Your Loop app will also die immediately if their developer account is not
+renewed or expires. Your Loop updates will also not be able to be built unless
+that person maintains the developer license agreement updates.
 
-Moral of the story, out of all the ways to save money...borrowing someone's developer account is not a good place to save money. You could find yourself unexpectedly without a Loop app without notice.
+Moral of the story, out of all the ways to save money...borrowing someone's
+developer account is not a good place to save money. You could find yourself
+unexpectedly without a Loop app without notice.
 
 ## Can I use MY Apple Developer account to build for others?
 
-Technically yes...however, there are reasons this is discouraged. When you build for others, you must be careful to not unintentionally revoke the signing certificate that had been used for other people's apps (see note in FAQ above). You also need to let the people know that the MAXIMUM their app will last is 12 months. It will need to be rebuilt no matter what every 12 months.
+Technically yes...however, there are reasons this is discouraged. When you build
+for others, you must be careful to not unintentionally revoke the signing
+certificate that had been used for other people's apps (see note in FAQ above).
+You also need to let the people know that the MAXIMUM their app will last is 12
+months. It will need to be rebuilt no matter what every 12 months.
 
-But the biggest issue with building for others is that they may be left without a decent method of getting Loop updates. There are a lot of new Loopers on Omnipod system and their apps will likely need updating on a regular basis over the first year. Unless you plan on meeting with that person regularly to update their app, you could leave them on an old app that doesn't work as well as the new versions.
+But the biggest issue with building for others is that they may be left without
+a decent method of getting Loop updates. There are a lot of new Loopers on
+Omnipod system and their apps will likely need updating on a regular basis over
+the first year. Unless you plan on meeting with that person regularly to update
+their app, you could leave them on an old app that doesn't work as well as the
+new versions.
 
 ## How can I find a compatible pump? supplies?
 
-There is a [whole page with detailed information about Medtronic pumps](https://loopkit.github.io/loopdocs/build/step3/); how to find them, how to find supplies, and assessing whether your Medtronic pump is compatible. Please check out that page for more info.
+There is a
+[whole page with detailed information about Medtronic pumps](https://loopkit.github.io/loopdocs/build/step3/);
+how to find them, how to find supplies, and assessing whether your Medtronic
+pump is compatible. Please check out that page for more info.
 
-With the addition of Omnipod support, you can also now use Omnipod suppliers the way you'd normally source them.
+With the addition of Omnipod support, you can also now use Omnipod suppliers the
+way you'd normally source them.
 
 ## Can I pay someone else to do this?
 
-NOOOO...you really need to figure this out yourself. This is an automated insulin delivery system and you really need to know how to build and operate this yourself.
+NOOOO...you really need to figure this out yourself. This is an automated
+insulin delivery system and you really need to know how to build and operate
+this yourself.
 
 ## What if I lose my RileyLink?
 
-For Medtronic users, you simply go back to old school pump use until you get a new RileyLink. You can either let your temp basal finish by itself (30 minutes or less) or cancel the temp basal on the pump's menu. For bolusing, you'd go back to using the pump's blus commands. When you get a RileyLink (either finding your old one or getting your backup RileyLink out) and Loop running again, you'll want to do one thing. Enter in any carbs to Loop that you may have eaten in the recent past that could still be affecting blood glucose. While Loop will read whatever insulin deliveries had happened while the RileyLink was missing, it will not read any carbs you entered into the pump...so make sure to add those to Loop and backdate them to the time they were eaten. That will help make the transition smoother to Looping again.
+For Medtronic users, you simply go back to old school pump use until you get a
+new RileyLink. You can either let your temp basal finish by itself (30 minutes
+or less) or cancel the temp basal on the pump's menu. For bolusing, you'd go
+back to using the pump's blus commands. When you get a RileyLink (either finding
+your old one or getting your backup RileyLink out) and Loop running again,
+you'll want to do one thing. Enter in any carbs to Loop that you may have eaten
+in the recent past that could still be affecting blood glucose. While Loop will
+read whatever insulin deliveries had happened while the RileyLink was missing,
+it will not read any carbs you entered into the pump...so make sure to add those
+to Loop and backdate them to the time they were eaten. That will help make the
+transition smoother to Looping again.
 
-For pod users, your pod will finish any currently running temporary basal rate and then revert back to your scheduled basal rate. Without a RileyLink, you will not be able to affect any pod use; no basal changes, suspends, or boluses. If you have a backup RileyLink, you can simply connect to the new RileyLink on the same Loop app and it will work with the existing pod session. If you don't have a backup RileyLink, you'll have to remove the pod and start a new pod paired with your PDM until you get a new RileyLink.
+For pod users, your pod will finish any currently running temporary basal rate
+and then revert back to your scheduled basal rate. Without a RileyLink, you will
+not be able to affect any pod use; no basal changes, suspends, or boluses. If
+you have a backup RileyLink, you can simply connect to the new RileyLink on the
+same Loop app and it will work with the existing pod session. If you don't have
+a backup RileyLink, you'll have to remove the pod and start a new pod paired
+with your PDM until you get a new RileyLink.
 
 ## What if I lose or get a new iPhone?
 
-When you get a new iPhone, Loop will need to be built onto that new iPhone in the same way that you built on your old iPhone. Loop will not restore from any iCloud or iTunes backups, so make sure you plan on finding an Apple computer to rebuild on before you plan on Looping with the new iPhone.
+When you get a new iPhone, Loop will need to be built onto that new iPhone in
+the same way that you built on your old iPhone. Loop will not restore from any
+iCloud or iTunes backups, so make sure you plan on finding an Apple computer to
+rebuild on before you plan on Looping with the new iPhone.
 
 ## What about other pumps? When will they Loop?
 
-Hey now...let's be grateful for what we have first. The ability to use Loop is the result of tremendous amounts of effort, time, and sacrifice by volunteers. Cracking the pumps for Loop use is a large undertaking. If and when another set of people spend a large amount of time figuring out other pumps, then they could conceivably be added to Loop. But, you don't need to let us know that you'd love to see more pumps compatible with Loop. So would we. There is just an awful lot of work that needs to happen and it is not easy nor quick.
+Hey now...let's be grateful for what we have first. The ability to use Loop is
+the result of tremendous amounts of effort, time, and sacrifice by volunteers.
+Cracking the pumps for Loop use is a large undertaking. If and when another set
+of people spend a large amount of time figuring out other pumps, then they could
+conceivably be added to Loop. But, you don't need to let us know that you'd love
+to see more pumps compatible with Loop. So would we. There is just an awful lot
+of work that needs to happen and it is not easy nor quick.
 
-Tandem pumps are not Loop compatible.
-Animas pumps are not Loop compatible.
-DASH pods are not Loop compatible.
-And those all likely won't be compatible anytime in the future.
+Tandem pumps are not Loop compatible. Animas pumps are not Loop compatible. DASH
+pods are not Loop compatible. And those all likely won't be compatible anytime
+in the future.
 
 ## Can I have more than one Loop app on a phone?
 
-Yes, technically possible. You can have multiple Loop apps built onto the same iPhone. However, having multiple Loop apps on a single phone may lead to unexpected conflicts that can negatively affect your Loop's ability to stay green (keep looping). Additionally, your pod will only work on one Loop app at a time anyways. So for smooth looping, just keep one Loop app on any phone for looping use. 
+Yes, technically possible. You can have multiple Loop apps built onto the same
+iPhone. However, having multiple Loop apps on a single phone may lead to
+unexpected conflicts that can negatively affect your Loop's ability to stay
+green (keep looping). Additionally, your pod will only work on one Loop app at a
+time anyways. So for smooth looping, just keep one Loop app on any phone for
+looping use.
 
 ## Will I be able to Loop on a plane? Or in the mountains?
 
-Yes. Loop does not require internet or cell coverage to work. So long as the Looper has Bluetooth turned on on the iPhone (or iPod touch), then the Dexcom and RileyLink will still be able to do their work with Loop and your pump/pod.
-
+Yes. Loop does not require internet or cell coverage to work. So long as the
+Looper has Bluetooth turned on on the iPhone (or iPod touch), then the Dexcom
+and RileyLink will still be able to do their work with Loop and your pump/pod.

--- a/docs/faqs/algorithm-faqs.md
+++ b/docs/faqs/algorithm-faqs.md
@@ -1,16 +1,35 @@
 # Algorithm FAQs
 
-
 ## Does Loop "learn" or detect changes in your insulin needs?
 
-No. Loop assumes the settings you've provided are correct. If outside factors (such as hormones, illness, exercise, medications, etc) affect your underlying settings that determine insulin needs (basals, insulin sensitivity factor, carb ratio) you may need to manually adjust your settings. Loop will not "learn" or "assume" that your underlying needs have changed. Instead, Loop is designed to react to the changes in blood glucose and its insulin dosing decisions are based on the settings that you have entered in the app.
+No. Loop assumes the settings you've provided are correct. If outside factors
+(such as hormones, illness, exercise, medications, etc) affect your underlying
+settings that determine insulin needs (basals, insulin sensitivity factor, carb
+ratio) you may need to manually adjust your settings. Loop will not "learn" or
+"assume" that your underlying needs have changed. Instead, Loop is designed to
+react to the changes in blood glucose and its insulin dosing decisions are based
+on the settings that you have entered in the app.
 
-There is a short-term retrospective analysis built into Loop which will apply a weighted-correction based on the past 60 minutes of blood glucose changes. While this does help some, larger-scale "learning" is not currently a part of Loop's algorithm.
+There is a short-term retrospective analysis built into Loop which will apply a
+weighted-correction based on the past 60 minutes of blood glucose changes. While
+this does help some, larger-scale "learning" is not currently a part of Loop's
+algorithm.
 
-Perhaps in subsequent versions of Loop, auto-adjustment of settings or machine learning could be incorporated. Until then, you will need to tell Loop if your underlying settings need updating or make temporary adjustments for short term issues. To understand why your settings matter, check out [Looptips.org](https://looptips.org).
+Perhaps in subsequent versions of Loop, auto-adjustment of settings or machine
+learning could be incorporated. Until then, you will need to tell Loop if your
+underlying settings need updating or make temporary adjustments for short term
+issues. To understand why your settings matter, check out
+[Looptips.org](https://looptips.org).
 
 ## What does negative Active Insulin mean?
 
-When Loop withholds or suspends some of your expected basal insulin, that starts an accumulation of insulin deficit. Similar to if you have a kinked cannula and insulin is not delivered, you'd call yourself "lacking insulin". That is the same concept of having negative active insulin (aka negative insulin on board). When you have negative insulin on board, it is a sign that Loop has been actively helping you prevent a low blood sugar. If you find significant negative insulin on board regularly, you probably need to [adjust/test your settings](https://kdisimone.github.io/looptips/settings/settings/).
+When Loop withholds or suspends some of your expected basal insulin, that starts
+an accumulation of insulin deficit. Similar to if you have a kinked cannula and
+insulin is not delivered, you'd call yourself "lacking insulin". That is the
+same concept of having negative active insulin (aka negative insulin on board).
+When you have negative insulin on board, it is a sign that Loop has been
+actively helping you prevent a low blood sugar. If you find significant negative
+insulin on board regularly, you probably need to
+[adjust/test your settings](https://kdisimone.github.io/looptips/settings/settings/).
 
-## 
+##

--- a/docs/faqs/branch-faqs.md
+++ b/docs/faqs/branch-faqs.md
@@ -1,133 +1,344 @@
 # Branch FAQs
 
-This page is mostly suited to people who have built the app once already and then are coming back to update. In the course of updating, you may be wondering about the different branches, what the differences are, and such...so let's try to answer some of those questions as best we can.
+This page is mostly suited to people who have built the app once already and
+then are coming back to update. In the course of updating, you may be wondering
+about the different branches, what the differences are, and such...so let's try
+to answer some of those questions as best we can.
 
 ## What are all these branches?
 
-Yes, there are a lot of "branches" in Loop talk but the concept is simple. I'll use an analogy to help. Basically, they are all slightly different versions of Loop...kind of like different edits of the same book.
+Yes, there are a lot of "branches" in Loop talk but the concept is simple. I'll
+use an analogy to help. Basically, they are all slightly different versions of
+Loop...kind of like different edits of the same book.
 
-To really understand what branches are, we should probably explain a little more about Loop's code and how development works.
+To really understand what branches are, we should probably explain a little more
+about Loop's code and how development works.
 
-Loop developers' own an account in GitHub called [LoopKit](https://github.com/LoopKit).  Within that account, the developers have several "repositories" that support Loop in particular. A repository is like a book...let's think of it like a cookbook for now. Within the LoopKit account, there are repositories for Loop itself, LoopDocs, and various other supporting "frameworks" that are helper repositories for Loop to build correctly. For example, Loop's repo has a lot of the info about the app itself; the outward facing things that you interact with. How information is put to you and taken in from you...that's in Loop repository code. But, there's more than just a user interface for Loop. Loop has to do a lot of complex work like Bluetooth communications, algorithm math, pump communications, etc. The Loop app has help from frameworks to do those other parts. CGMBLEkit for some of the transmitter parts of Loop, RileyLink_ios for the pump managers (talking to the pumps and decoding their information), LoopKit for the algorithm about carbs and insulin curves, etc.
+Loop developers' own an account in GitHub called
+[LoopKit](https://github.com/LoopKit). Within that account, the developers have
+several "repositories" that support Loop in particular. A repository is like a
+book...let's think of it like a cookbook for now. Within the LoopKit account,
+there are repositories for Loop itself, LoopDocs, and various other supporting
+"frameworks" that are helper repositories for Loop to build correctly. For
+example, Loop's repo has a lot of the info about the app itself; the outward
+facing things that you interact with. How information is put to you and taken in
+from you...that's in Loop repository code. But, there's more than just a user
+interface for Loop. Loop has to do a lot of complex work like Bluetooth
+communications, algorithm math, pump communications, etc. The Loop app has help
+from frameworks to do those other parts. CGMBLEkit for some of the transmitter
+parts of Loop, RileyLink_ios for the pump managers (talking to the pumps and
+decoding their information), LoopKit for the algorithm about carbs and insulin
+curves, etc.
 
-When you build Loop, in the background, Loop pulls those other frameworks (7 in total) into the build process using "Carthage".  Carthage is like a personal shopper. You give it a shopping list (the cartfile in Loop code is that shopping list) and it goes and fetches that for you during the build process. Sometimes your computer has an old shopping list...and that can cause build errors. Hence the "carthage update" fix in the Build Errors page...that command updates the shopping list to get the right versions of those frameworks.
+When you build Loop, in the background, Loop pulls those other frameworks (7 in
+total) into the build process using "Carthage". Carthage is like a personal
+shopper. You give it a shopping list (the cartfile in Loop code is that shopping
+list) and it goes and fetches that for you during the build process. Sometimes
+your computer has an old shopping list...and that can cause build errors. Hence
+the "carthage update" fix in the Build Errors page...that command updates the
+shopping list to get the right versions of those frameworks.
 
 <p align="center">
 <img src="../img/loopkit.png" width="650">
 </p>
 
-Anyways...so now you know about the general structure of Loop and LoopKit in Github. Now we can discuss Loop itself a little deeper.
+Anyways...so now you know about the general structure of Loop and LoopKit in
+Github. Now we can discuss Loop itself a little deeper.
 
-So let's imagine Loop as a cookbook. The developers are the authors/chefs of the recipes (code) in the cookbook. The authors spend countless hours testing new recipes, taste testing, documenting improvements. They send the drafts to the editor, who makes suggestions and eventually the cookbook is finalized. There are no grammar issues, no typos, the photos are beautiful and the recipes are yummy. They publish the book and you see a gorgeous final product on the shelves. That is called a "release" and it is the master branch. This book has been well-tested and is super stable. Everytime you cook with those recipes, you know exactly what you're getting and lots of people have had a chance before you to make sure that it all tastes good. Master branch is stable and tested.
+So let's imagine Loop as a cookbook. The developers are the authors/chefs of the
+recipes (code) in the cookbook. The authors spend countless hours testing new
+recipes, taste testing, documenting improvements. They send the drafts to the
+editor, who makes suggestions and eventually the cookbook is finalized. There
+are no grammar issues, no typos, the photos are beautiful and the recipes are
+yummy. They publish the book and you see a gorgeous final product on the
+shelves. That is called a "release" and it is the master branch. This book has
+been well-tested and is super stable. Everytime you cook with those recipes, you
+know exactly what you're getting and lots of people have had a chance before you
+to make sure that it all tastes good. Master branch is stable and tested.
 
-But then...the chefs/developers go on a trip. They are inspired by new cuisine and want to add new recipes to the old cookbook. (Things like omnipod support and overrides are new "recipes" that were developed since the last master release, for example.) But, the process for developing a recipe is arduous. Lots of trial and error involved. Lots of tweaking ingredients (code). The editors try out the new recipes and offer feedback (similar to the [Issues List in GitHub](https://github.com/LoopKit/Loop/issues)). While the recipes are being developed, they have a version of the old cookbook that gets marked up...edited in pencil a lot. Scribbles and notes in the side. Revisions happen frequently, because that's what testing new recipes is all about. These marked-up versions of the cookbook are called "dev" branch. Short for "development" branch. Like the name sounds...this is where new developments are happening, new recipes and tweaks. 
+But then...the chefs/developers go on a trip. They are inspired by new cuisine
+and want to add new recipes to the old cookbook. (Things like omnipod support
+and overrides are new "recipes" that were developed since the last master
+release, for example.) But, the process for developing a recipe is arduous. Lots
+of trial and error involved. Lots of tweaking ingredients (code). The editors
+try out the new recipes and offer feedback (similar to the
+[Issues List in GitHub](https://github.com/LoopKit/Loop/issues)). While the
+recipes are being developed, they have a version of the old cookbook that gets
+marked up...edited in pencil a lot. Scribbles and notes in the side. Revisions
+happen frequently, because that's what testing new recipes is all about. These
+marked-up versions of the cookbook are called "dev" branch. Short for
+"development" branch. Like the name sounds...this is where new developments are
+happening, new recipes and tweaks.
 
-After much testing and tweaking, eventually the recipes get the flavors right (bugs in code are squashed) and enough people have provided feedback and careful observations of results...that the book goes to the publishing house for the next printing. The cookbook is republished with an updated edition number and new recipes are highlighted. When this happens in Loop, Loop's master branch is updated with the new features coming from dev (aka, "dev branch is merged into master branch"). When that happens, master branch gets another "release" version (you can see release history [here](https://github.com/LoopKit/Loop/releases)) and for that one day...dev and master are exactly the same. They stay the same until the Loop developers start working on the next batch of improvements, could be the next hour even or days later, but the process begins again. The developers will start editing the code again and dropping those edits in dev branch for further development.
+After much testing and tweaking, eventually the recipes get the flavors right
+(bugs in code are squashed) and enough people have provided feedback and careful
+observations of results...that the book goes to the publishing house for the
+next printing. The cookbook is republished with an updated edition number and
+new recipes are highlighted. When this happens in Loop, Loop's master branch is
+updated with the new features coming from dev (aka, "dev branch is merged into
+master branch"). When that happens, master branch gets another "release" version
+(you can see release history [here](https://github.com/LoopKit/Loop/releases))
+and for that one day...dev and master are exactly the same. They stay the same
+until the Loop developers start working on the next batch of improvements, could
+be the next hour even or days later, but the process begins again. The
+developers will start editing the code again and dropping those edits in dev
+branch for further development.
 
 ## So what was/is Omnipod-testing branch?
 
-Omnipod Loop development testing (not talking about the actual hacking work that preceeded that) was done by a smaller group of people privately for months and months before public release of the omnipod-testing branch. This smaller group of people (several dozen) were actively watching their Omnipod Loops and capturing bug reports. There was a lot of work put in by the testers and Pete Schwamb (Loop Developer) to get the code fairly stable and reliable. 
+Omnipod Loop development testing (not talking about the actual hacking work that
+preceeded that) was done by a smaller group of people privately for months and
+months before public release of the omnipod-testing branch. This smaller group
+of people (several dozen) were actively watching their Omnipod Loops and
+capturing bug reports. There was a lot of work put in by the testers and Pete
+Schwamb (Loop Developer) to get the code fairly stable and reliable.
 
-When the code got to a stable, reliable state and was ready for a larger audience, omnipod-testing branch was made available as a "public testing" branch. This branch is slightly different than a dev branch. What it means is that it was pretty well tested, but not necessarily going to be perfect for everyone right away. There were expectations that some user-interface requests might be asked for after having a wider audience of users (bolus beeps is a good example of that kind of testing outcome). 
+When the code got to a stable, reliable state and was ready for a larger
+audience, omnipod-testing branch was made available as a "public testing"
+branch. This branch is slightly different than a dev branch. What it means is
+that it was pretty well tested, but not necessarily going to be perfect for
+everyone right away. There were expectations that some user-interface requests
+might be asked for after having a wider audience of users (bolus beeps is a good
+example of that kind of testing outcome).
 
-Also, omnipod-testing branch was not going to undergo a lot of active revisions to it when it was released. The intent was to keep it as a fairly known, un-changed product for people rather than a constantly changing code set...that way if people noted a bug, it would be a more "known" code base to work to debug.
+Also, omnipod-testing branch was not going to undergo a lot of active revisions
+to it when it was released. The intent was to keep it as a fairly known,
+un-changed product for people rather than a constantly changing code set...that
+way if people noted a bug, it would be a more "known" code base to work to
+debug.
 
-So, omnipod-testing branch has undergone very little revision since it was first released. In face, since its release in late April/early May 2019, there has only been two updates; one for the newer style Dexcom G6 transmitters and one for iOS 13 compatibility. Nothing major has been done in that branch, intentionally. As described above, the branch is serving as a stable platform for users and has helped catch bugs as a result of NOT being changed constantly.
+So, omnipod-testing branch has undergone very little revision since it was first
+released. In face, since its release in late April/early May 2019, there has
+only been two updates; one for the newer style Dexcom G6 transmitters and one
+for iOS 13 compatibility. Nothing major has been done in that branch,
+intentionally. As described above, the branch is serving as a stable platform
+for users and has helped catch bugs as a result of NOT being changed constantly.
 
 ## What is the future of omnipod-testing branch? Will it be updated?
 
-No. Omnipod-testing branch is not going to be "updated" in the way many people are asking about. Little code fixes going in constantly will not happen. The reasons are given above. Omnipod-testing branch was just for that...testing that code in a static, fairly unchanged format to learn the most from it in a clean way.
+No. Omnipod-testing branch is not going to be "updated" in the way many people
+are asking about. Little code fixes going in constantly will not happen. The
+reasons are given above. Omnipod-testing branch was just for that...testing that
+code in a static, fairly unchanged format to learn the most from it in a clean
+way.
 
-As I just mentioned, bugs have been found in omnipod-testing branch. Those bugs are being squashed in dev branch and not in omnipod-testing branch. WHY? Because dev branch is the place for new code testing. Like playing a game of Jenga, changing code to squash one bug may result in unintended consequences that cause another bug. So the playground for that kind of testing is most appropriate for dev branch. Omnipod-testing branch is not a place to be testing bug squashes and code changes.
+As I just mentioned, bugs have been found in omnipod-testing branch. Those bugs
+are being squashed in dev branch and not in omnipod-testing branch. WHY? Because
+dev branch is the place for new code testing. Like playing a game of Jenga,
+changing code to squash one bug may result in unintended consequences that cause
+another bug. So the playground for that kind of testing is most appropriate for
+dev branch. Omnipod-testing branch is not a place to be testing bug squashes and
+code changes.
 
-When dev gets more stable and the bugs are squashed/cleaned up, eventually that cleaned up code will be announced as a recommended replacement for omnipod-testing branch. Don't worry...there will be LoopDocs updates, pinned announcements in Looped and Zulipchat, instagram posts, etc. You shouldn't be able to miss it.
+When dev gets more stable and the bugs are squashed/cleaned up, eventually that
+cleaned up code will be announced as a recommended replacement for
+omnipod-testing branch. Don't worry...there will be LoopDocs updates, pinned
+announcements in Looped and Zulipchat, instagram posts, etc. You shouldn't be
+able to miss it.
 
 ## How can I stay current with what's going on in the branches?
 
-Now we've learned that master and omnipod-testing branches really aren't changing much. They've each had some "hot-fixes" for late-breaking things that were needed for users in a timely fashion; the updated G6 transmitters and iOS update compatibility...but mostly the essential core of the code remains intentionally unchanged in those branches. ("Hot-fixes" are code changes to keep core functions when one of the outside pieces triggered the need. Apple and Dexcom changing their gear represent times when hot-fixes are most likely, but do not represent a major release change. Most people will want to update their Loop apps after a hot-fix is merged into the branch because those help ensure your gear works as expected.)
+Now we've learned that master and omnipod-testing branches really aren't
+changing much. They've each had some "hot-fixes" for late-breaking things that
+were needed for users in a timely fashion; the updated G6 transmitters and iOS
+update compatibility...but mostly the essential core of the code remains
+intentionally unchanged in those branches. ("Hot-fixes" are code changes to keep
+core functions when one of the outside pieces triggered the need. Apple and
+Dexcom changing their gear represent times when hot-fixes are most likely, but
+do not represent a major release change. Most people will want to update their
+Loop apps after a hot-fix is merged into the branch because those help ensure
+your gear works as expected.)
 
-So it's just dev branch that changes often. The developers need YOU to know that dev is a constantly shifting, moving place. If you choose to come into a dev branch build...you need to be aware that is what dev does...moves, shakes, changes, and will update code frequently and unannounced in the traditional sense that most users in Looped group or instagram would see. Developers are not helped by people being in a dev branch if those users are mistakenly thinking of it as a stable master branch with lots of detailed docs to go with it. People should only use a dev branch build if they EDUCATE themselves on the expectations and how to properly manage dev information and updates. People using dev branch should also have regular access to a computer to be able to rebuild quickly if a new bug/fix is identified. 
+So it's just dev branch that changes often. The developers need YOU to know that
+dev is a constantly shifting, moving place. If you choose to come into a dev
+branch build...you need to be aware that is what dev does...moves, shakes,
+changes, and will update code frequently and unannounced in the traditional
+sense that most users in Looped group or instagram would see. Developers are not
+helped by people being in a dev branch if those users are mistakenly thinking of
+it as a stable master branch with lots of detailed docs to go with it. People
+should only use a dev branch build if they EDUCATE themselves on the
+expectations and how to properly manage dev information and updates. People
+using dev branch should also have regular access to a computer to be able to
+rebuild quickly if a new bug/fix is identified.
 
-If you choose to use a dev build, you can stay abreast of developments in a number of ways...but they will all require you to do some legwork and keep yourself informed. This is not a situation where you should expect a fancy Loopdocs page updated regularly with current "dev updates"...that's just not the way dev branch works.
+If you choose to use a dev build, you can stay abreast of developments in a
+number of ways...but they will all require you to do some legwork and keep
+yourself informed. This is not a situation where you should expect a fancy
+Loopdocs page updated regularly with current "dev updates"...that's just not the
+way dev branch works.
 
 ### Watch the Loop Repo and Issues list
-First, subscribe to the Loop repo's Issues list by "watching" the [Loop repo](https://github.com/LoopKit/Loop). You can choose to watch the repo so that you get emails when new Issues are reported. This is a good way to find out if there's other people reporting odd behavior that you are wondering about. If you use dev and wonder about something you are seeing in Loop, you can check [Issues list](https://github.com/LoopKit/Loop/issues) to see if others are noticing the same. If so, you can help by capturing information and reporting it. Not super helpful to just say "yeah, me too..." but better if you can attach screenshots, Issue Reports from Loop settings, and a thorough description of the problem you are seeing. Be a part of the solution by thoughtfully providing information to help debug.
+
+First, subscribe to the Loop repo's Issues list by "watching" the
+[Loop repo](https://github.com/LoopKit/Loop). You can choose to watch the repo
+so that you get emails when new Issues are reported. This is a good way to find
+out if there's other people reporting odd behavior that you are wondering about.
+If you use dev and wonder about something you are seeing in Loop, you can check
+[Issues list](https://github.com/LoopKit/Loop/issues) to see if others are
+noticing the same. If so, you can help by capturing information and reporting
+it. Not super helpful to just say "yeah, me too..." but better if you can attach
+screenshots, Issue Reports from Loop settings, and a thorough description of the
+problem you are seeing. Be a part of the solution by thoughtfully providing
+information to help debug.
 
 <p align="center">
 <img src="../img/watching.png" width="650">
 </p>
 
 ### Subscribe to the Zulipchat channels
-Second, use [Zulipchat](https://loop.zulipchat.com) forums for Loop. This forum has several "streams" of conversions depending on interest. I highly recommend following the #github channel if you are wanting to watch for code changes. Code changes are called "commits" in GitHub. The #github channel will have an automated post whenever a new commit is made and it will give a brief line description of the commit.
+
+Second, use [Zulipchat](https://loop.zulipchat.com) forums for Loop. This forum
+has several "streams" of conversions depending on interest. I highly recommend
+following the #github channel if you are wanting to watch for code changes. Code
+changes are called "commits" in GitHub. The #github channel will have an
+automated post whenever a new commit is made and it will give a brief line
+description of the commit.
 
 <p align="center">
 <img src="../img/zulipchat.png" width="650">
 </p>
 
-You can also go directly to the commit history for each of the branches if you'd like.
+You can also go directly to the commit history for each of the branches if you'd
+like.
 
-<a href="https://github.com/LoopKit/Loop/commits/master">Loop master branch commit history</a>
+<a href="https://github.com/LoopKit/Loop/commits/master">Loop master branch
+commit history</a>
 
-<a href="https://github.com/LoopKit/Loop/commits/dev">Loop dev branch commit history</a>
+<a href="https://github.com/LoopKit/Loop/commits/dev">Loop dev branch commit
+history</a>
 
-<a href="https://github.com/LoopKit/Loop/commits/omnipod-testing">Loop omnipod-testing branch commit history</a>
+<a href="https://github.com/LoopKit/Loop/commits/omnipod-testing">Loop
+omnipod-testing branch commit history</a>
 
-If you click on the commit, you can see exactly what changes to the code were made. It's an interesting learning experience. In red are the code that is old, in green is the updated code. The line numbers and file names of the edited code are also there to help.
+If you click on the commit, you can see exactly what changes to the code were
+made. It's an interesting learning experience. In red are the code that is old,
+in green is the updated code. The line numbers and file names of the edited code
+are also there to help.
 
 <p align="center">
 <img src="../img/commit.png" width="650">
 </p>
 
-I don't expect many of you would understand exactly what the edits mean, or how the new code might function...but I bring up the topic of commit history so that you can use that to realize just how often dev is updated. Go ahead and look at the number and frequency of commits in that dev branch...that is why there is no way someone is going to keep a "loopdocs" of dev changes. It's just too much a moving target.
+I don't expect many of you would understand exactly what the edits mean, or how
+the new code might function...but I bring up the topic of commit history so that
+you can use that to realize just how often dev is updated. Go ahead and look at
+the number and frequency of commits in that dev branch...that is why there is no
+way someone is going to keep a "loopdocs" of dev changes. It's just too much a
+moving target.
 
 ### Keep checking Looped group
-Third, keep watching Looped group. Major concerns/issues are brought up there...so no harm in scrolling through and seeing what's going on there.
+
+Third, keep watching Looped group. Major concerns/issues are brought up
+there...so no harm in scrolling through and seeing what's going on there.
 
 ### Become familiar with your data sources
-Another useful thing if you'll be on dev branches undergoing a lot of active change...know how Loop works and where to look for additional information about what you are seeing. For example, if you see an IOB value that looks odd, you should know to look at the insulin deliveries are stored in Health app. Knowing to pull an Issue Report when you see a problem so you can provide that if asked. Knowing [how to capture debugging logs if the developers ask for that kind of info](https://youtu.be/Ac4MguvUO7M) is also a good skill. 
+
+Another useful thing if you'll be on dev branches undergoing a lot of active
+change...know how Loop works and where to look for additional information about
+what you are seeing. For example, if you see an IOB value that looks odd, you
+should know to look at the insulin deliveries are stored in Health app. Knowing
+to pull an Issue Report when you see a problem so you can provide that if asked.
+Knowing
+[how to capture debugging logs if the developers ask for that kind of info](https://youtu.be/Ac4MguvUO7M)
+is also a good skill.
 
 ## What are the differences in branches now?
 
 Roughly speaking...right now (September 23nd):
 
-* Master: No Omnipod support, only Medtronic users. Stable. No updates planned in near future. The next update will depend on how long dev takes to settle down and get some good testing showing stability.
+- Master: No Omnipod support, only Medtronic users. Stable. No updates planned
+  in near future. The next update will depend on how long dev takes to settle
+  down and get some good testing showing stability.
 
-* Omnipod-testing branch: [known bug for IOB tracking](https://github.com/LoopKit/Loop/issues/1034) that has been discussed a lot in Looped group (go ahead and search group if you want to read up on it) for Pod users. The fix for this bug has been implemented in dev branch...the fix is NOT in omnipod-testing branch for reasons discussed above. Jenga. 
+- Omnipod-testing branch:
+  [known bug for IOB tracking](https://github.com/LoopKit/Loop/issues/1034) that
+  has been discussed a lot in Looped group (go ahead and search group if you
+  want to read up on it) for Pod users. The fix for this bug has been
+  implemented in dev branch...the fix is NOT in omnipod-testing branch for
+  reasons discussed above. Jenga.
 
-* Dev: Dev branch has a fix for the IOB tracking for Pod users. Dev branch also has new features that have not previously been a part of mainline Loop branches...overrides and Nightscout profile automatic updating. These two features are new and improved versions of the ones previously a part of JoJo branches (if you've tried those).
+- Dev: Dev branch has a fix for the IOB tracking for Pod users. Dev branch also
+  has new features that have not previously been a part of mainline Loop
+  branches...overrides and Nightscout profile automatic updating. These two
+  features are new and improved versions of the ones previously a part of JoJo
+  branches (if you've tried those).
 
-    Dev branches also has some known bugs still being addressed. For example, when the Loop cancels a temp basal to revert back to scheduled basals...the timestamp below the HUD's temp basal indicator goes back to the time when Loop was first opened. When the next temp basal is set, the timestamp operates properly again. Little stuff like that comes up a lot in dev...and you'll need to do your homework to read up on known issues please. Don't assume that dev branch is supposed to be glitch free...instead look at issues list, scroll through recent posts in Zulipchat and see if others have already noted/discussed the same.
+  Dev branches also has some known bugs still being addressed. For example, when
+  the Loop cancels a temp basal to revert back to scheduled basals...the
+  timestamp below the HUD's temp basal indicator goes back to the time when Loop
+  was first opened. When the next temp basal is set, the timestamp operates
+  properly again. Little stuff like that comes up a lot in dev...and you'll need
+  to do your homework to read up on known issues please. Don't assume that dev
+  branch is supposed to be glitch free...instead look at issues list, scroll
+  through recent posts in Zulipchat and see if others have already
+  noted/discussed the same.
 
 ## Should I update to dev branch?
 
 You mean after all that you can't answer that question yourself? Really?
 
-Ask yourself some questions. Are you the type that will have access to a computer? Be willing to update more frequently if needed? Be willing to do some leg work to stay current with possible reported issues? Be willing to watch a little closer after each time you update your Loop app to make sure no code regressions or new bugs came in with the update? If you can't commit to those things, then you should stay on master or omnipod-testing for awhile longer until dev settles down a bit.
+Ask yourself some questions. Are you the type that will have access to a
+computer? Be willing to update more frequently if needed? Be willing to do some
+leg work to stay current with possible reported issues? Be willing to watch a
+little closer after each time you update your Loop app to make sure no code
+regressions or new bugs came in with the update? If you can't commit to those
+things, then you should stay on master or omnipod-testing for awhile longer
+until dev settles down a bit.
 
 ## Is dev branch always changing frequently?
 
-Sometimes yes, sometimes no. Right now we just happen to be in a time of a lot of changes. Pod updates, insulin tracking code changes (which get into the very core of Loop code), Nightscout integration updates, iOS updates...there's just a lot going on right now.
+Sometimes yes, sometimes no. Right now we just happen to be in a time of a lot
+of changes. Pod updates, insulin tracking code changes (which get into the very
+core of Loop code), Nightscout integration updates, iOS updates...there's just a
+lot going on right now.
 
 ## Will JoJo branch be updated? Does it have "a fix"?
 
-JoJo branches are my (me, Katie) personal-use branches that incorporated changes I found useful for our Looping. Those are changes that were pieced together from various sources in the open source community. Other people who coded up particular changes that benefitted themselves and I found were useful, too. What JoJo was not designed to be is a branch that bi-forcated users and complicated which branch people selected. The unintended consequence of sharing my personal branches over time is that confusion about branches has grown...and I dont' enjoy that. I am working with Pete to get the features in my personal branches merged/improved into mainline Loop. 
+JoJo branches are my (me, Katie) personal-use branches that incorporated changes
+I found useful for our Looping. Those are changes that were pieced together from
+various sources in the open source community. Other people who coded up
+particular changes that benefitted themselves and I found were useful, too. What
+JoJo was not designed to be is a branch that bi-forcated users and complicated
+which branch people selected. The unintended consequence of sharing my personal
+branches over time is that confusion about branches has grown...and I dont'
+enjoy that. I am working with Pete to get the features in my personal branches
+merged/improved into mainline Loop.
 
-Dev branch already has automatic Nightscout profile updating now...and that is a huge feature that I really grew to depend on. It is nice to verify (without asking) that my daughter (or a caregiver) successfully edited a basal rate or setting the way I'd suggested when adjustments were needed during a school day. 
+Dev branch already has automatic Nightscout profile updating now...and that is a
+huge feature that I really grew to depend on. It is nice to verify (without
+asking) that my daughter (or a caregiver) successfully edited a basal rate or
+setting the way I'd suggested when adjustments were needed during a school day.
 
-Dev branch also has overrides included now, in a way that improves upon the original version used in JoJo. Michael Pangburn is the author of that AMAZING set of features and I'll be forever in debt to him for the work he's put into overrides. Those have been a super tool to add to Loop and I'm so happy to see them in dev branch. 
+Dev branch also has overrides included now, in a way that improves upon the
+original version used in JoJo. Michael Pangburn is the author of that AMAZING
+set of features and I'll be forever in debt to him for the work he's put into
+overrides. Those have been a super tool to add to Loop and I'm so happy to see
+them in dev branch.
 
-Dev branch is also hopefully getting remote overrides...not sure when, but my fingers are crossed. 
+Dev branch is also hopefully getting remote overrides...not sure when, but my
+fingers are crossed.
 
-The Integral Retrospective Correction is not in dev branch and may/may not be in the future (I don't know). We only used IRC for a short period of time and I think that it may be undergoing some code revision...so it may be "dormant" for a bit in the near future. Take a deep breath...you will be fine if IRC is dormant.
+The Integral Retrospective Correction is not in dev branch and may/may not be in
+the future (I don't know). We only used IRC for a short period of time and I
+think that it may be undergoing some code revision...so it may be "dormant" for
+a bit in the near future. Take a deep breath...you will be fine if IRC is
+dormant.
 
-There are other minor things in Jojo that I expect could get fixed in dev (meter BG uploading to NS for Medtronic Loopers). Insulin delay will probably not be going into dev and instead there's some talk in the development channels about carb modelling improvements which would better address the reason insulin delay was helpful (to the extent it helped improve bolus amounts up-front). Finally, the bolusing below suspend threshold is a one-line code customization that I expect people could do on their own if it is added to LoopDocs. 
+There are other minor things in Jojo that I expect could get fixed in dev (meter
+BG uploading to NS for Medtronic Loopers). Insulin delay will probably not be
+going into dev and instead there's some talk in the development channels about
+carb modelling improvements which would better address the reason insulin delay
+was helpful (to the extent it helped improve bolus amounts up-front). Finally,
+the bolusing below suspend threshold is a one-line code customization that I
+expect people could do on their own if it is added to LoopDocs.
 
-So...in short...NO. JoJo will not be updated with any new code. Instead, JoJo will go into retirement and dev branch (and eventually master branch) will have all you'd need...the IOB tracking fix, overrides, NS profile updating, etc.
+So...in short...NO. JoJo will not be updated with any new code. Instead, JoJo
+will go into retirement and dev branch (and eventually master branch) will have
+all you'd need...the IOB tracking fix, overrides, NS profile updating, etc.
 
-We have been running dev branch live on Anna (my daughter) for several weeks now on both Pods and Medtronic (she's been going between the two), with regular updates to get new code and test/watch. 
+We have been running dev branch live on Anna (my daughter) for several weeks now
+on both Pods and Medtronic (she's been going between the two), with regular
+updates to get new code and test/watch.
 
-The girl who maintains JoJo branches isn't even using JoJo branches. I think that says something, don't you?  
-
-
-
-
+The girl who maintains JoJo branches isn't even using JoJo branches. I think
+that says something, don't you?

--- a/docs/faqs/cgm-faqs.md
+++ b/docs/faqs/cgm-faqs.md
@@ -2,24 +2,37 @@
 
 ## What CGMs does Loop work with?
 
-Loop works Dexcom G4 with share, G5, G6, Share and the Medtronic CGM systems compatible with Looping pumps.
+Loop works Dexcom G4 with share, G5, G6, Share and the Medtronic CGM systems
+compatible with Looping pumps.
 
 Read the details [here](https://loopkit.github.io/loopdocs/build/step4/).
 
 ## Can I use Libre sensors with a reader like Miao Miao?
 
-If you want to use a Libre sensor you will need to modify Loop to accomplish that use. Loop code does not natively support that sensor, nor readers.
+If you want to use a Libre sensor you will need to modify Loop to accomplish
+that use. Loop code does not natively support that sensor, nor readers.
 
 ## Can I use Eversense?
 
-Nope. Eversense does not write to Apple Health nor has the BT communications protocol been reverse engineered the way it has been done with Dexcom.  
+Nope. Eversense does not write to Apple Health nor has the BT communications
+protocol been reverse engineered the way it has been done with Dexcom.
 
 ## Can Loop read CGM data from Nightscout?
 
-Loop does not read from, nor upload to, CGM data for Nightscout. You would need to use a solution such as NightscoutShareServer and make changes to Loop code in order to do that. Please search the Looped group on Facebook for posts regarding that option, as it is not a part of standard Loop use and is a community-based modification. You will need to do your homework and research to make that happen. At this time, there is not an active version of a modified Loop that appears to support this option easily.
+Loop does not read from, nor upload to, CGM data for Nightscout. You would need
+to use a solution such as NightscoutShareServer and make changes to Loop code in
+order to do that. Please search the Looped group on Facebook for posts regarding
+that option, as it is not a part of standard Loop use and is a community-based
+modification. You will need to do your homework and research to make that
+happen. At this time, there is not an active version of a modified Loop that
+appears to support this option easily.
 
 ## Can Spike or Xdrip be used with Loop?
 
-Spike and Xdrip are not supported by Loop. You will need to implement community-based modifications to Loop in order to use those apps with Loop. Helpful tip: Use `spike loop` as a search term in Looped group for additional info about community-modified Loop versions for Spike. Links to those modified Loop versions are not provided in these LoopDocs because we (the LoopDocs maintainers and Loop developers) do not actively watch those versions to ensure they are up-to-date.
-
-
+Spike and Xdrip are not supported by Loop. You will need to implement
+community-based modifications to Loop in order to use those apps with Loop.
+Helpful tip: Use `spike loop` as a search term in Looped group for additional
+info about community-modified Loop versions for Spike. Links to those modified
+Loop versions are not provided in these LoopDocs because we (the LoopDocs
+maintainers and Loop developers) do not actively watch those versions to ensure
+they are up-to-date.

--- a/docs/faqs/docs-faqs.md
+++ b/docs/faqs/docs-faqs.md
@@ -1,41 +1,72 @@
 # Using This Site FAQs
 
-This website is a step-by-step guide on how to build your Loop app. It is totally understandable to be intimidated and worried that this will be too technical...but please realize that this is actually as simple as reading, copying a few lines and clicking a few buttons...REALLY. And these directions will tell you exactly how to do that, and in particular how to navigate this site to make that easy.
+This website is a step-by-step guide on how to build your Loop app. It is
+totally understandable to be intimidated and worried that this will be too
+technical...but please realize that this is actually as simple as reading,
+copying a few lines and clicking a few buttons...REALLY. And these directions
+will tell you exactly how to do that, and in particular how to navigate this
+site to make that easy.
 
 ## Where do I start? I don't know what Loop is.
 
-The best thing to do is to start by learning about Loop using the FAQs pages. The short answer is that Loop is an iPhone app that helps automate your insulin delivery, based on CGM data and user inputs, to keep blood glucose within range. It requires certain gear (pump, CGM, iPhone or iPod touch, and a RileyLink) and a computer to build the app.
+The best thing to do is to start by learning about Loop using the FAQs pages.
+The short answer is that Loop is an iPhone app that helps automate your insulin
+delivery, based on CGM data and user inputs, to keep blood glucose within range.
+It requires certain gear (pump, CGM, iPhone or iPod touch, and a RileyLink) and
+a computer to build the app.
 
-Click on the image below to watch a short [Introduction to Loop video](https://youtu.be/qw_u1lqboCs) and then read the rest of these FAQs pages. 
+Click on the image below to watch a short
+[Introduction to Loop video](https://youtu.be/qw_u1lqboCs) and then read the
+rest of these FAQs pages.
 
 <a href="https://youtu.be/qw_u1lqboCs" target="_blank"><img src="../img/intro-to-loop.png"  title="Introduction to Loop video" /></a>
 
 ## This looks so hard. I don't know if I can do it!
 
-That isn't a question, but I do have an answer. ;) Building Loop app is actually really quite simple. There are a lot of steps only because they are laid out into short segments so that you can take breaks if you want.
+That isn't a question, but I do have an answer. ;) Building Loop app is actually
+really quite simple. There are a lot of steps only because they are laid out
+into short segments so that you can take breaks if you want.
 
-* Each step is designed to end at a natural stopping or resting point, in case you get interrupted or want to take a break.</br></br>
-* Some of the steps only take 5 minutes to finish...so don't be intimidated just by the number of steps.</br></br>
-* The steps are listed in the order that you'd do each task. So start at step 1 and proceed forward.</br></br>
-* Each step ends with a "next step" link to guide you to the next steps you'll need to do. Just keep swimming onto the next little step or take a break and come back later.
+- Each step is designed to end at a natural stopping or resting point, in case
+  you get interrupted or want to take a break.</br></br>
+- Some of the steps only take 5 minutes to finish...so don't be intimidated just
+  by the number of steps.</br></br>
+- The steps are listed in the order that you'd do each task. So start at step 1
+  and proceed forward.</br></br>
+- Each step ends with a "next step" link to guide you to the next steps you'll
+  need to do. Just keep swimming onto the next little step or take a break and
+  come back later.
 
-!!!info "One step at a time..."
-    Don't look at the whole build process at once...that's overwhelming. Instead view it as several smaller tasks to be accomplished and work one step at a time. Start at Step 1 and just read slowly and follow the screenshots. Don't skip steps or skip paragraphs.
-    
+!!!info "One step at a time..." Don't look at the whole build process at
+once...that's overwhelming. Instead view it as several smaller tasks to be
+accomplished and work one step at a time. Start at Step 1 and just read slowly
+and follow the screenshots. Don't skip steps or skip paragraphs.
+
 ## What if I get stuck?
 
 If you get stuck, there are several things that can help:
 
-* Scroll back up in the directions and see if you maybe missed a step accidentally. Might even be that you missed a paragraph.</br></br>
-* Check and compare your screen's display with what the screenshots are highlighting. Does your screen seem similar? Or does yours have an error message? If you have an error message, see if it helps guide you to the problem.</br></br>
-* If you just get stumped, post in Looped Group (Facebook) or Zulipchat and ask for help. Lots of people standing by to help each other. If you have a screenshot of where you are stuck and what part of the directions you are on, that will help a lot.
+- Scroll back up in the directions and see if you maybe missed a step
+  accidentally. Might even be that you missed a paragraph.</br></br>
+- Check and compare your screen's display with what the screenshots are
+  highlighting. Does your screen seem similar? Or does yours have an error
+  message? If you have an error message, see if it helps guide you to the
+  problem.</br></br>
+- If you just get stumped, post in Looped Group (Facebook) or Zulipchat and ask
+  for help. Lots of people standing by to help each other. If you have a
+  screenshot of where you are stuck and what part of the directions you are on,
+  that will help a lot.
 
 ## So, I build the app and then I'm done?
 
-Nope...we wouldn't just leave you dangling like that. There's also an important walk-thru for how to set up your app for the first time. The new displays and settings are all explained in the "Set up App" section of this website. Check it out and follow along with each page step-by-step, just like you did for building. This way you'll learn valuable tips along the way too. Do similar for the "Operate" section of these docs...those are very helpful for understanding how you will use the app to enter meals, edit entries, bolus, etc.
+Nope...we wouldn't just leave you dangling like that. There's also an important
+walk-thru for how to set up your app for the first time. The new displays and
+settings are all explained in the "Set up App" section of this website. Check it
+out and follow along with each page step-by-step, just like you did for
+building. This way you'll learn valuable tips along the way too. Do similar for
+the "Operate" section of these docs...those are very helpful for understanding
+how you will use the app to enter meals, edit entries, bolus, etc.
 
 <p align="center">
 <img src="../img/setup-app.png" width="700">
 </p>
-
-

--- a/docs/faqs/ios13.md
+++ b/docs/faqs/ios13.md
@@ -1,60 +1,114 @@
 # iOS 13 FAQs
 
-Every time a new iOS release comes out...there's loads of questions and a flurry of activity. To help answer these questions, this page will be here short term to help answer these FAQs.
+Every time a new iOS release comes out...there's loads of questions and a flurry
+of activity. To help answer these questions, this page will be here short term
+to help answer these FAQs.
 
 ## Should I update to iOS 13?
 
-That is a question that you should answer separate from Loop considerations. New iOS releases often have bugs in them, so I tend to avoid updating my daughter's phone for a bit. Instead, I update my phone and test things out first. Dexcom's app could have problems even...who knows. But, I certainly want to get a chance to kick-the-tires (or watch other people kick tires) for a bit before I try new iOS releases. Once I see things are ok and working without major issues, then I'll update her phone's iOS. Plus, going backwards once you've updated is a pain and usually not possible shortly after the new version is released.
+That is a question that you should answer separate from Loop considerations. New
+iOS releases often have bugs in them, so I tend to avoid updating my daughter's
+phone for a bit. Instead, I update my phone and test things out first. Dexcom's
+app could have problems even...who knows. But, I certainly want to get a chance
+to kick-the-tires (or watch other people kick tires) for a bit before I try new
+iOS releases. Once I see things are ok and working without major issues, then
+I'll update her phone's iOS. Plus, going backwards once you've updated is a pain
+and usually not possible shortly after the new version is released.
 
-Also, I don't update iOS until I've had time to update my macOS and Xcode as well. Once you update iOS, you'll likely have to do matching updates to other Apple software for Loop building...so might as make sure you successfully update the other pieces so that everything is squared away.
+Also, I don't update iOS until I've had time to update my macOS and Xcode as
+well. Once you update iOS, you'll likely have to do matching updates to other
+Apple software for Loop building...so might as make sure you successfully update
+the other pieces so that everything is squared away.
 
 ## Will my Loop keep working if I don't update to iOS 13?
 
-Yes. Your Loop app will work for one year after you built it (or until the developer team's enrollment/signing certificate expires, whichever comes first). So, if you don't update iOS...no big deal for your Loop app.
+Yes. Your Loop app will work for one year after you built it (or until the
+developer team's enrollment/signing certificate expires, whichever comes first).
+So, if you don't update iOS...no big deal for your Loop app.
 
 ## Will my Loop keep working if I update to iOS 13?
 
-Yes. We have not had one iOS update that has broken Loop apps already installed on the phone. I think we started Loop on iOS 9? Loop has worked through all the updates.
+Yes. We have not had one iOS update that has broken Loop apps already installed
+on the phone. I think we started Loop on iOS 9? Loop has worked through all the
+updates.
 
 ## Do I have to update my Loop if I change to iOS 13?
 
-No. You don't have to. 
+No. You don't have to.
 
 ## Is there a benefit to updating my Loop if I use iOS 13?
 
-Nope. Unless you want to try dark mode which is in dev branch and being developed there...that's about the only thing that is iOS 13 specific in Loop.
+Nope. Unless you want to try dark mode which is in dev branch and being
+developed there...that's about the only thing that is iOS 13 specific in Loop.
 
 ## Why is iOS update a big deal then?
 
-Because iOS major releases (like going from iOS 12 to 13...where the whole number changes) involve updates to several major other Apple-related things. It's a cascade effect.
+Because iOS major releases (like going from iOS 12 to 13...where the whole
+number changes) involve updates to several major other Apple-related things.
+It's a cascade effect.
 
-If you update iOS with a major release, then Xcode will need to update, too. Because Xcode will need the new command tools, Swift language updates, and simulators to be able to properly build for devices that have the new iOS.
+If you update iOS with a major release, then Xcode will need to update, too.
+Because Xcode will need the new command tools, Swift language updates, and
+simulators to be able to properly build for devices that have the new iOS.
 
-And then the cascade continues...that new Xcode will likely require a macOS update. And sometimes (as happened when Xcode 10 was released), the required update to macOS was also a major update (High Sierra to Mojave) that some computers couldn't do. They were "unsupported" by Apple and were aged-out. Luckily, the update to Xcode 11 does not involve aging out any computers this time. If you were running Xcode 10 already, you'll be able to update to Xcode 11 without fear that you'll be left out based on macOS age.
+And then the cascade continues...that new Xcode will likely require a macOS
+update. And sometimes (as happened when Xcode 10 was released), the required
+update to macOS was also a major update (High Sierra to Mojave) that some
+computers couldn't do. They were "unsupported" by Apple and were aged-out.
+Luckily, the update to Xcode 11 does not involve aging out any computers this
+time. If you were running Xcode 10 already, you'll be able to update to Xcode 11
+without fear that you'll be left out based on macOS age.
 
-So, iOS updates are a big deal (for Loopers) because they involve needing to do some updates to be able to properly build Loop again the next time you want to. And people forget about updates. And then they forget about LoopDocs' page specifically to help with Updating your Loop app. And so they just blindly download and build like they did last time...unaware there were needed updates.
+So, iOS updates are a big deal (for Loopers) because they involve needing to do
+some updates to be able to properly build Loop again the next time you want to.
+And people forget about updates. And then they forget about LoopDocs' page
+specifically to help with Updating your Loop app. And so they just blindly
+download and build like they did last time...unaware there were needed updates.
 
-It's not so much about Loop when you update iOS...the issue is about what other things you need to update BEFORE you build Loop again and AFTER you update iOS.
+It's not so much about Loop when you update iOS...the issue is about what other
+things you need to update BEFORE you build Loop again and AFTER you update iOS.
 
 ## What do I need to do to build now with iOS 13?
 
 As of today, September 23rd...things are much easier:
 
-!!!danger "Download Xcode 11 from the App store"
-    If you downloaded Xcode 11 GM previously, go to the App store and get the Xcode update waiting for you now. Xcode 11 GM is not what you need anymore...you need to get Xcode 11 from the App store.
-    
-!!!warning "Restart computer after updating Xcode"
-    Make sure to restart your computer after updating Xcode. There's a known issue that happens often enough to be frustrating if you don't reboot. Either a build error about missing simultors or a "device not connected" (even when phone is connected). Just restart computer. It's easy enough.
+!!!danger "Download Xcode 11 from the App store" If you downloaded Xcode 11 GM
+previously, go to the App store and get the Xcode update waiting for you now.
+Xcode 11 GM is not what you need anymore...you need to get Xcode 11 from the App
+store.
 
-!!!info "Use the Updating Loop app page in LoopDocs"
-    Anytime you want to update your Loop app (aka rebuild your Loop app), always start with the [Updating Loop page](https://loopkit.github.io/loopdocs/build/updating/). That page will have current info to help you get going with what the new minimums are. Always start there. Is it possible there will be a slight delay in updating that page? Yes, I'm human. I have kids, job, house, etc. so it might be slightly delayed sometimes. But, generally during times like this when things are important to update...I make sure the pages reflect that. I'll do my part...your part is to check that page for current info.
-    
-!!!danger "CHECK BUILD ERRORS PAGE"
-    If you get a build error...still check the [Build Errors page](https://loopkit.github.io/loopdocs/build/build_errors/). Because even if your exact error isn't there...the information you NEED to provide when asking for help is listed out on that page. And that information is critical. CRITICAL to be able to troubleshoot your build error.
+!!!warning "Restart computer after updating Xcode" Make sure to restart your
+computer after updating Xcode. There's a known issue that happens often enough
+to be frustrating if you don't reboot. Either a build error about missing
+simultors or a "device not connected" (even when phone is connected). Just
+restart computer. It's easy enough.
+
+!!!info "Use the Updating Loop app page in LoopDocs" Anytime you want to update
+your Loop app (aka rebuild your Loop app), always start with the
+[Updating Loop page](https://loopkit.github.io/loopdocs/build/updating/). That
+page will have current info to help you get going with what the new minimums
+are. Always start there. Is it possible there will be a slight delay in updating
+that page? Yes, I'm human. I have kids, job, house, etc. so it might be slightly
+delayed sometimes. But, generally during times like this when things are
+important to update...I make sure the pages reflect that. I'll do my part...your
+part is to check that page for current info.
+
+!!!danger "CHECK BUILD ERRORS PAGE" If you get a build error...still check the
+[Build Errors page](https://loopkit.github.io/loopdocs/build/build_errors/).
+Because even if your exact error isn't there...the information you NEED to
+provide when asking for help is listed out on that page. And that information is
+critical. CRITICAL to be able to troubleshoot your build error.
 
 ## What if I don't have Xcode 11? Can I still build?
 
-I cannot understand why you wouldn't update to Xcode 11 at this point..but since you asked the answer depends on which version of iOS **AND** which branch of Loop you are using. If you are using iOS 13, YES...in any branch of Loop you want to build ever, you will need Xcode 11. If you are using dev branch, YES. No matter what iOS you are using with dev branch, you'll need Xcode 11.  Checkout out this chart to find out specifically about your combination of ios/branch and the needed Xcode minimum. (But really...just pull off the band-aid and install Xcode 11 anyways.)
+I cannot understand why you wouldn't update to Xcode 11 at this point..but since
+you asked the answer depends on which version of iOS **AND** which branch of
+Loop you are using. If you are using iOS 13, YES...in any branch of Loop you
+want to build ever, you will need Xcode 11. If you are using dev branch, YES. No
+matter what iOS you are using with dev branch, you'll need Xcode 11. Checkout
+out this chart to find out specifically about your combination of ios/branch and
+the needed Xcode minimum. (But really...just pull off the band-aid and install
+Xcode 11 anyways.)
 
 <p align="center">
 <img src="../img/xcode11.png" width="650">

--- a/docs/faqs/omnipod-faqs.md
+++ b/docs/faqs/omnipod-faqs.md
@@ -6,51 +6,105 @@ YES IT IS!!! WOOHOO!!
 
 ## Which pods will work with Loop?
 
-The Loop system described in these documents (aka DIY Loop) works with Eros pods...these are the current pods on the market in wide release. The newer DASH pods are not compatible with DIY Loop. Tidepool has begun a process to bring [DIY Loop through FDA approval](https://tidepool.org/blog/tidepool-delivering-loop) and Insulet has been announced as the [first pump partner for that project](https://diatribe.org/omnipod-first-insulin-pump-partner-tidepool-loop). Tidepool Loop will be using DASH pods, no RileyLink required.  If you would like to stay informed about Tidepool Loop progress, you can fill out an interest form [here](https://tidepool.org/loop). 
+The Loop system described in these documents (aka DIY Loop) works with Eros
+pods...these are the current pods on the market in wide release. The newer DASH
+pods are not compatible with DIY Loop. Tidepool has begun a process to bring
+[DIY Loop through FDA approval](https://tidepool.org/blog/tidepool-delivering-loop)
+and Insulet has been announced as the
+[first pump partner for that project](https://diatribe.org/omnipod-first-insulin-pump-partner-tidepool-loop).
+Tidepool Loop will be using DASH pods, no RileyLink required. If you would like
+to stay informed about Tidepool Loop progress, you can fill out an interest form
+[here](https://tidepool.org/loop).
 
 Summary of eventual systems:
 
-* DIY Loop + Eros pods + RileyLink</br></br>
-* Tidepool Loop +DASH pods (no RileyLink)
+- DIY Loop + Eros pods + RileyLink</br></br>
+- Tidepool Loop +DASH pods (no RileyLink)
 
 ## Do I still need a PDM with Omnipod Loop?
 
-No, pods are monogamous little creatures. They will pair with only one device at a time for safety reasons...so a pod is either paired with a PDM or your Loop app on your iPhone. In other words, your PDM can stay in the diabetes closet while you are Looping. You cannot use the PDM for a pod that has been activated with Loop. That doesn't mean you should get rid of your PDM. Instead, keep it for backup situations if you lose your phone. See below for what to do if you lose your phone or RileyLink. 
+No, pods are monogamous little creatures. They will pair with only one device at
+a time for safety reasons...so a pod is either paired with a PDM or your Loop
+app on your iPhone. In other words, your PDM can stay in the diabetes closet
+while you are Looping. You cannot use the PDM for a pod that has been activated
+with Loop. That doesn't mean you should get rid of your PDM. Instead, keep it
+for backup situations if you lose your phone. See below for what to do if you
+lose your phone or RileyLink.
 
 ## Can I cancel a temp basal Loop sets? How about a bolus?
 
-Yes, you can cancel a temp basal or a bolus in progress. There is a "suspend delivery" command that is easy to access by tapping on the [pod age icon in your Heads Up Display, upper right area](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/#pod-age-omnipod-users). Suspending insulin delivery will cancel any running temp basal or bolus in progress. The suspend command will run indefinitely. A banner notification will be displayed on the Loop main screen while insulin delivery is suspended.
+Yes, you can cancel a temp basal or a bolus in progress. There is a "suspend
+delivery" command that is easy to access by tapping on the
+[pod age icon in your Heads Up Display, upper right area](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/#pod-age-omnipod-users).
+Suspending insulin delivery will cancel any running temp basal or bolus in
+progress. The suspend command will run indefinitely. A banner notification will
+be displayed on the Loop main screen while insulin delivery is suspended.
 
 <p align="center">
 <img src="../img/pump-suspend-banner.png" width="300">
 </p>
 
-Insulin will remain suspended until the user either clicks on the "Tap to Resume" command from Loop's main screen or the "resume delivery" command accessed by tapping the pod age icon. Once insulin delivery is resumed, you will be resumed at your scheduled basal rate. If a bolus was interrupted, the bolus will not resume. If you don't turn on open loop mode, within 5 minutes of resuming insulin delivery, your Loop should resume automatic temp basal adjustments.
+Insulin will remain suspended until the user either clicks on the "Tap to
+Resume" command from Loop's main screen or the "resume delivery" command
+accessed by tapping the pod age icon. Once insulin delivery is resumed, you will
+be resumed at your scheduled basal rate. If a bolus was interrupted, the bolus
+will not resume. If you don't turn on open loop mode, within 5 minutes of
+resuming insulin delivery, your Loop should resume automatic temp basal
+adjustments.
 
 ## Can I prime or set my own temp basal on Loop?
 
-No. Loop does not allow you to pick your own temp basal rate or prime insulin in. 
+No. Loop does not allow you to pick your own temp basal rate or prime insulin
+in.
 
-If you find yourself in a situation where you would like to specify an exact temp basal rate of your own, you would need to (1) change your scheduled basal rate for the time(s) that you'd like a temp basal rate to run, and (2) suspend/resume insulin delivery (in order to cancel any currently running temp basal that Loop has running) and then (3) turn the slider so that you are running in "open loop" mode for the duration of the time you want to use that specific basal rate. 
+If you find yourself in a situation where you would like to specify an exact
+temp basal rate of your own, you would need to (1) change your scheduled basal
+rate for the time(s) that you'd like a temp basal rate to run, and (2)
+suspend/resume insulin delivery (in order to cancel any currently running temp
+basal that Loop has running) and then (3) turn the slider so that you are
+running in "open loop" mode for the duration of the time you want to use that
+specific basal rate.
 
 ## What if I lose my phone or RileyLink?
-For pod users, your pod will finish any currently running temporary basal rate and then revert back to your scheduled basal rate. Without a phone or RileyLink however, you will not be able to affect any pod use; no basal change, suspend, cancel, or bolus. To do anything other than let basals continue, you will need to take action depending on the situation.
 
-* Lost RileyLink only: You can find replace your missing RileyLink with one from your backup supplies. No problem to switch out to a different Rileylink mid-pod session. If you don't have a backup RileyLink to use, then you will need to remove the pod and put on a new pod paired with your PDM until you can get a new RileyLink.
+For pod users, your pod will finish any currently running temporary basal rate
+and then revert back to your scheduled basal rate. Without a phone or RileyLink
+however, you will not be able to affect any pod use; no basal change, suspend,
+cancel, or bolus. To do anything other than let basals continue, you will need
+to take action depending on the situation.
 
-* Lost iPhone only: You will need to remove the pod and put on a new pod paired with your PDM until you can get a new phone and Loop app built onto it.
+- Lost RileyLink only: You can find replace your missing RileyLink with one from
+  your backup supplies. No problem to switch out to a different Rileylink
+  mid-pod session. If you don't have a backup RileyLink to use, then you will
+  need to remove the pod and put on a new pod paired with your PDM until you can
+  get a new RileyLink.
 
-* Lost both RileyLink and phone: You're having a really bad day. You'll need a hug and follow the same directions as if you lost the phone as shown in the bullet above.
+- Lost iPhone only: You will need to remove the pod and put on a new pod paired
+  with your PDM until you can get a new phone and Loop app built onto it.
+
+- Lost both RileyLink and phone: You're having a really bad day. You'll need a
+  hug and follow the same directions as if you lost the phone as shown in the
+  bullet above.
 
 ## Is there an increase in pod failures on Loop?
-In the early stages of development, there were. Thankfully to the hard work of Pete Schwamb and others, pod failure rate is now no longer increased compared to typical pod use with a PDM.
+
+In the early stages of development, there were. Thankfully to the hard work of
+Pete Schwamb and others, pod failure rate is now no longer increased compared to
+typical pod use with a PDM.
 
 ## What do I do if a pod fails to pair?
 
-The most common time of pod errors on Loop will be during the pairing process. If you get a pod that is failing to pair, please see [this page](https://loopkit.github.io/loopdocs/troubleshooting/pod-pairing/) for steps on how to fix the failure and recover before you lose the pod.
+The most common time of pod errors on Loop will be during the pairing process.
+If you get a pod that is failing to pair, please see
+[this page](https://loopkit.github.io/loopdocs/troubleshooting/pod-pairing/) for
+steps on how to fix the failure and recover before you lose the pod.
 
 ## What do you do to stop a screaming pod?
-Screaming pods can be silenced by carrying a paperclip. Simply put the paperclip in the small hole that is on the bottom (the side opposite where the cannula is) of the pod as shown. Push the paperclip in until you hear a little click, that click is breaking the circuit that lets the audible scream go. 
+
+Screaming pods can be silenced by carrying a paperclip. Simply put the paperclip
+in the small hole that is on the bottom (the side opposite where the cannula is)
+of the pod as shown. Push the paperclip in until you hear a little click, that
+click is breaking the circuit that lets the audible scream go.
 
 <p align="center">
 <img src="../img/paperclip.jpg" width="500">

--- a/docs/faqs/rileylink-faqs.md
+++ b/docs/faqs/rileylink-faqs.md
@@ -2,31 +2,62 @@
 
 ## What is the RileyLink? Do I have to have one?
 
-Yes, RileyLink is a required part of Loop. The RileyLink is a little device that helps your iPhone and pump (or Omnipod...that's a pump, too) speak to each other. The RileyLink is a critical part of the Loop system because the pump needs communications in radio form, and the iPhone needs communications in Bluetooth form. RileyLink is like a translator and can speak both formats so that the pump and iPhone can loop together. RileyLink helps get information to/from your pump by radio communications, and to/from your iPhone using Bluetooth.
+Yes, RileyLink is a required part of Loop. The RileyLink is a little device that
+helps your iPhone and pump (or Omnipod...that's a pump, too) speak to each
+other. The RileyLink is a critical part of the Loop system because the pump
+needs communications in radio form, and the iPhone needs communications in
+Bluetooth form. RileyLink is like a translator and can speak both formats so
+that the pump and iPhone can loop together. RileyLink helps get information
+to/from your pump by radio communications, and to/from your iPhone using
+Bluetooth.
 
 ## Where can I buy a RileyLink?
 
-RileyLinks are made in batch productions (meaning sometimes they can go on backorder as another production is in process) and are available at GetRileyLink.org.</br>
+RileyLinks are made in batch productions (meaning sometimes they can go on
+backorder as another production is in process) and are available at
+GetRileyLink.org.</br>
 
-* If you want to buy a RileyLink for Omnipods, click [here](https://getrileylink.org/product/rileylink433). </br>
+- If you want to buy a RileyLink for Omnipods, click
+  [here](https://getrileylink.org/product/rileylink433). </br>
 
-* If you want to buy a RileyLink for Loop-compatible Medtronic pumps, click [here](https://getrileylink.org/product/rileylink916).
+- If you want to buy a RileyLink for Loop-compatible Medtronic pumps, click
+  [here](https://getrileylink.org/product/rileylink916).
 
 ## Do I have to carry the RileyLink everywhere?
 
-The short answer is yes. If you want your Loop to keep automatically adjusting basals and issuing commands to your pump, you will need the RileyLink so that these communications can happen. Put it in a purse, pocket, SPIbelt. Clip it to a backpack, belt, or bra...but please do bring it with you.
+The short answer is yes. If you want your Loop to keep automatically adjusting
+basals and issuing commands to your pump, you will need the RileyLink so that
+these communications can happen. Put it in a purse, pocket, SPIbelt. Clip it to
+a backpack, belt, or bra...but please do bring it with you.
 
 ## How far away can the RileyLink be?
 
-That answer will depend, it is environmentally dependent. Generally speaking, RileyLink is solid about 10-12 feet away in most environments. In some situations, you could have RileyLink work fine even at 20+feet away. Other times, you may need to get RileyLink closer. What influences this distance? The biggest influences are (1) body-blocking and (2) "noisy" environments. The human body is a lot of water, and water is an excellent blocker of wireless communication.  So, sleeping on a pod and smothering it entirely with your body will possibly decrease the ability of RileyLink to communicate with the pod. Environments with a high concentration of wireless signals can also interfere with RileyLink's communications and make closer proximity a benefit. Where might those kinds of situations happen? Concerts, conferences, and sporting arenas are pretty prone to interference.
+That answer will depend, it is environmentally dependent. Generally speaking,
+RileyLink is solid about 10-12 feet away in most environments. In some
+situations, you could have RileyLink work fine even at 20+feet away. Other
+times, you may need to get RileyLink closer. What influences this distance? The
+biggest influences are (1) body-blocking and (2) "noisy" environments. The human
+body is a lot of water, and water is an excellent blocker of wireless
+communication. So, sleeping on a pod and smothering it entirely with your body
+will possibly decrease the ability of RileyLink to communicate with the pod.
+Environments with a high concentration of wireless signals can also interfere
+with RileyLink's communications and make closer proximity a benefit. Where might
+those kinds of situations happen? Concerts, conferences, and sporting arenas are
+pretty prone to interference.
 
 ## What happens if I walk away from my RileyLink?
 
-While you are out of the communication range for your RileyLink, any running temp basal will keep going until it finishes (the longest temp basal that Loop sets are for 30 minutes duration...so within 30 minutes or less your pump would go back to your regularly scheduled basal). When you come back into range of your RileyLink, Loop will pick back up within 5-10 minutes without you needing to do anything.
+While you are out of the communication range for your RileyLink, any running
+temp basal will keep going until it finishes (the longest temp basal that Loop
+sets are for 30 minutes duration...so within 30 minutes or less your pump would
+go back to your regularly scheduled basal). When you come back into range of
+your RileyLink, Loop will pick back up within 5-10 minutes without you needing
+to do anything.
 
 ## What are the differences between Medtronic and Omnipod RileyLinks?
 
-There are two different types of RileyLink currently; the difference being the antenna is optimized for the pump you are using. Otherwise they are identical.
+There are two different types of RileyLink currently; the difference being the
+antenna is optimized for the pump you are using. Otherwise they are identical.
 
 <p align="center">
 <img src="../img/two-rl.png" width="650">
@@ -34,51 +65,111 @@ There are two different types of RileyLink currently; the difference being the a
 
 ## Is the new antenna an "upgrade" in Loop performance?
 
-It is a bit of a misnomer to think of the newer copper coil antenna as an "upgrade". It is only an upgrade if you want to pod Loop. The new antenna will actually decrease your range if you try to use it with a Medtronic Loop.  See the next FAQ for a more detailed description and chart.
+It is a bit of a misnomer to think of the newer copper coil antenna as an
+"upgrade". It is only an upgrade if you want to pod Loop. The new antenna will
+actually decrease your range if you try to use it with a Medtronic Loop. See the
+next FAQ for a more detailed description and chart.
 
 ## What will happen if you use a 916MHz antenna RileyLink with an Omnipod? Or vice versa?
 
-The answer will first depend on exactly how old that RileyLink is and what firmware it has installed.
+The answer will first depend on exactly how old that RileyLink is and what
+firmware it has installed.
 
-Before August 2018, RileyLinks had a firmware that works for only Medtronic pump communication. So, if you have the older firmware on a RileyLink, your pod will never pair in Loop using that RileyLink. The GetRileyLink site does offer a [RileyLink firmware update service](https://getrileylink.org/product/rileylink-fw-update/), if you want to update to the newer pod-usable firmware.
+Before August 2018, RileyLinks had a firmware that works for only Medtronic pump
+communication. So, if you have the older firmware on a RileyLink, your pod will
+never pair in Loop using that RileyLink. The GetRileyLink site does offer a
+[RileyLink firmware update service](https://getrileylink.org/product/rileylink-fw-update/),
+if you want to update to the newer pod-usable firmware.
 
-RileyLinks produced after August 2018, include newer firmware that is needed for Omnipod pump communications as well. The newer firmware will say `subg_rfspy 2.2/ble_rfspy 2.0` in the RileyLink menu, like below when paired in Loop.
+RileyLinks produced after August 2018, include newer firmware that is needed for
+Omnipod pump communications as well. The newer firmware will say
+`subg_rfspy 2.2/ble_rfspy 2.0` in the RileyLink menu, like below when paired in
+Loop.
 
 <p align="center">
 <img src="../img/rl-firmware.jpg" width="350">
 </p>
 
-Assuming your has the newer RileyLink firmware, you can *technically* use that RileyLink with either pump on Loop. But, you will have significant frustrations with the short distances required between the pump/pod and RileyLink when using the "wrong" antenna. Even keeping RileyLink in the pocket on the opposite of where the POD is on your body can cause issues with the 916MHz antenna. With mismatched antenna/pump, the RileyLink needs to be very close and in clear line-of-sight to pump/pod, that it makes everyday living a bit hard. If you use the appropriate-antenna-for-your-pump RileyLink, the distances the pump/pod and RileyLink can tolerate from each other is much more "real world" friendly and stable.
+Assuming your has the newer RileyLink firmware, you can _technically_ use that
+RileyLink with either pump on Loop. But, you will have significant frustrations
+with the short distances required between the pump/pod and RileyLink when using
+the "wrong" antenna. Even keeping RileyLink in the pocket on the opposite of
+where the POD is on your body can cause issues with the 916MHz antenna. With
+mismatched antenna/pump, the RileyLink needs to be very close and in clear
+line-of-sight to pump/pod, that it makes everyday living a bit hard. If you use
+the appropriate-antenna-for-your-pump RileyLink, the distances the pump/pod and
+RileyLink can tolerate from each other is much more "real world" friendly and
+stable.
 
-In summary, definitely use the appropriate RileyLink with the antenna that matches your pump so that you are less frustrated. In a pinch, your old RileyLink might work as a backup, but you won't love it.
+In summary, definitely use the appropriate RileyLink with the antenna that
+matches your pump so that you are less frustrated. In a pinch, your old
+RileyLink might work as a backup, but you won't love it.
 
 <p align="center">
 <img src="../img/rl-antenna-chart.png" width="750">
 </p>
 
 ## Can you swap out the old antenna on a RileyLink?
-Yes, the antenna swap is not a hard swap if you just have basic soldering skills. The old antenna can be removed easily by reheating the solder. New 433MHz antennas and a cap can be found on [GetRileyLink site](https://getrileylink.org/product/433diyupgrade/). Tips: use flux and clean the antenna stub before soldering. Poorly DIY-soldered antennas can lead to a decreased range and frequent communication drops between Loop and the pods.
+
+Yes, the antenna swap is not a hard swap if you just have basic soldering
+skills. The old antenna can be removed easily by reheating the solder. New
+433MHz antennas and a cap can be found on
+[GetRileyLink site](https://getrileylink.org/product/433diyupgrade/). Tips: use
+flux and clean the antenna stub before soldering. Poorly DIY-soldered antennas
+can lead to a decreased range and frequent communication drops between Loop and
+the pods.
 
 ## How long will my RileyLink go between charging?
-RileyLink's can go about 30-32 hours (more or less) on a single charge. There is no way to see the remaining charge level, so most people just get into the habit of charing overnight while they sleep. The actual time to fully recharge is about 1 or 2 hours; you'll know it is fully charged when the red light turns off. After a full charge, the red light will turn off and then periodically turn on for short times while it "tops off" while still on a charger.
+
+RileyLink's can go about 30-32 hours (more or less) on a single charge. There is
+no way to see the remaining charge level, so most people just get into the habit
+of charing overnight while they sleep. The actual time to fully recharge is
+about 1 or 2 hours; you'll know it is fully charged when the red light turns
+off. After a full charge, the red light will turn off and then periodically turn
+on for short times while it "tops off" while still on a charger.
 
 ## How long will my RileyLink battery last?
-Eventually, lipo batteries will lose charging capacity and you would want to replace if you notice the battery not lasting the full day. We've been using our current battery for nearly 2 years without issue.
+
+Eventually, lipo batteries will lose charging capacity and you would want to
+replace if you notice the battery not lasting the full day. We've been using our
+current battery for nearly 2 years without issue.
 
 ## How can I tell how much charge my RileyLink has?
-You can't. There is no charge level indicator. Just charge it nightly, and you won't have a problem. Full battery charge should last about 30-36 hours depending on battery health. Charging takes less than 2 hours.
+
+You can't. There is no charge level indicator. Just charge it nightly, and you
+won't have a problem. Full battery charge should last about 30-36 hours
+depending on battery health. Charging takes less than 2 hours.
 
 ## How should I carry the RileyLink? Does it make a difference?
-In general, you want to get in the habit of carrying RileyLink with you, yes. A pocket, carabiner, lanyard, SPIbelt...the options are endless. What you don't want to do is put the RileyLink in a blocking bag that has Rf-ID blocking (some travel fanny packs have that). The distance that your RileyLink can be away from your pump will depend heavily on the environment you are in.
+
+In general, you want to get in the habit of carrying RileyLink with you, yes. A
+pocket, carabiner, lanyard, SPIbelt...the options are endless. What you don't
+want to do is put the RileyLink in a blocking bag that has Rf-ID blocking (some
+travel fanny packs have that). The distance that your RileyLink can be away from
+your pump will depend heavily on the environment you are in.
 
 ## Is RileyLink waterproof?
+
 Nope. Nor is it sweat-proof. Be careful.
 
 ## What is the most common issue for RileyLink?
-People not [pushing the lipo battery](https://loopkit.github.io/loopdocs/setup/requirements/rileylink/#assembling-rl) in all the way when they first assemble their RileyLink. It takes quite a bit of push to get the plug inserted far enough. If not secured well, Loop will have more frequent problems.
+
+People not
+[pushing the lipo battery](https://loopkit.github.io/loopdocs/setup/requirements/rileylink/#assembling-rl)
+in all the way when they first assemble their RileyLink. It takes quite a bit of
+push to get the plug inserted far enough. If not secured well, Loop will have
+more frequent problems.
 
 ## Can I use more than one RileyLink at a time? Will it improve anything?
-Yes, you can have two turned on, but it won't help anything really. Loop only uses one RileyLink at a time. IF you have several RileyLinks turned on in Loop settings, your Loop will only look for another RileyLink after Loop fails for over 15 minutes on the original RileyLink. In my experience, it is rare that Loop would fail for more than 15 minutes and a second RileyLink would help in the same environment. If one RileyLink gets damaged though and you need to swap out to a second RileyLink, there are no issues with that. 
+
+Yes, you can have two turned on, but it won't help anything really. Loop only
+uses one RileyLink at a time. IF you have several RileyLinks turned on in Loop
+settings, your Loop will only look for another RileyLink after Loop fails for
+over 15 minutes on the original RileyLink. In my experience, it is rare that
+Loop would fail for more than 15 minutes and a second RileyLink would help in
+the same environment. If one RileyLink gets damaged though and you need to swap
+out to a second RileyLink, there are no issues with that.
 
 ## Can I run Loop without a RileyLink?
+
 Nope.

--- a/docs/faqs/safety-faqs.md
+++ b/docs/faqs/safety-faqs.md
@@ -1,16 +1,23 @@
 # Safety Tips
 
-
 ## Beware the Medtronic Easy Bolus button
 
-Medtronic's easy bolus button has been the cause of several accidental boluses when the pump has been carried in a pocket. Best practice would be to disable the Easy Bolus button since you will be doing boluses from the phone anyways.
+Medtronic's easy bolus button has been the cause of several accidental boluses
+when the pump has been carried in a pocket. Best practice would be to disable
+the Easy Bolus button since you will be doing boluses from the phone anyways.
 
 ## Health app permissions
 
-Do not let other apps, such as Spike App or MyFitnessPal, on your iPhone write carbohydrates to Health app. Loop could read those carbohydrates and you could be dosed for those carbohydrates. You can read more about Health permissions [here](https://loopkit.github.io/loopdocs/build/health/#loop-permissions).
+Do not let other apps, such as Spike App or MyFitnessPal, on your iPhone write
+carbohydrates to Health app. Loop could read those carbohydrates and you could
+be dosed for those carbohydrates. You can read more about Health permissions
+[here](https://loopkit.github.io/loopdocs/build/health/#loop-permissions).
 
 ## Finish your Medtronic priming
 
-After a site change and reservoir rewind, Medtronic's pump will have a menu on the pump screen related to finishing your prime. Make sure you complete that screen and always return to the main menu. Medtronic's pump won't resume basal insulin delivery until that priming screen is completed.
+After a site change and reservoir rewind, Medtronic's pump will have a menu on
+the pump screen related to finishing your prime. Make sure you complete that
+screen and always return to the main menu. Medtronic's pump won't resume basal
+insulin delivery until that priming screen is completed.
 
-## 
+##

--- a/docs/faqs/update-faqs.md
+++ b/docs/faqs/update-faqs.md
@@ -1,39 +1,80 @@
 # Updating/Rebuilding Loop FAQs
 
-SOOOO many questions about updating or rebuilding Loop. The general answer is that people tend to overthink this. Rebuilding your Loop app is really quite easy...so a short read of these questions should help a lot.
+SOOOO many questions about updating or rebuilding Loop. The general answer is
+that people tend to overthink this. Rebuilding your Loop app is really quite
+easy...so a short read of these questions should help a lot.
 
 First, please take a minute to understand what the words mean.
 
-"Updating Loop" is the process of getting a new download of Loop's code and using that to update your Loop. You do this when you want to switch branches. You do this when you want to get fixes or new features from the same branch. The process doesn't care if you are moving from omnipod-testing -> dev or jojo -> dev or master -> dev or any other combination. 
+"Updating Loop" is the process of getting a new download of Loop's code and
+using that to update your Loop. You do this when you want to switch branches.
+You do this when you want to get fixes or new features from the same branch. The
+process doesn't care if you are moving from omnipod-testing -> dev or jojo ->
+dev or master -> dev or any other combination.
 
-Updating Loop is the same idea as what happens to your other apps on your iPhone when you update them from the App Store on the phone. A refreshed version of the same app appears on the phone, simply replacing-in-place the same Loop you were using with an updated version.
+Updating Loop is the same idea as what happens to your other apps on your iPhone
+when you update them from the App Store on the phone. A refreshed version of the
+same app appears on the phone, simply replacing-in-place the same Loop you were
+using with an updated version.
 
 ## Where should I start when I want to update my Loop?
 
-**ALWAYS start with the [Update Loop page](https://loopkit.github.io/loopdocs/build/updating/) before any new build that you'd be doing.** That page is important because it will offer information on the updates you need to do before building, as well as any late breaking things that might need to be considered.
+**ALWAYS start with the
+[Update Loop page](https://loopkit.github.io/loopdocs/build/updating/) before
+any new build that you'd be doing.** That page is important because it will
+offer information on the updates you need to do before building, as well as any
+late breaking things that might need to be considered.
 
-Do not simply build with your old downloaded folder from months ago. There is a high likelihood that your original code from awhile ago is outdated. Grab new code and you will get the version that has all the latest and greatest features and bug fixes.
+Do not simply build with your old downloaded folder from months ago. There is a
+high likelihood that your original code from awhile ago is outdated. Grab new
+code and you will get the version that has all the latest and greatest features
+and bug fixes.
 
 ## When do I have to update/rebuild?
 
 Absolute minimum: 1 year from when you last built (paid account).
 
-Good idea minimum: If on dev branch, frequently. I've found valuable updates to dev branch at least once a week lately...but I'd say monthly minimum at least for dev right now. Master and omnipod-testing branch do not have changes frequently.
+Good idea minimum: If on dev branch, frequently. I've found valuable updates to
+dev branch at least once a week lately...but I'd say monthly minimum at least
+for dev right now. Master and omnipod-testing branch do not have changes
+frequently.
 
-Issue specific minimum: There are also times where you may need to update for "hot-fixes" to keep your Loop working when other things change. For example, the new style Dexcom transmitters changed their Bluetooth protocol. Loop's code was updated for the new transmitters so that offline looping can continue to work. If you don't update to get that fix, you will be forced to rely on internet-required looping because older versoin of Loop won't have the updated protocols.
+Issue specific minimum: There are also times where you may need to update for
+"hot-fixes" to keep your Loop working when other things change. For example, the
+new style Dexcom transmitters changed their Bluetooth protocol. Loop's code was
+updated for the new transmitters so that offline looping can continue to work.
+If you don't update to get that fix, you will be forced to rely on
+internet-required looping because older versoin of Loop won't have the updated
+protocols.
 
 ## Will I have to delete my old Loop app?
 
-No. Do not delete your old Loop. In fact, that is a bad idea as you will lose your currently paired pod and/or settings if you do that. So, don't delete (except for two situations below):
+No. Do not delete your old Loop. In fact, that is a bad idea as you will lose
+your currently paired pod and/or settings if you do that. So, don't delete
+(except for two situations below):
 
-1. You broke it: There is a glitch in Loop where if you enter the target correction range backwards, then your Loop app will stop working. Correction range needs to be in minimum-maximum, for example 100-120 mg/dL. If you entered that as 120-100 mg/dL, Loop will not work during the time that backwards correction range is supposed to be active. In this case you would need to delete the app and rebuild.</br></br>
-2. Moving from dev branch back down to jojo branch. The way the new dev branch is coded will require you to delete your dev build prior to going back jojo branch.
+1. You broke it: There is a glitch in Loop where if you enter the target
+   correction range backwards, then your Loop app will stop working. Correction
+   range needs to be in minimum-maximum, for example 100-120 mg/dL. If you
+   entered that as 120-100 mg/dL, Loop will not work during the time that
+   backwards correction range is supposed to be active. In this case you would
+   need to delete the app and rebuild.</br></br>
+2. Moving from dev branch back down to jojo branch. The way the new dev branch
+   is coded will require you to delete your dev build prior to going back jojo
+   branch.
 
 ## Does updating make a separate, second Loop app?
 
-No. Loop is simply updated in-place, written right over the old version. 
+No. Loop is simply updated in-place, written right over the old version.
 
-The only exception to this is if you update/build using a different developer signing team than your original Loop app was built with. The app's identity on your phone is defined by the developer team that you signed the app with. That team has a unique ID to identify the app. So, if you change that unique ID, your phone interprets that as a unique app as well...giving you two Loop apps on the phone. Therefore, if changing developer accounts...you will get a new Loop app, and you would need a new Pod. You'll need to transfer your settings manually to the new app and delete your old app.
+The only exception to this is if you update/build using a different developer
+signing team than your original Loop app was built with. The app's identity on
+your phone is defined by the developer team that you signed the app with. That
+team has a unique ID to identify the app. So, if you change that unique ID, your
+phone interprets that as a unique app as well...giving you two Loop apps on the
+phone. Therefore, if changing developer accounts...you will get a new Loop app,
+and you would need a new Pod. You'll need to transfer your settings manually to
+the new app and delete your old app.
 
 ## Will my settings be saved when I update?
 
@@ -41,11 +82,15 @@ Yes. That's why we don't delete the app. Your settings will be saved.
 
 ## Will my pod still work when I update?
 
-Yes. So long as you use the same developer team as you originally built the app with before.
+Yes. So long as you use the same developer team as you originally built the app
+with before.
 
 ## How can I confirm what version was installed?
 
-The Loop's version is given at the top of the Loop settings page. Even better though, the new dev branch has very detailed info about the version of Loop you are using at the top of your Loop's Issue Report. This is a great new addition to help identify where, what, and when of your Loop version.
+The Loop's version is given at the top of the Loop settings page. Even better
+though, the new dev branch has very detailed info about the version of Loop you
+are using at the top of your Loop's Issue Report. This is a great new addition
+to help identify where, what, and when of your Loop version.
 
 <p align="center">
 <img src="../img/loop-version.jpg" width="450">
@@ -53,12 +98,16 @@ The Loop's version is given at the top of the Loop settings page. Even better th
 
 ## What if I'm changing branches? Does that matter?
 
-Does not matter. Moving between branches is an "updating Loop" action. Nothing about the information above changes.
+Does not matter. Moving between branches is an "updating Loop" action. Nothing
+about the information above changes.
 
 ## What if I'm changing phones?
 
-Changing phones is a little different than updating. You will need to change pods in order to move to the new phone's Loop. And you will have to enter all your setting in again. Loop will not be "restored from backup" the way other apps are when switching phones...so you will have to actually build it fresh.
+Changing phones is a little different than updating. You will need to change
+pods in order to move to the new phone's Loop. And you will have to enter all
+your setting in again. Loop will not be "restored from backup" the way other
+apps are when switching phones...so you will have to actually build it fresh.
 
 ## How long does it take?
 
-Assuming your macOS and Xcode updates are done, then plan on about 30 minutes. 
+Assuming your macOS and Xcode updates are done, then plan on about 30 minutes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,13 @@
 
 ## Introduction
 
-[Loop](https://github.com/LoopKit/Loop) is an app template for building an automated insulin delivery system. It is a stone resting on the boulders of work done by many others.  
+[Loop](https://github.com/LoopKit/Loop) is an app template for building an
+automated insulin delivery system. It is a stone resting on the boulders of work
+done by many others.
 
-The app is built on top of [LoopKit](https://github.com/LoopKit/LoopKit). LoopKit is a set of frameworks that provide data storage, retrieval, and calculation, as well as boilerplate view controllers used in Loop.
+The app is built on top of [LoopKit](https://github.com/LoopKit/LoopKit).
+LoopKit is a set of frameworks that provide data storage, retrieval, and
+calculation, as well as boilerplate view controllers used in Loop.
 
 !!!warning "Important"
 
@@ -18,32 +22,66 @@ The app is built on top of [LoopKit](https://github.com/LoopKit/LoopKit). LoopKi
 
       **You take full responsibility for building and running this system and do so at your own risk.**
 
-Using the open-source Loop app template, you can build an insulin delivery system that uses specific commercial and open-source hardware and software technologies to bring together the insulin pump, continuous glucose monitor (CGM), and insulin dosing algorithm to create a continuous insulin basal dosing “Loop”.  This Loop predicts future glucose based on basal-rate schedules, carbohydrate intake, insulin on board, and current CGM readings.  These glucose forecasts provide Loop with the information needed to recommend a temporary basal rate to attain a targeted glucose range in the future.  The system can either operate as an “open-loop” by making recommendations to the user for their approval before enacting or as a “closed-loop” by automatically setting the recommended temporary basal rate. 
+Using the open-source Loop app template, you can build an insulin delivery
+system that uses specific commercial and open-source hardware and software
+technologies to bring together the insulin pump, continuous glucose monitor
+(CGM), and insulin dosing algorithm to create a continuous insulin basal dosing
+“Loop”. This Loop predicts future glucose based on basal-rate schedules,
+carbohydrate intake, insulin on board, and current CGM readings. These glucose
+forecasts provide Loop with the information needed to recommend a temporary
+basal rate to attain a targeted glucose range in the future. The system can
+either operate as an “open-loop” by making recommendations to the user for their
+approval before enacting or as a “closed-loop” by automatically setting the
+recommended temporary basal rate.
 
-You should undertake this project in stages. For example, first “open loop” to familiarize yourself with Loop’s operation. Also, investigate the code to ensure you understand what it is recommending and why. Then when you progress to “closed-loop”, do so safely by starting with appropriate safety limits and only progress to higher limits after several days of no lows. Please ask questions at this point about why Loop is making the recommendations it does.  It should be similar to the therapy decisions you would make yourself.  If the recommendations it makes are different than you would make, try to figure out why.
+You should undertake this project in stages. For example, first “open loop” to
+familiarize yourself with Loop’s operation. Also, investigate the code to ensure
+you understand what it is recommending and why. Then when you progress to
+“closed-loop”, do so safely by starting with appropriate safety limits and only
+progress to higher limits after several days of no lows. Please ask questions at
+this point about why Loop is making the recommendations it does. It should be
+similar to the therapy decisions you would make yourself. If the recommendations
+it makes are different than you would make, try to figure out why.
 
 ## Development History
 
-Loop has been developed as an open-source, shared project.  For a really interesting read about the history of Loop development, check out this [History of Loop and LoopKit](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805) post, written by Loop developer Nate Racklyeft.  The project continues to be a labor-of-love by a community of users; maintained and improved by volunteers.
-
+Loop has been developed as an open-source, shared project. For a really
+interesting read about the history of Loop development, check out this
+[History of Loop and LoopKit](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805)
+post, written by Loop developer Nate Racklyeft. The project continues to be a
+labor-of-love by a community of users; maintained and improved by volunteers.
 
 ## How to Use These Docs
 
-* Use the navigation menu at the top of the screen to find the info you are looking for.
-* A Table of Contents for the current page is always displayed on the left side of the screen.
-* You can search the Loop Docs site by clicking the <img src="img/search_icon.png" width="50px"> icon.
+- Use the navigation menu at the top of the screen to find the info you are
+  looking for.
+- A Table of Contents for the current page is always displayed on the left side
+  of the screen.
+- You can search the Loop Docs site by clicking the
+  <img src="img/search_icon.png" width="50px"> icon.
 
     <img src="img/search_example.png" width="400">
 
-
 ## Stay in the Loop!
 
-[Sign up for the Loop Users announcement list](https://groups.google.com/forum/#!forum/loop-ios-users) to stay informed of critical issues that may arise.
+[Sign up for the Loop Users announcement list](https://groups.google.com/forum/#!forum/loop-ios-users)
+to stay informed of critical issues that may arise.
 
 Join the Zulipchat at [https://loop.zulipchat.com](https://loop.zulipchat.com)
 
-There is also a [Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf) that you might wish to join for support.  When you request to join the group, please remember to check your messages box on facebook and respond to the message.
+There is also a
+[Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf)
+that you might wish to join for support. When you request to join the group,
+please remember to check your messages box on facebook and respond to the
+message.
 
 ## Contribute
 
-Please consider submitting any updates and improvements to the documentation that you want to share by submitting a Pull Request to the [loopdocs repo](https://github.com/LoopKit/loopdocs). For more information on how to contribute to an open-source project, this [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/) guide may be useful. Also, please review the Loop [LICENSE](https://github.com/LoopKit/Loop/blob/master/LICENSE.md) and Loop [CODE_OF_CONDUCT](https://github.com/LoopKit/Loop/blob/master/CODE_OF_CONDUCT.md).
+Please consider submitting any updates and improvements to the documentation
+that you want to share by submitting a Pull Request to the
+[loopdocs repo](https://github.com/LoopKit/loopdocs). For more information on
+how to contribute to an open-source project, this
+[How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+guide may be useful. Also, please review the Loop
+[LICENSE](https://github.com/LoopKit/Loop/blob/master/LICENSE.md) and Loop
+[CODE_OF_CONDUCT](https://github.com/LoopKit/Loop/blob/master/CODE_OF_CONDUCT.md).

--- a/docs/nightscout/azure_migration.md
+++ b/docs/nightscout/azure_migration.md
@@ -1,14 +1,17 @@
 # Migrating from Azure to Heroku
 
-If you are a current Azure user who wants to move to Heroku, but not lose all your old NS data, you will need do the following steps:
+If you are a current Azure user who wants to move to Heroku, but not lose all
+your old NS data, you will need do the following steps:
 
-* update your repository in GitHub
-* create a new heroku nightscout site
-* migrate your mLab database to new site
+- update your repository in GitHub
+- create a new heroku nightscout site
+- migrate your mLab database to new site
 
 ## Updating your repository in GitHub
 
-* Copy, paste, and goto the one of the following links depending on which branch of cgm-remote-monitor you are currently running (replace `yourgithubname` with your actual GitHub user name)
+- Copy, paste, and goto the one of the following links depending on which branch
+  of cgm-remote-monitor you are currently running (replace `yourgithubname` with
+  your actual GitHub user name)
 
 for **master** branch deployments:
 
@@ -18,13 +21,16 @@ For **dev** branch deployments:
 
 `https://github.com/yourgithubname/cgm-remote-monitor/compare/dev...nightscout:dev`
 
-
 <p align="center">
 <img src="../img/compare_repo.jpg" width="450">
-</p> 
+</p>
 
-* Click the big green `Create pull request` button. Another screen will appear, fill in a title and click button to create the pull request, and then you can `Merge pull request`, and finally `Confirm merge`.
-*********
+- Click the big green `Create pull request` button. Another screen will appear,
+  fill in a title and click button to create the pull request, and then you can
+  `Merge pull request`, and finally `Confirm merge`.
+
+---
+
 <p align="center">
 <img src="../img/update1.jpg" width="450">
 </p> 
@@ -38,28 +44,36 @@ For **dev** branch deployments:
 </p> 
 **********
 
-* Your cgm-remote-monitor repository is now up-to-date.  Nice work.
+- Your cgm-remote-monitor repository is now up-to-date. Nice work.
 
 ## Heroku Nightscout Site Setup
 
-* Create an account at [Heroku](https://www.heroku.com) and choose the Primary Development Language to be Node.js when you create your account.  You’re going to use a free account, but you will still need to enter credit card information for your account setup.  Don’t forget to check your email to confirm your Heroku account.
+- Create an account at [Heroku](https://www.heroku.com) and choose the Primary
+  Development Language to be Node.js when you create your account. You’re going
+  to use a free account, but you will still need to enter credit card
+  information for your account setup. Don’t forget to check your email to
+  confirm your Heroku account.
 
 <p align="center">
 <img src="../img/heroku_signup.jpg" width="450">
-</p> 
+</p>
 
-* Go to your Nightscout cgm-remote-monitor repository in GitHub (https://github.com/yourGitHubname/cgm-remote-monitor)
+- Go to your Nightscout cgm-remote-monitor repository in GitHub
+  (https://github.com/yourGitHubname/cgm-remote-monitor)
 
-* Scroll down until you see the purple `Deploy to Heroku` button.  Click that button.
-
+- Scroll down until you see the purple `Deploy to Heroku` button. Click that
+  button.
 
 <p align="center">
 <img src="../img/deploy_heroku.jpg" width="450">
-</p> 
+</p>
 
-* Give your app a name, this will be the prefix of your NS site’s URL. For example, `https://yourappname.herokuapp.com`
+- Give your app a name, this will be the prefix of your NS site’s URL. For
+  example, `https://yourappname.herokuapp.com`
 
-* Fill out the information lines in the `Config Variables` Section of that page, as shown below.  Some of the lines can stay with the default entries already provided.
+- Fill out the information lines in the `Config Variables` Section of that page,
+  as shown below. Some of the lines can stay with the default entries already
+  provided.
 
 <table>
 <thead>
@@ -138,41 +152,58 @@ For **dev** branch deployments:
 
 **The remaining variables can be left at their default values.**</br></br>
 
-* Click the purple `Deploy` button at the bottom of screen
+- Click the purple `Deploy` button at the bottom of screen
 
 <p align="center">
 <img src="../img/deploy_button.jpg" width="450">
-</p> 
+</p>
 
-* Wait a little bit while Heroku builds your NS app.  You’ll see some text scroll by in the Build App box, and then finally, you will have a message that the NS app was successfully deployed.
+- Wait a little bit while Heroku builds your NS app. You’ll see some text scroll
+  by in the Build App box, and then finally, you will have a message that the NS
+  app was successfully deployed.
 
 <p align="center">
 <img src="../img/deploy_success.jpg" width="450">
-</p> 
+</p>
 
-* You can verify your site’s successful build by clicking `View` (you should see black site with a profile warning).  You will be redirected to a profile set-up page.  (If it doesn't redirect automatically, refresh your webpage).  
+- You can verify your site’s successful build by clicking `View` (you should see
+  black site with a profile warning). You will be redirected to a profile set-up
+  page. (If it doesn't redirect automatically, refresh your webpage).
 
 <p align="center">
 <img src="../img/no_profile.jpg" width="450">
-</p> 
+</p>
 
-You do not have to enter all the information in the profile if you are using Loop (since Loop will be providing the information for IOB and COB rather than letting NS calculate them), but you do have to fill out the `Basal Profile` and `TimeZone` at a minimum in order to have your temp basals properly display.  Click `Save` when you have entered the information.  You will be prompted to authenticate, if it is the first time you’ve used the device to make changes in your profile.  Click on the `Authenticate` link at the bottom of the site, and enter your API_SECRET to complete the authentication.
+You do not have to enter all the information in the profile if you are using
+Loop (since Loop will be providing the information for IOB and COB rather than
+letting NS calculate them), but you do have to fill out the `Basal Profile` and
+`TimeZone` at a minimum in order to have your temp basals properly display.
+Click `Save` when you have entered the information. You will be prompted to
+authenticate, if it is the first time you’ve used the device to make changes in
+your profile. Click on the `Authenticate` link at the bottom of the site, and
+enter your API_SECRET to complete the authentication.
 
 <p align="center">
 <img src="../img/profile.jpg" width="450">
-</p> 
+</p>
 
-* Assuming your previous browser tab is still open for "Create a new App | Heroku", let's go back to that tab.  This time instead of choosing the `View` option, we are going to select the `Manage App` button. Then, select the `Settings` tab near the top of the screen on your Heroku app.
+- Assuming your previous browser tab is still open for "Create a new App |
+  Heroku", let's go back to that tab. This time instead of choosing the `View`
+  option, we are going to select the `Manage App` button. Then, select the
+  `Settings` tab near the top of the screen on your Heroku app.
 
 <p align="center">
 <img src="../img/settings_heroku.jpg" width="450">
-</p> 
+</p>
 
-* Click on `Reveal Config  Vars`. Scroll down the bottom of the Config Vars lines until you find the last blank one.  You are going to add several additional lines of config vars for Loop use; the DEVICESTATUS_ADVANCED is a required line, the others just make Nightscout more useful when Looping.
+- Click on `Reveal Config Vars`. Scroll down the bottom of the Config Vars lines
+  until you find the last blank one. You are going to add several additional
+  lines of config vars for Loop use; the DEVICESTATUS_ADVANCED is a required
+  line, the others just make Nightscout more useful when Looping.
 
 <p align="center">
 <img src="../img/add_vars.jpg" width="450">
-</p> 
+</p>
 
 <table>
 <thead>
@@ -239,34 +270,39 @@ You do not have to enter all the information in the profile if you are using Loo
 
 The remaining variables can be left at their default values.</br></br>
 
-* Click on `Open App` in the top right corner of your Heroku site.
+- Click on `Open App` in the top right corner of your Heroku site.
 
 <p align="center">
 <img src="../img/open_app.jpg" width="450">
-</p> 
+</p>
 
-* Click on the settings (those three horizontal lines in upper right corner).  Now check that your basal render is selected to either default or icicle (personal preference for how the temp basals show as blue lines in NS site), check the boxes that you’d like display pills in the SHOW PLUGINS (usually all of them), and then press save. Your new Nightscout site is all set-up.  Congrats!
+- Click on the settings (those three horizontal lines in upper right corner).
+  Now check that your basal render is selected to either default or icicle
+  (personal preference for how the temp basals show as blue lines in NS site),
+  check the boxes that you’d like display pills in the SHOW PLUGINS (usually all
+  of them), and then press save. Your new Nightscout site is all set-up.
+  Congrats!
 
 <p align="center">
 <img src="../img/settings_ns.jpg" width="450">
-</p> 
-
+</p>
 
 ## Migrate mLab database
 
-If you’d like to seamlessly keep all your old Azure NS data showing in your new Heroku NS site, you’ll need to copy and paste your old `MONGODB` string from your Azure site.  Find it in either Application Settings or Connection strings in your Azure control panel and then go to Heroku’s `MONGODB_URI` line.  Replace the content with your copied string from Azure.  Double check that your Azure collection used the “entries” name…if it doesn’t, then you will need to update that variable in Heroku to match as well.
+If you’d like to seamlessly keep all your old Azure NS data showing in your new
+Heroku NS site, you’ll need to copy and paste your old `MONGODB` string from
+your Azure site. Find it in either Application Settings or Connection strings in
+your Azure control panel and then go to Heroku’s `MONGODB_URI` line. Replace the
+content with your copied string from Azure. Double check that your Azure
+collection used the “entries” name…if it doesn’t, then you will need to update
+that variable in Heroku to match as well.
 
 <p align="center">
 <img src="../img/mongo.jpg" width="450">
-</p> 
+</p>
 
 ## EVENT HISTORY
 
-Don't forget to keep you Loop App's Preferred Source set to `Event History` if you want your NS site to smoothly integrate.  Preferred Source set to `Reservoir` will result in carbs not being uploaded and temp basals not being displayed.
-
-
-
-
-
-
-
+Don't forget to keep you Loop App's Preferred Source set to `Event History` if
+you want your NS site to smoothly integrate. Preferred Source set to `Reservoir`
+will result in carbs not being uploaded and temp basals not being displayed.

--- a/docs/nightscout/ifttt.md
+++ b/docs/nightscout/ifttt.md
@@ -1,113 +1,150 @@
 # IFTTT Integration
 
-If This, Then That (IFTTT) is a useful Nightscout integration.  By using IFTTT, you can have single button presses that you can deploy from your iPhone to put a note in your NS site, enter low treatments, log a site change, or log a sensor change. 
-
+If This, Then That (IFTTT) is a useful Nightscout integration. By using IFTTT,
+you can have single button presses that you can deploy from your iPhone to put a
+note in your NS site, enter low treatments, log a site change, or log a sensor
+change.
 
 ## IFTTT Setup for phones
 
-* First we need to gather one thing called your "hashed API Secret". In your internet browser, open a console window while viewing your Nightscout site.  Make sure you have "authenticated" your site by using your API secret in the Nightscout settings area (hint: if you see a little padlock in the upper left corner of the site, you haven't authenticated it).  Refresh the site and your hashed secret key will be shown as "apisecrethash: "xxxxxxxxxx...""  For Safari users on Mac, you can open the console window by selecting "Develop" from the Safari top menu, and then "Show Page Source" (if you do not see "Develop" in the top menu, activate it by going to Safari > Preferences... > Advanced, and checking the "Show Develop menu in menu bar" option).  If you're having problems seeing the apisecrethash, click the little grey triangle next to the "status isAuthenticated" line and the objects below it will display (see screenshot).  Your hashed API secret can be copied and pasted from that line, as shown below.  Save that somewhere easy to get to again, because you will be using it later.
+- First we need to gather one thing called your "hashed API Secret". In your
+  internet browser, open a console window while viewing your Nightscout site.
+  Make sure you have "authenticated" your site by using your API secret in the
+  Nightscout settings area (hint: if you see a little padlock in the upper left
+  corner of the site, you haven't authenticated it). Refresh the site and your
+  hashed secret key will be shown as "apisecrethash: "xxxxxxxxxx..."" For Safari
+  users on Mac, you can open the console window by selecting "Develop" from the
+  Safari top menu, and then "Show Page Source" (if you do not see "Develop" in
+  the top menu, activate it by going to Safari > Preferences... > Advanced, and
+  checking the "Show Develop menu in menu bar" option). If you're having
+  problems seeing the apisecrethash, click the little grey triangle next to the
+  "status isAuthenticated" line and the objects below it will display (see
+  screenshot). Your hashed API secret can be copied and pasted from that line,
+  as shown below. Save that somewhere easy to get to again, because you will be
+  using it later.
 
 <p align="center">
 <img src="../img/hashed_API.png" width="550">
-</p> 
+</p>
 
-* Get an [IFTTT account](https://ifttt.com/join) 
+- Get an [IFTTT account](https://ifttt.com/join)
 
 <p align="center">
 <img src="../img/IFTTT_signup.png" width="550">
-</p> 
+</p>
 
-* Login to your IFTTT.com account and select the "New Applet" button.
+- Login to your IFTTT.com account and select the "New Applet" button.
 
 <p align="center">
 <img src="../img/IFTTT_newapplet.png" width="550">
-</p> 
+</p>
 
-* In the screen that appears, click on the blue "+this" part of the screen
+- In the screen that appears, click on the blue "+this" part of the screen
 
 <p align="center">
 <img src="../img/IFTTT_this.png" width="550">
-</p> 
+</p>
 
-* In the next screen, type "button" in the search field and then click on the red box labelled "ButtonWidget"
+- In the next screen, type "button" in the search field and then click on the
+  red box labelled "ButtonWidget"
 
 <p align="center">
 <img src="../img/IFTTT_button.png" width="550">
-</p> 
+</p>
 
-* Connect the buttonwidget by clicking on the large red "connect" button (You will only have to "connect" the widgets for the first applet you make.  After that the widgets will already connected to your IFTTT account.)
+- Connect the buttonwidget by clicking on the large red "connect" button (You
+  will only have to "connect" the widgets for the first applet you make. After
+  that the widgets will already connected to your IFTTT account.)
 
 <p align="center">
 <img src="../img/IFTTT_connect1.png" width="550">
-</p> 
+</p>
 
-* Click on the large red "button press" box 
+- Click on the large red "button press" box
 
 <p align="center">
 <img src="../img/IFTTT_buttonpress.png" width="550">
-</p> 
+</p>
 
-* Click on the blue "+that" text
+- Click on the blue "+that" text
 
 <p align="center">
 <img src="../img/IFTTT_that.png" width="550">
-</p> 
+</p>
 
-* Enter "Webhooks" in the search field and click on the Webhooks app
+- Enter "Webhooks" in the search field and click on the Webhooks app
 
 <p align="center">
 <img src="../img/webhooks1.png" width="550">
-</p> 
+</p>
 
-* Connect the Webhooks app
+- Connect the Webhooks app
 
 <p align="center">
 <img src="../img/webhooks2.png" width="550">
-</p> 
+</p>
 
-* Select the blue "Make a Web Request" box
+- Select the blue "Make a Web Request" box
 
 <p align="center">
 <img src="../img/webhooks24.png" width="550">
-</p> 
+</p>
 
-*  Now you will have a blank web request template to complete.  Screenshot below is an example of a completed recipe for eating soon IFTTT action.
+- Now you will have a blank web request template to complete. Screenshot below
+  is an example of a completed recipe for eating soon IFTTT action.
 
 <p align="center">
 <img src="../img/webhooks25.png" width="550">
-</p> 
+</p>
 
 The following info should be filled in:
 
-<font color=orange>**URL**:</font> https://yoursite.herokuapp.com/api/v1/treatments.json (**change the "yoursite" part to your NS info**)
+<font color=orange>**URL**:</font>
+https://yoursite.herokuapp.com/api/v1/treatments.json (**change the "yoursite"
+part to your NS info**)
 
 <font color=orange>**Method**:</font> POST
 
 <font color=orange>**Content Type**:</font> application/json
 
-<font color=orange>**Body**:</font>  The content of the body will depend on the action that you would like this particular button press to perform.  You can only do ONE of the actions per button.  There are many recipes available, but not all will work with Loop and NS together.  For example, you can use the Low Treatment recipe to log carbs to NS...but Loop will not read/use those carbs.  That may still be helpful though for remote care givers to leave an indication of when they gave uncovered carbs to treat a low.  You could also set temp targets in NS using IFTTT (recipes can be found on OpenAPS docs), but Loop does not read temp targets from Nightscout at this time.  Some sample content for actions that may be useful in Loop:
+<font color=orange>**Body**:</font> The content of the body will depend on the
+action that you would like this particular button press to perform. You can only
+do ONE of the actions per button. There are many recipes available, but not all
+will work with Loop and NS together. For example, you can use the Low Treatment
+recipe to log carbs to NS...but Loop will not read/use those carbs. That may
+still be helpful though for remote care givers to leave an indication of when
+they gave uncovered carbs to treat a low. You could also set temp targets in NS
+using IFTTT (recipes can be found on OpenAPS docs), but Loop does not read temp
+targets from Nightscout at this time. Some sample content for actions that may
+be useful in Loop:
 
-!!!info "Pump Site Change"
-    {"enteredBy": "IFTTT-button", "eventType": "Site Change", "duration": 0, "secret": "your_hashed_api_goes_here!!!"}
+!!!info "Pump Site Change" {"enteredBy": "IFTTT-button", "eventType": "Site
+Change", "duration": 0, "secret": "your_hashed_api_goes_here!!!"}
 
-!!!info "CGM Sensor Start"
-    {"enteredBy": "IFTTT-button", "eventType": "Sensor Start", "duration": 0, "secret": "your_hashed_api_goes_here!!!"}
+!!!info "CGM Sensor Start" {"enteredBy": "IFTTT-button", "eventType": "Sensor
+Start", "duration": 0, "secret": "your_hashed_api_goes_here!!!"}
 
-!!!info "Note"
-    {"enteredBy": "IFTTT-button", "eventType": "Note", "notes": "Hi mom, please don't text me for a bit.  I'm taking a test.", "secret": "your_hashed_api_goes_here!!!"}
+!!!info "Note" {"enteredBy": "IFTTT-button", "eventType": "Note", "notes": "Hi
+mom, please don't text me for a bit. I'm taking a test.", "secret":
+"your_hashed_api_goes_here!!!"}
 
-!!!info "Low Treatment"
-    {"enteredBy": "IFTTT-button", "reason": "low treatment", "carbs": 15, "secret": "your_hashed_api_goes_here!!!"}
+!!!info "Low Treatment" {"enteredBy": "IFTTT-button", "reason": "low treatment",
+"carbs": 15, "secret": "your_hashed_api_goes_here!!!"}
 
-* Click the `Create Action` button on the bottom of the screen when you finish.
+- Click the `Create Action` button on the bottom of the screen when you finish.
 
-* Now is your chance to change the title of your Applet now to something meaningful.  You can turn on notifications, too, using the slider shown.  If you turn on the notifications, you will get an alert on your phone and pebble watch when the button press has been successfully deployed.  Finish the IFTTT button by clicking on the Finish button that appears.  
+- Now is your chance to change the title of your Applet now to something
+  meaningful. You can turn on notifications, too, using the slider shown. If you
+  turn on the notifications, you will get an alert on your phone and pebble
+  watch when the button press has been successfully deployed. Finish the IFTTT
+  button by clicking on the Finish button that appears.
 
 <p align="center">
 <img src="../img/webhooks26.png" width="550">
-</p> 
+</p>
 
-* Repeat the setup for New Applets for as many automated actions as you would like to setup.
+- Repeat the setup for New Applets for as many automated actions as you would
+  like to setup.
 
 <p align="center">
 <img src="../img/webhooks27.png" width="550">
@@ -115,7 +152,8 @@ The following info should be filled in:
 
 ## Enable IFTTT in your Nightscout site
 
-* Find your Maker Key by going to your IFTTT account, Services and then click on the Webhooks service, settings.
+- Find your Maker Key by going to your IFTTT account, Services and then click on
+  the Webhooks service, settings.
 
 <p align="center">
 <img src="../img/webhooks9.png" width="550">
@@ -123,58 +161,81 @@ The following info should be filled in:
 ********
 <p align="center">
 <img src="../img/webhooks10.png" width="550">
-</p> 
+</p>
 
-* You will see your Maker Key as the last part of the URL; copy and paste that last part (the red circled part as shown)
+- You will see your Maker Key as the last part of the URL; copy and paste that
+  last part (the red circled part as shown)
 
 <p align="center">
 <img src="../img/webhooks11.png" width="550">
-</p> 
+</p>
 
-* Login to your Nightscout site host (azure or heroku) and (1) add your Maker Key to the MAKER_KEY line and (2) add "maker" to your ENABLE line.
+- Login to your Nightscout site host (azure or heroku) and (1) add your Maker
+  Key to the MAKER_KEY line and (2) add "maker" to your ENABLE line.
 
 <p align="center">
 <img src="../img/IFTTT_NSkey.png" width="550">
-</p> 
+</p>
 
 <p align="center">
 <img src="../img/IFTTT_enable.png" width="550">
-</p> 
+</p>
 
 ## Install IFTTT app on your iPhone/Android
 
-* Download the IFTTT app on your phone and log in.
+- Download the IFTTT app on your phone and log in.
 
-* You can add homescreen quick buttons.  Click on your IFTTT app and login, click on My Applets in the bottom right corner, and then click on the applet that you'd like to work with.  From the the middle of the applet, click on the Widget Settings, and then click on the Add button for the Homescreen Icon.
+- You can add homescreen quick buttons. Click on your IFTTT app and login, click
+  on My Applets in the bottom right corner, and then click on the applet that
+  you'd like to work with. From the the middle of the applet, click on the
+  Widget Settings, and then click on the Add button for the Homescreen Icon.
 
 <p align="center">
 <img src="../img/IFTTT_homescreen.PNG" width="550">
-</p> 
+</p>
 
-* For iPhone users, if you downswipe from the top of your iPhone screen, you will have the Today view or Notifications showing.  They are separate pages; Today view is on the left, Notifications is on the right.  You can left/right swipe to go between them.  Go into the Today view and scroll to the bottom, click "edit". This should show a list of existing widgets, followed by a list of "more widgets" with green + signs.  Click on the IFTTT's green circle and the widget will be moved to the top, active widgets area.  You can hold your finger on the three left lines of the IFTTT widget row to drag it to the top of your widget panel, if you prefer to have it as the top-most widget. 
+- For iPhone users, if you downswipe from the top of your iPhone screen, you
+  will have the Today view or Notifications showing. They are separate pages;
+  Today view is on the left, Notifications is on the right. You can left/right
+  swipe to go between them. Go into the Today view and scroll to the bottom,
+  click "edit". This should show a list of existing widgets, followed by a list
+  of "more widgets" with green + signs. Click on the IFTTT's green circle and
+  the widget will be moved to the top, active widgets area. You can hold your
+  finger on the three left lines of the IFTTT widget row to drag it to the top
+  of your widget panel, if you prefer to have it as the top-most widget.
 
 <p align="center">
 <img src="../img/IFTTT_today.PNG" width="550">
-</p> 
+</p>
 
-If you end up with more than four IFTTT applets, they will appear in reverse-order of when they were created...which may not be the same as you'd prefer them to appear on your widget bar.  If you'd like to reorder them:
+If you end up with more than four IFTTT applets, they will appear in
+reverse-order of when they were created...which may not be the same as you'd
+prefer them to appear on your widget bar. If you'd like to reorder them:
 
-  * go into your iPhone's IFTTT app
-  * click on My Applets
-  * click on the gear icon in upper left of screen
-  * click on Widgets
-  * click on the pencil icon in upper right of screen
-  * click and hold the three lines that appear on the right side of the widget that you want to move.  Drag the widget to the order in the list that you'd like it to appear in your widget quickscreen.
+- go into your iPhone's IFTTT app
+- click on My Applets
+- click on the gear icon in upper left of screen
+- click on Widgets
+- click on the pencil icon in upper right of screen
+- click and hold the three lines that appear on the right side of the widget
+  that you want to move. Drag the widget to the order in the list that you'd
+  like it to appear in your widget quickscreen.
 
 <p align="center">
 <img src="../img/IFTTT_reorder.png" width="550">
-</p> 
+</p>
 
 ## Alexa integration
-* Since you have IFTTT/Maker requests working, you can get it to work with anything that supports IFTTT, including Alexa. You will need to add "alexa" to your ENABLE line in your Nightscout host settings (azure) or config vars (heroku).  And then repeat the steps above, but instead of using "ButtonWidget" service we started with earlier (the "+if" part of the setup)...you will use the "AmazonAlexa" service.
+
+- Since you have IFTTT/Maker requests working, you can get it to work with
+  anything that supports IFTTT, including Alexa. You will need to add "alexa" to
+  your ENABLE line in your Nightscout host settings (azure) or config vars
+  (heroku). And then repeat the steps above, but instead of using "ButtonWidget"
+  service we started with earlier (the "+if" part of the setup)...you will use
+  the "AmazonAlexa" service.
 
 <p align="center">
 <img src="../img/alexa_maker.png" width="550">
-</p> 
+</p>
 
-  * Alexa requests do not need underscores, FYI.
+- Alexa requests do not need underscores, FYI.

--- a/docs/nightscout/mlab_cleanup.md
+++ b/docs/nightscout/mlab_cleanup.md
@@ -1,41 +1,67 @@
 # Nightscout Issues
 
-The free Nightscout we use also depends on a free database from mLab.  The free database only has so much room...500 MB to be specific.  After a period of time (it will vary, but usually on the order of months), your mLab database could reach its free limits.  When that happens, your NS site may stop showing data properly.  For example, you may notice your Share Bridge will not pull data and your site will be “stale”.
+The free Nightscout we use also depends on a free database from mLab. The free
+database only has so much room...500 MB to be specific. After a period of time
+(it will vary, but usually on the order of months), your mLab database could
+reach its free limits. When that happens, your NS site may stop showing data
+properly. For example, you may notice your Share Bridge will not pull data and
+your site will be “stale”.
 
-The good news?  Loop can still run just fine until you repair your mLab database.  The bad news?  You just won’t be able to remotely monitor Loop through NS until you clear up some storage space in mLab.
+The good news? Loop can still run just fine until you repair your mLab database.
+The bad news? You just won’t be able to remotely monitor Loop through NS until
+you clear up some storage space in mLab.
 
-!!! info ""
-    These steps **WILL BE NEEDED BY EVERYONE AT SOME POINT IN TIME**...so please don't ignore this troubleshooting. If you see anything suddenly strange about your NS site after it had been working fine, start with these steps below. 
+!!! info "" These steps **WILL BE NEEDED BY EVERYONE AT SOME POINT IN
+TIME**...so please don't ignore this troubleshooting. If you see anything
+suddenly strange about your NS site after it had been working fine, start with
+these steps below.
 
 ## mLab Cleanup
 
-There are two steps to getting your Nightscout site running again. You will need to do both steps.  The first step clears out some space in your database.  The second steps consolidates the remaining data into a more compact space, and therefore makes the data take up less room overall in your database. You need to do both steps to help keep your NS humming along.
+There are two steps to getting your Nightscout site running again. You will need
+to do both steps. The first step clears out some space in your database. The
+second steps consolidates the remaining data into a more compact space, and
+therefore makes the data take up less room overall in your database. You need to
+do both steps to help keep your NS humming along.
 
 ## Step 1: Delete Data
 
-Go to your Nightscout site's settings (the three horizontal bars in the upper right of your Nightscout site) and open your Admin Tools for the site.  Click on the buttons to "Delete all documents" in your Clean Mongo status database section of the Admin Tools.  For good measure, also click on the buttons for removing future items as well.  
+Go to your Nightscout site's settings (the three horizontal bars in the upper
+right of your Nightscout site) and open your Admin Tools for the site. Click on
+the buttons to "Delete all documents" in your Clean Mongo status database
+section of the Admin Tools. For good measure, also click on the buttons for
+removing future items as well.
 
 <p align="center">
 <img src="../img/ns_clean.jpeg" width="250">
-</p> 
+</p>
 
 ## Step 2: Repair Database
 
-Now that you cleared out some database space, we can now make the database more efficient by "repairing" the database.
+Now that you cleared out some database space, we can now make the database more
+efficient by "repairing" the database.
 
-To begin the repair process, click on the mlab link in your Heroku site control panel.
+To begin the repair process, click on the mlab link in your Heroku site control
+panel.
 
 <p align="center">
 <img src="../img/mlab_link.jpg" width="750">
-</p> 
+</p>
 
-Then click on the `Tools` tab in the screen that opens.  Click on the `commands` button and then select the `repairDatabase` from the dropdown menu of available commands.  At the bottom of the screen, select the `Run Command` button. 
+Then click on the `Tools` tab in the screen that opens. Click on the `commands`
+button and then select the `repairDatabase` from the dropdown menu of available
+commands. At the bottom of the screen, select the `Run Command` button.
 
 <p align="center">
 <img src="../img/mlab_compact2.png" width="650">
-</p> 
+</p>
 
-After a short time, you should get a return message of "ok" at the bottom of the command menu box.  If you failed to clear out your Mongo status database before running this command, you will likely not get a successful repair and instead your pointer wheel will just keep spinning.  Make sure you first clean out the database section as described above with your Nightscout Admin Tools.
+After a short time, you should get a return message of "ok" at the bottom of the
+command menu box. If you failed to clear out your Mongo status database before
+running this command, you will likely not get a successful repair and instead
+your pointer wheel will just keep spinning. Make sure you first clean out the
+database section as described above with your Nightscout Admin Tools.
 
-You can verify that your database housekeeping was successful by returning to your NS site and waiting for the next Loop upload.  You should see all your information back in with the next Loop run.
-
+You can verify that your database housekeeping was successful by returning to
+your NS site and waiting for the next Loop upload. You should see all your
+information back in with the next Loop run.

--- a/docs/nightscout/new_user.md
+++ b/docs/nightscout/new_user.md
@@ -1,8 +1,18 @@
 # New Nightscout Users
 
-Two options exist for easy hosting of NS; Azure or Heroku. Both hosting services are free.  However,  Azure has data quotas monthly and shorter term CPU quotas.  If you exceed those quotas, you may be facing a monthly data-use bill or being locked out of NS for about 12 hours until the quotas reset.  As you start to use NS more intensively for alarms, pebble watches, etc…it is possible that you may exceed your monthly data cap on Azure.  Many Loop users have transitioned their old sites from Azure over to Heroku and have found the hosting change to be beneficial.  Heroku also has some memory limits, but those limits have been more than adequate for Loop users.  Therefore, we recommend new users start with Heroku.
+Two options exist for easy hosting of NS; Azure or Heroku. Both hosting services
+are free. However, Azure has data quotas monthly and shorter term CPU quotas. If
+you exceed those quotas, you may be facing a monthly data-use bill or being
+locked out of NS for about 12 hours until the quotas reset. As you start to use
+NS more intensively for alarms, pebble watches, etc…it is possible that you may
+exceed your monthly data cap on Azure. Many Loop users have transitioned their
+old sites from Azure over to Heroku and have found the hosting change to be
+beneficial. Heroku also has some memory limits, but those limits have been more
+than adequate for Loop users. Therefore, we recommend new users start with
+Heroku.
 
-If you are the person who enjoys videos...here's a YouTube video that you can use to walk-through with these directions. Just give it a click.
+If you are the person who enjoys videos...here's a YouTube video that you can
+use to walk-through with these directions. Just give it a click.
 
 <p align="center">
 <a href="https://youtu.be/5WREY465eII" target="_blank"><img src="../img/thumbnail.png" width="650" title="How to build a Nightscout site: Loop Users" /></a>
@@ -10,49 +20,80 @@ If you are the person who enjoys videos...here's a YouTube video that you can us
 
 ## Step 1: Heroku Account
 
-Create an account at <a href="https://signup.heroku.com/login" target="_blank">Heroku's signup page</a>. 
+Create an account at
+<a href="https://signup.heroku.com/login" target="_blank">Heroku's signup
+page</a>.
 
-Enter your name, email address, role ("Hobbyist" is fine) and choose "Node.js" as the Primary Development Language.  When you get all those entered, confirm that you are not a robot and click the blue "Create Free Account" button
+Enter your name, email address, role ("Hobbyist" is fine) and choose "Node.js"
+as the Primary Development Language. When you get all those entered, confirm
+that you are not a robot and click the blue "Create Free Account" button
 
 <p align="center">
 <img src="../img/heroku1.png" width="450">
-</p> 
+</p>
 
-Now follow the directions and check your email to confirm your Heroku account. You'll be asked to create a password...save that password somewhere. You'll likely be logging into heroku as part of Looping in the future, so this is a good password to save.
+Now follow the directions and check your email to confirm your Heroku account.
+You'll be asked to create a password...save that password somewhere. You'll
+likely be logging into heroku as part of Looping in the future, so this is a
+good password to save.
 
 When you finish creating the password, you'll see a screen like below.
 
 <p align="center">
 <img src="../img/heroku2.png" width="450">
-</p> 
+</p>
 
-We have to complete one last step...adding a credit card to your Heroku account. Don't worry, Heroku is still free...but it's only free if you leave a credit card on file. I've used Heroku for 6 years now and never been charged.
+We have to complete one last step...adding a credit card to your Heroku account.
+Don't worry, Heroku is still free...but it's only free if you leave a credit
+card on file. I've used Heroku for 6 years now and never been charged.
 
-To add your credit card, click on the icon of a little ninja person in the upper right corner of the Heroku site, and then select Account Settings and then Billing...or <a href="https://dashboard.heroku.com/account/billing" target="_blank">this should take you right to the billing page for your account</a>. Then click the purple "Add credit card" button. Finish the steps to add a credit card.
+To add your credit card, click on the icon of a little ninja person in the upper
+right corner of the Heroku site, and then select Account Settings and then
+Billing...or
+<a href="https://dashboard.heroku.com/account/billing" target="_blank">this
+should take you right to the billing page for your account</a>. Then click the
+purple "Add credit card" button. Finish the steps to add a credit card.
 
 <p align="center">
 <img src="../img/heroku3.png" width="450">
-</p> 
+</p>
 
-Once you finish that, you can just leave that page/tab alone and move on down to the next step below. 
+Once you finish that, you can just leave that page/tab alone and move on down to
+the next step below.
 
 ## Step 2: Create an account at GitHub
 
-Go to <a href="https://github.com/join" target="_blank">GitHub's signup page</a>. Fill out the information to create your own unique username (write it down), email address, and password (also write this one down). Verify the you are a real person by tossing an animal's image around until it is upright...and then you'll be able to click the green "create an account" at the bottom of the page
+Go to <a href="https://github.com/join" target="_blank">GitHub's signup
+page</a>. Fill out the information to create your own unique username (write it
+down), email address, and password (also write this one down). Verify the you
+are a real person by tossing an animal's image around until it is upright...and
+then you'll be able to click the green "create an account" at the bottom of the
+page
 
 <p align="center">
 <img src="../img/github1.png" width="450">
-</p> 
+</p>
 
-Github will then ask if you want the Free Account (duh, yes). Confirm that (and unclick the Newsletter subscription if you don't want spam).
+Github will then ask if you want the Free Account (duh, yes). Confirm that (and
+unclick the Newsletter subscription if you don't want spam).
 
-Finally, Github will ask you a little about your programming experience and what you are going to use GitHub for...you can answer those or choose the "skip this step" option at the bottom of the screen.
+Finally, Github will ask you a little about your programming experience and what
+you are going to use GitHub for...you can answer those or choose the "skip this
+step" option at the bottom of the screen.
 
-Finally, you'll be sent the email to verify your new account. Go to your emails and click the link sent to you.
+Finally, you'll be sent the email to verify your new account. Go to your emails
+and click the link sent to you.
 
 ## Step 3: Fork and deploy cgm-remote-monitor
 
-Now go to the <a href="https://github.com/nightscout/cgm-remote-monitor" target="_blank">Nightscout cgm-remote-monitor repository</a>. This is where the Nightscout developer's store their code that we are going to borrow a copy of. A copy of code in Github is called a "fork". In the upper right corner, you'll find a little button labeled `Fork`.  Click that button and you'll see a message that GitHub is cloning/forking a copy of that code to your GitHub account.  That is a good thing.  Don't worry it only takes a few seconds.
+Now go to the
+<a href="https://github.com/nightscout/cgm-remote-monitor" target="_blank">Nightscout
+cgm-remote-monitor repository</a>. This is where the Nightscout developer's
+store their code that we are going to borrow a copy of. A copy of code in Github
+is called a "fork". In the upper right corner, you'll find a little button
+labeled `Fork`. Click that button and you'll see a message that GitHub is
+cloning/forking a copy of that code to your GitHub account. That is a good
+thing. Don't worry it only takes a few seconds.
 
 <p align="center">
 <img src="../img/ns_fork.jpg" width="550">
@@ -68,18 +109,27 @@ Once the forking is done, scroll down (below all those folder and file names) un
 Pretty quickly, you should see a Heroku screen popup for "Create New App".  If you see that, you're good to go onto the next step to start setting up the Heroku Nightscout app.
 </br></br>
 
-
 ## Step 4: Setup your Heroku Nightscout app
 
-Heroku calls the code that you just deployed an "app"...but probably easier for most people to imagine it as a website. 
+Heroku calls the code that you just deployed an "app"...but probably easier for
+most people to imagine it as a website.
 
-The first step is to give your "app" a name, this will be the prefix of your soon-to-be-created Nightscout site’s URL. For example, if you enter "janehasthesugars" then your nightscout site's URL will be `https://janehasthesugars.herokuapp.com`
+The first step is to give your "app" a name, this will be the prefix of your
+soon-to-be-created Nightscout site’s URL. For example, if you enter
+"janehasthesugars" then your nightscout site's URL will be
+`https://janehasthesugars.herokuapp.com`
 
 <p align="center">
 <img src="../img/heroku4.png" width="650">
-</p> 
+</p>
 
-Now scroll down a bit and we are going to fill out the information lines in the `Config Vars` section (circled in red above) of that page. There are many variables listed in that section, but we will only *<b>need*</b> to edit a few of them right now to get started. You can always go back later and edit the default values of your BG alarms and other defaults (or do it now, if you'd like). The variables listed below though do need you to make some edits/entries or review that the default settings work for your situation.
+Now scroll down a bit and we are going to fill out the information lines in the
+`Config Vars` section (circled in red above) of that page. There are many
+variables listed in that section, but we will only _<b>need_</b> to edit a few
+of them right now to get started. You can always go back later and edit the
+default values of your BG alarms and other defaults (or do it now, if you'd
+like). The variables listed below though do need you to make some edits/entries
+or review that the default settings work for your situation.
 
 <table>
 <thead>
@@ -117,29 +167,38 @@ Now scroll down a bit and we are going to fill out the information lines in the 
 </table>
 </br>
 
-!!!info "MOST COMMON ERRORS"
-    The `BRIDGE_PASSWORD` and `BRIDGE_USER_NAME` are NOT visible from within your Dexcom app or online account. The values for them are what you entered into your Dexcom mobile app when you VERY FIRST logged into that app however long ago. The `BRIDGE_USER_NAME` is not an email address. The most common error on initial Nightscout setups is that people incorrectly use an old account or an old password. To test your username and password, go to <a href="https://clarity.dexcom.com" target="_blank">Dexcom's Clarity</a> page and try logging into your Dexcom account. If your account info doesn't let you in, or you don't see data in your Clarity account...then you need to figure out your actual credentials before moving ahead.
+!!!info "MOST COMMON ERRORS" The `BRIDGE_PASSWORD` and `BRIDGE_USER_NAME` are
+NOT visible from within your Dexcom app or online account. The values for them
+are what you entered into your Dexcom mobile app when you VERY FIRST logged into
+that app however long ago. The `BRIDGE_USER_NAME` is not an email address. The
+most common error on initial Nightscout setups is that people incorrectly use an
+old account or an old password. To test your username and password, go to
+<a href="https://clarity.dexcom.com" target="_blank">Dexcom's Clarity</a> page
+and try logging into your Dexcom account. If your account info doesn't let you
+in, or you don't see data in your Clarity account...then you need to figure out
+your actual credentials before moving ahead.
 
-!!!info ""
-    If you are using Dexcom Share outside the United States, you will need to make sure you have EU in the BRIDGE_SERVER.
-    </br>
-    <table>
-    <thead>
-    <tr>
-    <th>KEY</th>
-    <th>VALUE</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-    <th>BRIDGE_SERVER</th>
-    <p alighn="left"><td>EU</td>
-    </tr>
-    </tbody>
-    </table>
+!!!info "" If you are using Dexcom Share outside the United States, you will
+need to make sure you have EU in the BRIDGE_SERVER. </br>
 
-Now that we have all the variables fixed up, click the purple `Deploy` button at the bottom of screen
-</br></br>
+<table>
+<thead>
+<tr>
+<th>KEY</th>
+<th>VALUE</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<th>BRIDGE_SERVER</th>
+<p alighn="left"><td>EU</td>
+</tr>
+</tbody>
+</table>
+
+Now that we have all the variables fixed up, click the purple `Deploy` button at
+the bottom of screen </br></br>
+
 <p align="center">
 <img src="../img/deploy_button.jpg" width="650">
 </p> 
@@ -155,7 +214,8 @@ Click on the `Manage App` button and then we will move onto the next step.
 
 ## Step 5: Additional Variables
 
-Select the `Settings` tab near the top of the screen on your Heroku app. Click on `Reveal Config  Vars` button that will be partway down the page. 
+Select the `Settings` tab near the top of the screen on your Heroku app. Click
+on `Reveal Config Vars` button that will be partway down the page.
 
 <p align="center">
 <img src="../img/heroku5.png" width="650">
@@ -217,36 +277,59 @@ Finally, I recommend deleting the `PAPERTRAIL_API_TOKEN` line. Heroku offers a f
 
 ## Step 6: Setup Profile
 
-Now that we have finished all the variable setup, scroll up to the top of the page and click on the `Open App` button in the top right corner of your Heroku site.
+Now that we have finished all the variable setup, scroll up to the top of the
+page and click on the `Open App` button in the top right corner of your Heroku
+site.
 
 <p align="center">
 <img src="../img/open_app.jpg" width="650">
-</p> 
+</p>
 
-You will see black site with a profile warning at the top of the screen. Confirm to redirect to a profile set-up page.  (If it doesn't redirect automatically, refresh your webpage...might have to push the button a few times).  
+You will see black site with a profile warning at the top of the screen. Confirm
+to redirect to a profile set-up page. (If it doesn't redirect automatically,
+refresh your webpage...might have to push the button a few times).
 
 <p align="center">
 <img src="../img/no_profile.jpg" width="450">
-</p> 
+</p>
 
-You do not have to enter all the information in the profile if you are using Loop (since Loop will be providing the information for IOB and COB rather than letting NS calculate them), but you do have to fill out the `TimeZone`. That one is non-negotiable. I highly recommend also filling in the `Insulin to carb ratio`, `Insulin Sensitivity Factor`, and `Basal Rates` so that your information is properly displayed in Nightscout. To be clear, those values you enter in the Profile will not affect your Loop in anyway, because Loop will not read them from Nightscout. New versions of Loop will also update these values in this Profile if you change the corresponding settings in Loop. So really, this is just a one-time setup and after that Loop will do the work of updating these values. 
+You do not have to enter all the information in the profile if you are using
+Loop (since Loop will be providing the information for IOB and COB rather than
+letting NS calculate them), but you do have to fill out the `TimeZone`. That one
+is non-negotiable. I highly recommend also filling in the
+`Insulin to carb ratio`, `Insulin Sensitivity Factor`, and `Basal Rates` so that
+your information is properly displayed in Nightscout. To be clear, those values
+you enter in the Profile will not affect your Loop in anyway, because Loop will
+not read them from Nightscout. New versions of Loop will also update these
+values in this Profile if you change the corresponding settings in Loop. So
+really, this is just a one-time setup and after that Loop will do the work of
+updating these values.
 
-Click `Save` when you have entered the information.  You will be prompted to authenticate, if it is the first time you’ve used the device to make changes in your profile.  Click on the `Authenticate` link at the bottom of the site, and enter your API_SECRET to complete the authentication.
+Click `Save` when you have entered the information. You will be prompted to
+authenticate, if it is the first time you’ve used the device to make changes in
+your profile. Click on the `Authenticate` link at the bottom of the site, and
+enter your API_SECRET to complete the authentication.
 
 <p align="center">
 <img src="../img/profile.jpg" width="650">
-</p> 
+</p>
 
 </br></br>
 
-Close out of the Profile Editor to return to the main Nightscout page and configure your NS settings.
+Close out of the Profile Editor to return to the main Nightscout page and
+configure your NS settings.
 
 ## Step 7: Nightscout Settings
-The last step is to finish your Nightscout's settings. Click on the settings (those three horizontal lines in upper right corner).  Now check that you have everything displaying correctly:
 
-* `Render Basal` is set to either default or icicle (totally personal preference for how the temp basals show as blue lines in NS site)
-* Theme is set to Colors
-* Check the boxes that you’d like display pills in the SHOW PLUGINS (usually all of them except Openaps) section.
+The last step is to finish your Nightscout's settings. Click on the settings
+(those three horizontal lines in upper right corner). Now check that you have
+everything displaying correctly:
+
+- `Render Basal` is set to either default or icicle (totally personal preference
+  for how the temp basals show as blue lines in NS site)
+- Theme is set to Colors
+- Check the boxes that you’d like display pills in the SHOW PLUGINS (usually all
+  of them except Openaps) section.
 
 <p align="center">
 <img src="../img/settings_ns.jpg" width="650">
@@ -256,16 +339,32 @@ Save the settings changes and you'll be on your way! Congrats!!
 
 ## Step 8: Loop Settings
 
-Don't forget to enter your new Nightscout site into your Loop settings! That way Loop can upload all the juicy great info directly to your Nightscout site (except CGM data...that is all handled by that BRIDGE info you put in earlier)
+Don't forget to enter your new Nightscout site into your Loop settings! That way
+Loop can upload all the juicy great info directly to your Nightscout site
+(except CGM data...that is all handled by that BRIDGE info you put in earlier)
 
-Directions [here](https://loopkit.github.io/loopdocs/operation/loop-settings/services/#nightscout) as well as warnings about the two most common errors when people add the URL to Loop settings. (Hint hint hint)
+Directions
+[here](https://loopkit.github.io/loopdocs/operation/loop-settings/services/#nightscout)
+as well as warnings about the two most common errors when people add the URL to
+Loop settings. (Hint hint hint)
 
 ## Troubleshooting
 
-If your site is not showing CGM (and Loop, if you are Looping) data within about 10 minutes of finishing your setup, then please follow these steps [here](https://loopkit.github.io/loopdocs/nightscout/troublehoot/) to troubleshoot.
+If your site is not showing CGM (and Loop, if you are Looping) data within about
+10 minutes of finishing your setup, then please follow these steps
+[here](https://loopkit.github.io/loopdocs/nightscout/troublehoot/) to
+troubleshoot.
 
 ## Future warning
 
-At some point in the future months, your Nightscout site will likely stop in some quirky way...like CGM data won't be showing is the most common. This won't affect Looping, but it might be kind of annoying if you are a parent using Nightscout for remote info. The reason? The database Heroku gives us for free has some size limitations. After several months of Looping, you'll likely fill up that free amount of space and we will need to cleanout in order to make room.
+At some point in the future months, your Nightscout site will likely stop in
+some quirky way...like CGM data won't be showing is the most common. This won't
+affect Looping, but it might be kind of annoying if you are a parent using
+Nightscout for remote info. The reason? The database Heroku gives us for free
+has some size limitations. After several months of Looping, you'll likely fill
+up that free amount of space and we will need to cleanout in order to make room.
 
-So...keep it in your head that if you see something odd with your NS site (like no CGM even though Dexcom is working), then please check [this page to learn how you can cleanout the database](https://loopkit.github.io/loopdocs/nightscout/mlab_cleanup/). It is easy and fast...no worries.
+So...keep it in your head that if you see something odd with your NS site (like
+no CGM even though Dexcom is working), then please check
+[this page to learn how you can cleanout the database](https://loopkit.github.io/loopdocs/nightscout/mlab_cleanup/).
+It is easy and fast...no worries.

--- a/docs/nightscout/overview.md
+++ b/docs/nightscout/overview.md
@@ -1,12 +1,22 @@
 # Overview
 
-Nightscout (NS) is an excellent tool for remotely viewing Loop's actions.  It allows for easy remote monitoring of Loop activities, troubleshooting of Loop errors, history of CGM, carbs, boluses, & temp basals, reports analyzing data trends and patterns. There is a Nightscout app in your iPhone App Store, or you can use a web browser to view the data.  Setting up Nightscout is free and fairly quick.  Once set up, the site can be accessed by anyone that you share your unique Nightscout URL with.  
+Nightscout (NS) is an excellent tool for remotely viewing Loop's actions. It
+allows for easy remote monitoring of Loop activities, troubleshooting of Loop
+errors, history of CGM, carbs, boluses, & temp basals, reports analyzing data
+trends and patterns. There is a Nightscout app in your iPhone App Store, or you
+can use a web browser to view the data. Setting up Nightscout is free and fairly
+quick. Once set up, the site can be accessed by anyone that you share your
+unique Nightscout URL with.
 
-Nightscout is highly recommended for Loop users, especially those using Loop as caregivers to t1ds.  Nightscout displays are often the easiest way to troubleshoot Loop settings, if you are having problems and seeking input from others.  Below is some discussion about the general Nightscout display, as well as some Loop-specific display information.
+Nightscout is highly recommended for Loop users, especially those using Loop as
+caregivers to t1ds. Nightscout displays are often the easiest way to
+troubleshoot Loop settings, if you are having problems and seeking input from
+others. Below is some discussion about the general Nightscout display, as well
+as some Loop-specific display information.
 
 <p align="center">
 <img src="../img/example.jpg" width="600">
-</p> 
+</p>
 
 </br>
 <dl>
@@ -32,8 +42,7 @@ Nightscout is highly recommended for Loop users, especially those using Loop as 
 <dd>The Loop pill is the little display box which when hovered over, or clicked, will provide additional information about recent Loop activities and status.  Information included is the last time Loop ran, the temp basal set, IOB, and COB.  Looking at the Loop pill is a quick method for assessing if you loop is currently active, as well.</br>
 
 !!! info "Loop Pill status indicator symbols"
-    <font style='font-size: 1.2em;'>X</font> &nbsp;
-    Error in Loop
+<font style='font-size: 1.2em;'>X</font> &nbsp; Error in Loop
 
     <font style='font-size: 1.4em;'>ϕ</font> &nbsp;
     Recommending basal, but not enacting (open loop or pump suspended)
@@ -46,7 +55,11 @@ Nightscout is highly recommended for Loop users, especially those using Loop as 
 
     <font style='font-size: 1.5em;'>⚠</font> &nbsp;
     Warning (Loop has not completed since since the time set on your LOOP_WARN setting in NS)
-Mouseover or Touch the Loop pill to view a tool tip containing one or more of the latest status messages. The most up-to-date NS also includes information in the Loop pill for the minimum and maximum predicted BG, eventual and predicted BG.
+
+Mouseover or Touch the Loop pill to view a tool tip containing one or more of
+the latest status messages. The most up-to-date NS also includes information in
+the Loop pill for the minimum and maximum predicted BG, eventual and predicted
+BG.
 
 <img src="../img/loop_pill_message.png" width="750"></dd>
 

--- a/docs/nightscout/pebble.md
+++ b/docs/nightscout/pebble.md
@@ -1,12 +1,19 @@
 # Pebble Watchface
 
-The Pebble Watchface called `SkyLoop Predict` can be used with either Loop or OpenAPS systems.  You will need to have a Nightscout website setup and integrated in order for the watchface to work.  Simply use your Pebble app to search for the watchface and install it.  In the watchface settings, enter your Nightscout URL in the Data Endpoint field, select Loop for the system, and enter `iob` in the T1 Name field.  By entering `iob`, the watchface will display the iob on the watchface.  In addition to the information displayed on the main watchface screen, shaking your wrist will bring up information about the pump battery and reservoir levels.
+The Pebble Watchface called `SkyLoop Predict` can be used with either Loop or
+OpenAPS systems. You will need to have a Nightscout website setup and integrated
+in order for the watchface to work. Simply use your Pebble app to search for the
+watchface and install it. In the watchface settings, enter your Nightscout URL
+in the Data Endpoint field, select Loop for the system, and enter `iob` in the
+T1 Name field. By entering `iob`, the watchface will display the iob on the
+watchface. In addition to the information displayed on the main watchface
+screen, shaking your wrist will bring up information about the pump battery and
+reservoir levels.
 
 <p align="center">
 <img src="../img/skyloop.png" width="700">
-</p> 
-
+</p>
 
 <p align="center">
 <img src="../img/skyloop1.jpg" width="700">
-</p> 
+</p>

--- a/docs/nightscout/pushover.md
+++ b/docs/nightscout/pushover.md
@@ -1,18 +1,48 @@
 # Remote notifications
 
-While Loop app currently sends notifications locally on Loop user's iPhone, parents and caregivers likely want those messages on their phones, too.  We can achieve this functionality through a combination of Nightscout, IFTTT, Google, and Pushover.
+While Loop app currently sends notifications locally on Loop user's iPhone,
+parents and caregivers likely want those messages on their phones, too. We can
+achieve this functionality through a combination of Nightscout, IFTTT, Google,
+and Pushover.
 
-Traditionally, most people may already know of Pushover alerts through their NS site.  The old Loop docs had setup for how to add your `PUSHOVER_ANNOUNCEMENT_KEY` , `PUSHOVER_API_TOKEN`, and `PUSHOVER_USER_KEY` in your Heroku settings to get notifications on the non-looping phones of parents and caregivers.  The drawback for that method is that you could not necessarily fine tune the alerts (maybe you wanted battery alarms on your NS website, but not get pushovers for them...a bit hard to separate out the environments that way) and Pushover had a demanding acknowledgement requirement.  If you failed to acknowledge an alert, you may end up getting alarm fatigue fairly quickly as the alarm repeated itself.
+Traditionally, most people may already know of Pushover alerts through their NS
+site. The old Loop docs had setup for how to add your
+`PUSHOVER_ANNOUNCEMENT_KEY` , `PUSHOVER_API_TOKEN`, and `PUSHOVER_USER_KEY` in
+your Heroku settings to get notifications on the non-looping phones of parents
+and caregivers. The drawback for that method is that you could not necessarily
+fine tune the alerts (maybe you wanted battery alarms on your NS website, but
+not get pushovers for them...a bit hard to separate out the environments that
+way) and Pushover had a demanding acknowledgement requirement. If you failed to
+acknowledge an alert, you may end up getting alarm fatigue fairly quickly as the
+alarm repeated itself.
 
-Using Pushover <i>**THROUGH**</i> IFTTT however, we can improve the possible notifications and who receives which ones.  For example, a teenage Looper may want notifications when his/her pump site needs changing and when his/her dexcom is about to expire in the next day.  S/he already gets local notifications on his/her phone via Loop for low reservoir volumes, low pump battery, and Loop failures.  Dexcom app provides high/low BG notifications locally, too.  If s/he were to get those same alarms via Pushover, s/he would inevitably get alarm fatigue.  A remotely-monitoring parent may want additional information, like a pushover alerts when the school nurse bolused for lunch, as well as Loop failures, low iPhone battery level for the child, low pump battery, and other such information that might be useful.  Perhaps there's also an emergency contact person that you only want to get high/low BG alerts...you can set that up as well quite easily.
+Using Pushover <i>**THROUGH**</i> IFTTT however, we can improve the possible
+notifications and who receives which ones. For example, a teenage Looper may
+want notifications when his/her pump site needs changing and when his/her dexcom
+is about to expire in the next day. S/he already gets local notifications on
+his/her phone via Loop for low reservoir volumes, low pump battery, and Loop
+failures. Dexcom app provides high/low BG notifications locally, too. If s/he
+were to get those same alarms via Pushover, s/he would inevitably get alarm
+fatigue. A remotely-monitoring parent may want additional information, like a
+pushover alerts when the school nurse bolused for lunch, as well as Loop
+failures, low iPhone battery level for the child, low pump battery, and other
+such information that might be useful. Perhaps there's also an emergency contact
+person that you only want to get high/low BG alerts...you can set that up as
+well quite easily.
 
-The basic concept is that NS puts out an event that triggers the IFTTT service called Webhooks (old name was "Maker Webhooks" hence you may see references to "maker" in NS docs).  Actually, there are several types of events that NS has programmed in all ready to use in IFTTT.
+The basic concept is that NS puts out an event that triggers the IFTTT service
+called Webhooks (old name was "Maker Webhooks" hence you may see references to
+"maker" in NS docs). Actually, there are several types of events that NS has
+programmed in all ready to use in IFTTT.
 
 <p align="center">
 <img src="../img/ns-core-events.png" width="700">
 </p>
 
-For this setup, we are going to use the most general logging event called `ns-event`.  You'll get all the alarms and notifications logged, and then you can decide in subsequent steps which ones you'd actually like to send to your phone for pushover notification.
+For this setup, we are going to use the most general logging event called
+`ns-event`. You'll get all the alarms and notifications logged, and then you can
+decide in subsequent steps which ones you'd actually like to send to your phone
+for pushover notification.
 
 As a brief roadmap for what we are going to do:
 
@@ -20,41 +50,51 @@ As a brief roadmap for what we are going to do:
 2. Add a folder to your Google Drive
 3. Make an IFTTT applet to log NS events to your Google Spreadsheets
 4. Enable NS to work with that new IFTTT applet
-5. Make an IFTTT applet to send Pushover alert when the Google Spreadsheet is updated
+5. Make an IFTTT applet to send Pushover alert when the Google Spreadsheet is
+   updated
 
 ## Get Prepped
 
-If you don't already have these steps done, you will need them.  Skip any that you already have done.
+If you don't already have these steps done, you will need them. Skip any that
+you already have done.
 
-* Setup a Nightscout site
-* Get an [IFTTT account](https://ifttt.com)
-* Get a [Pushover Account](https://pushover.net)
-* Get a [Google Account](https://accounts.google.com/SignUp)
-* Download the Pushover app onto your phone, and any other phone you'd like to receive Pushover alerts
-* Download the IFTTT app onto your phone, and any other phone you'd like to use IFTTT applets on
-* Login to the Pushover and IFTTT apps with your login information
+- Setup a Nightscout site
+- Get an [IFTTT account](https://ifttt.com)
+- Get a [Pushover Account](https://pushover.net)
+- Get a [Google Account](https://accounts.google.com/SignUp)
+- Download the Pushover app onto your phone, and any other phone you'd like to
+  receive Pushover alerts
+- Download the IFTTT app onto your phone, and any other phone you'd like to use
+  IFTTT applets on
+- Login to the Pushover and IFTTT apps with your login information
 
 ## Add a Google Drive folder
 
-* Login to your Google account and select Google Drive
+- Login to your Google account and select Google Drive
 
 <p align="center">
 <img src="../img/google1.png" width="550">
 </p>
 
-* Click on the blue "New" button and create a new folder named IFTTT.
+- Click on the blue "New" button and create a new folder named IFTTT.
 
 <p align="center">
 <img src="../img/google2.png" width="550">
 </p>
 
-* Double click on the newly created IFTTT folder, select the blue "New" button again, and create a new subfolder called "Nightscout-Alarms"
+- Double click on the newly created IFTTT folder, select the blue "New" button
+  again, and create a new subfolder called "Nightscout-Alarms"
 
 <p align="center">
 <img src="../img/google3.png" width="550">
 </p>
 
-This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spreadsheets, one for each NS alarm or information that is logged.  As new alarms are triggered, the IFTTT applet we are about to write will add a row to the appropriate spreadsheet logging the time of the alarm and any other reported details that go with the entry.  For now though, your drive will be blank...screenshot below just to give you an idea of where we are going.
+This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google
+Spreadsheets, one for each NS alarm or information that is logged. As new alarms
+are triggered, the IFTTT applet we are about to write will add a row to the
+appropriate spreadsheet logging the time of the alarm and any other reported
+details that go with the entry. For now though, your drive will be
+blank...screenshot below just to give you an idea of where we are going.
 
 <p align="center">
 <img src="../img/google4.png" width="550">
@@ -62,67 +102,85 @@ This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spre
 
 ## Make 1st IFTTT Applet to Log NS Alarms
 
-* Login to your IFTTT.com account and select the "New Applet" button.
+- Login to your IFTTT.com account and select the "New Applet" button.
 
 <p align="center">
 <img src="../img/IFTTT_newapplet.png" width="550">
 </p>
 
-* In the screen that appears, click on the blue "+this" part of the screen
+- In the screen that appears, click on the blue "+this" part of the screen
 
 <p align="center">
 <img src="../img/IFTTT_this.png" width="550">
 </p>
 
-* In the next screen, type "webhooks" in the search field and then click on the blue connect button
+- In the next screen, type "webhooks" in the search field and then click on the
+  blue connect button
 
 <p align="center">
 <img src="../img/webhooks1.png" width="550">
 </p>
 
-* If this is the first time you are using IFTTT Webhooks service, you will have a "Connect" button to select.  If you already have IFTTT applets using Webhooks, you won't see this screen...just move to the next bullet.
+- If this is the first time you are using IFTTT Webhooks service, you will have
+  a "Connect" button to select. If you already have IFTTT applets using
+  Webhooks, you won't see this screen...just move to the next bullet.
 
 <p align="center">
 <img src="../img/webhooks2.png" width="550">
 </p>
 
-* Click on the "receive a web request" blue box, and then fill in the Event Name as `ns-event` and then press the "Create trigger" button.  (Side note:  the event name used here corresponds to the triggers discussed above for core events that NS already has integrated for IFTTT users.  If you want to instead use the other triggers such as ns-warn or ns-urgent, you can.  This example is using the most general trigger so that the options are wider for most users.)
+- Click on the "receive a web request" blue box, and then fill in the Event Name
+  as `ns-event` and then press the "Create trigger" button. (Side note: the
+  event name used here corresponds to the triggers discussed above for core
+  events that NS already has integrated for IFTTT users. If you want to instead
+  use the other triggers such as ns-warn or ns-urgent, you can. This example is
+  using the most general trigger so that the options are wider for most users.)
 
 <p align="center">
 <img src="../img/webhooks3.png" width="550">
 </p>
 
-* Click on the blue "+that" text
+- Click on the blue "+that" text
 
 <p align="center">
 <img src="../img/IFTTT_that2.png" width="550">
 </p>
 
-* Enter `google` in the search field and click on the Google Sheets icon
+- Enter `google` in the search field and click on the Google Sheets icon
 
 <p align="center">
 <img src="../img/webhooks4.png" width="550">
 </p>
 
-* Select the green "Add row to spreadsheet" box
+- Select the green "Add row to spreadsheet" box
 
 <p align="center">
 <img src="../img/webhooks5.png" width="550">
 </p>
 
-*  Delete the contents of the "Spreadsheet Name" and "Drive folder path".  For the "Spreadsheet Name", click the "Add Ingredient" button and select the "Value1".  For the "Drive folder path", enter `IFTTT/Nightscout-Alarms`.  You do not have to modify the "Formatted row" box's contents.  Click the "Create action" button at the bottom.
+- Delete the contents of the "Spreadsheet Name" and "Drive folder path". For the
+  "Spreadsheet Name", click the "Add Ingredient" button and select the "Value1".
+  For the "Drive folder path", enter `IFTTT/Nightscout-Alarms`. You do not have
+  to modify the "Formatted row" box's contents. Click the "Create action" button
+  at the bottom.
 
 <p align="center">
 <img src="../img/webhooks6.png" width="550">
 </p>
 
-* Turn off the toggle for receiving notifications when the applet runs, and then click the Finish button
+- Turn off the toggle for receiving notifications when the applet runs, and then
+  click the Finish button
 
 <p align="center">
 <img src="../img/webhooks7.png" width="550">
 </p>
 
-* You'll now have the finished IFTTT applet that will cause a row to be added to a Google spreadsheet...tracking all your NS notifications and alarms.  If it is the first time that alarm has been logged, the applet will also create the spreadsheet itself.  After awhile, your IFTTT/Nightscout-Alarms folder will start to look like the screenshot posted above with numerous spreadsheets for each alarm type.
+- You'll now have the finished IFTTT applet that will cause a row to be added to
+  a Google spreadsheet...tracking all your NS notifications and alarms. If it is
+  the first time that alarm has been logged, the applet will also create the
+  spreadsheet itself. After awhile, your IFTTT/Nightscout-Alarms folder will
+  start to look like the screenshot posted above with numerous spreadsheets for
+  each alarm type.
 
 <p align="center">
 <img src="../img/webhooks8.png" width="550">
@@ -130,10 +188,15 @@ This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spre
 
 ## Enable IFTTT Webhooks in your Nightscout site
 
-!!!info ""
-    If you already have created IFTTT buttons previously to work with your NS site, you can skip this section.  If those buttons are working, then you've already added your MAKER_KEY and "maker" to your ENABLE line in Heroku.
+!!!info "" If you already have created IFTTT buttons previously to work with
+your NS site, you can skip this section. If those buttons are working, then
+you've already added your MAKER_KEY and "maker" to your ENABLE line in Heroku.
 
-* To actually make that first applet work, we need to enter a "Maker Key" to get NS and IFTTT talking to each other.  Find your Maker Key by going to your IFTTT account, Services and then clicking on Webhooks.  (Your screen may not have as many services showing; the example account below just happens to already use several services.)
+- To actually make that first applet work, we need to enter a "Maker Key" to get
+  NS and IFTTT talking to each other. Find your Maker Key by going to your IFTTT
+  account, Services and then clicking on Webhooks. (Your screen may not have as
+  many services showing; the example account below just happens to already use
+  several services.)
 
 <p align="center">
 <img src="../img/webhooks9.png" width="550">
@@ -143,13 +206,16 @@ This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spre
 <img src="../img/webhooks10.png" width="550">
 </p>
 
-* You will see your Maker Key as the last part of the URL; copy that last part (the red circled part)
+- You will see your Maker Key as the last part of the URL; copy that last part
+  (the red circled part)
 
 <p align="center">
 <img src="../img/webhooks11.png" width="550">
 </p>
 
-* Navigate to your Heroku account's settings tab, "reveal config vars" and (1) add your Maker Key to the MAKER_KEY line and (2) add "maker" to your ENABLE line.
+- Navigate to your Heroku account's settings tab, "reveal config vars" and (1)
+  add your Maker Key to the MAKER_KEY line and (2) add "maker" to your ENABLE
+  line.
 
 <p align="center">
 <img src="../img/IFTTT_NSkey.png" width="550">
@@ -161,86 +227,108 @@ This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spre
 
 ## Make 2nd IFTTT Applet to send Pushover notifications
 
-* In your IFTTT account, select the "New Applet" button.
+- In your IFTTT account, select the "New Applet" button.
 
 <p align="center">
 <img src="../img/webhooks12.png" width="550">
 </p>
 
-* In the screen that appears, click on the blue "+this" part of the screen
+- In the screen that appears, click on the blue "+this" part of the screen
 
 <p align="center">
 <img src="../img/IFTTT_this.png" width="550">
 </p>
 
-* In the next screen, type "google" in the search field and then click on the "Google Sheets" logo.
+- In the next screen, type "google" in the search field and then click on the
+  "Google Sheets" logo.
 
 <p align="center">
 <img src="../img/webhooks4.png" width="550">
 </p>
 
-* Click on the "New row added to spreadsheet" as the trigger.
+- Click on the "New row added to spreadsheet" as the trigger.
 
 <p align="center">
 <img src="../img/webhooks13.png" width="550">
 </p>
 
-* Enter the following information:  Folder path is `IFTTT/Nightscout-Alarms` and for filename you are going to enter the name of the particular NS alarm or information that you would like to get pushover alerts for.  Click on the "Create trigger" button to save the trigger.
+- Enter the following information: Folder path is `IFTTT/Nightscout-Alarms` and
+  for filename you are going to enter the name of the particular NS alarm or
+  information that you would like to get pushover alerts for. Click on the
+  "Create trigger" button to save the trigger.
 
 <p align="center">
 <img src="../img/webhooks14.png" width="550">
 </p>
 
-!!!info ""
-    This applet can't be created unless your filename (alarm spreadsheet) already exists.  If your 1st applet we created above hasn't run for a long time, the spreadsheets may not exist yet because the alarms haven't triggered.  You have two options...(1) manually create the file in your Google Drive so that you can finish the applet now or (2) wait several days/weeks for the alarms to happen and that will automatically create the files in your Google drive.</br></br>
-    If you choose option 1, here's a partial list of some of the filenames you could create in advance:
-    
-    * Loop isn't looping
-    * Cannula age 48 hours
-    * Cannula age 72 hours
-    * Meal Bolus
-    * Warning, Pump Reservoir Low
-    * Warning Uploader Battery is Low
-    
-    Depending on your alert levels you specified in NS, some of the hours in the titles may vary to match your settings
+!!!info "" This applet can't be created unless your filename (alarm spreadsheet)
+already exists. If your 1st applet we created above hasn't run for a long time,
+the spreadsheets may not exist yet because the alarms haven't triggered. You
+have two options...(1) manually create the file in your Google Drive so that you
+can finish the applet now or (2) wait several days/weeks for the alarms to
+happen and that will automatically create the files in your Google
+drive.</br></br> If you choose option 1, here's a partial list of some of the
+filenames you could create in advance:
 
-* Click on the blue "+that" text
+_ Loop isn't looping _ Cannula age 48 hours _ Cannula age 72 hours _ Meal Bolus
+_ Warning, Pump Reservoir Low _ Warning Uploader Battery is Low
+
+Depending on your alert levels you specified in NS, some of the hours in the
+titles may vary to match your settings
+
+- Click on the blue "+that" text
 
 <p align="center">
 <img src="../img/IFTTT_that2.png" width="550">
 </p>
 
-* Enter `pushover` in the search field and click on the Pushover icon.  If this is your first time linking your IFTTT to Pushover, you will be prompted to enter your Pushover account login and allow IFTTT access.  This only needs to be done once.
+- Enter `pushover` in the search field and click on the Pushover icon. If this
+  is your first time linking your IFTTT to Pushover, you will be prompted to
+  enter your Pushover account login and allow IFTTT access. This only needs to
+  be done once.
 
 <p align="center">
 <img src="../img/webhooks15.png" width="550">
 </p>
 
-* Select the "Send a Pushover notification" box
+- Select the "Send a Pushover notification" box
 
 <p align="center">
 <img src="../img/webhooks16.png" width="550">
 </p>
 
-*  Delete the contents of the "Title" and "Message" and "URL" boxes.  For the Title, click the "Add Ingredient" button and add `ColumnC`.  For the "Message", click the "Add Ingredient" button and add the values of various columns from your spreadsheet for the infomation you would like to include.  For the alerts: `ColumnC` contains the alarm name, `ColumnA` is the date/time of the alarm, and `ColumnD` has the more detailed information about the info/alarm.  This is a pretty decent recipe to follow to get the useful information in your notification.
+- Delete the contents of the "Title" and "Message" and "URL" boxes. For the
+  Title, click the "Add Ingredient" button and add `ColumnC`. For the "Message",
+  click the "Add Ingredient" button and add the values of various columns from
+  your spreadsheet for the infomation you would like to include. For the alerts:
+  `ColumnC` contains the alarm name, `ColumnA` is the date/time of the alarm,
+  and `ColumnD` has the more detailed information about the info/alarm. This is
+  a pretty decent recipe to follow to get the useful information in your
+  notification.
 
 <p align="center">
 <img src="../img/webhooks17.png" width="550">
 </p>
 
-* Select the "Message Priority" that you would like for this particular alarm type.
+- Select the "Message Priority" that you would like for this particular alarm
+  type.
 
 <p align="center">
 <img src="../img/webhooks18.png" width="550">
 </p>
 
-* Select the "Device" that you would like to receive this particular alarm type.  The devices listed will be all your devices that have Pushover app installed and logged into.  Click "Create Action" when you are finished.
+- Select the "Device" that you would like to receive this particular alarm type.
+  The devices listed will be all your devices that have Pushover app installed
+  and logged into. Click "Create Action" when you are finished.
 
 <p align="center">
 <img src="../img/webhooks19.png" width="550">
 </p>
 
-* You'll now have made the IFTTT applet that will cause a Pushover notification to a particular device for a particular NS alarm, once the first applet records the alarm in the google spreadsheet.  Keep the "receive notification when this Applet runs" toggled off and click the Finish button.
+- You'll now have made the IFTTT applet that will cause a Pushover notification
+  to a particular device for a particular NS alarm, once the first applet
+  records the alarm in the google spreadsheet. Keep the "receive notification
+  when this Applet runs" toggled off and click the Finish button.
 
 <p align="center">
 <img src="../img/webhooks20.png" width="550">
@@ -248,7 +336,15 @@ This IFTTT/Nightscout-Alarms folder will eventually contain numerous Google Spre
 
 ## Revisit Nightscout Alert Levels
 
-Putting all these notifications together may cause you to want to revisit the alert levels you have set in your Heroku settings.  Here's a short summary of NS for the looping-related alerts (Note: the last row, Upbat, is the Looping iPhone battery level for Loop users; or the rig's battery level for OpenAPS users.)  If you'd like some of these alarms for your site and don't currently have them activated (they are all off by default unless specifically turned on), the lines you'd need to add are in the last column.  If you like the default values of the WARN and/or URGENT, you don't have to add those extra lines...just the line to enable the alerts will be sufficient.
+Putting all these notifications together may cause you to want to revisit the
+alert levels you have set in your Heroku settings. Here's a short summary of NS
+for the looping-related alerts (Note: the last row, Upbat, is the Looping iPhone
+battery level for Loop users; or the rig's battery level for OpenAPS users.) If
+you'd like some of these alarms for your site and don't currently have them
+activated (they are all off by default unless specifically turned on), the lines
+you'd need to add are in the last column. If you like the default values of the
+WARN and/or URGENT, you don't have to add those extra lines...just the line to
+enable the alerts will be sufficient.
 
 <table>
 <thead>
@@ -323,20 +419,36 @@ Putting all these notifications together may cause you to want to revisit the al
 </tbody>
 </table>
 
-
 ## Final notes
 
-* You can use other notification services than Pushover in the last part of the second applet.  For example, you could use the SMS service to send text notifications to your iPhone instead of Pushover.  The downside for that is that the SMS service is limited to 100 message each month...some users may exceed that pretty easily.  Another alternative notification would be IFTTT's own Notification service.  This would work well, but does not have the ability to distinguish between devices the way Pushover allows.  If you use IFTTT's Notifications service, every phone using your IFTTT account will get the notices.
+- You can use other notification services than Pushover in the last part of the
+  second applet. For example, you could use the SMS service to send text
+  notifications to your iPhone instead of Pushover. The downside for that is
+  that the SMS service is limited to 100 message each month...some users may
+  exceed that pretty easily. Another alternative notification would be IFTTT's
+  own Notification service. This would work well, but does not have the ability
+  to distinguish between devices the way Pushover allows. If you use IFTTT's
+  Notifications service, every phone using your IFTTT account will get the
+  notices.
 
-* To be clear, you do <i>**NOT**</i> need to have pushover on your ENABLE line nor have `PUSHOVER_USER_KEY`, `PUSHOVER_API_TOKEN`, or `PUSHOVER_ANNOUNCEMENT_KEY` entered into your Heroku settings in order for any of the above to work.  This is not the same Pushover as NS has integrated into it's code.  This is actually through IFTTT services, you just need a Pushover account to link to during the 2nd applet setup.
+- To be clear, you do <i>**NOT**</i> need to have pushover on your ENABLE line
+  nor have `PUSHOVER_USER_KEY`, `PUSHOVER_API_TOKEN`, or
+  `PUSHOVER_ANNOUNCEMENT_KEY` entered into your Heroku settings in order for any
+  of the above to work. This is not the same Pushover as NS has integrated into
+  it's code. This is actually through IFTTT services, you just need a Pushover
+  account to link to during the 2nd applet setup.
 
-* To create more notifications, simply repeat the steps for the 2nd applet you created, only this time use a new filename that corresponds to the spreadsheet tracking the alert you'd like notifications for.  You'll end up with multiple applets of the dark blue type (the pushover notifiers) and only a single light blue (NS alarm general collector).
+- To create more notifications, simply repeat the steps for the 2nd applet you
+  created, only this time use a new filename that corresponds to the spreadsheet
+  tracking the alert you'd like notifications for. You'll end up with multiple
+  applets of the dark blue type (the pushover notifiers) and only a single light
+  blue (NS alarm general collector).
 
 <p align="center">
 <img src="../img/webhooks23.png" width="550">
 </p>
 
-* Here's examples of the Meal Bolus and Temp Basal ns-event logging spreadsheets
+- Here's examples of the Meal Bolus and Temp Basal ns-event logging spreadsheets
 
 <p align="center">
 <img src="../img/webhooks21.png" width="550">
@@ -346,5 +458,10 @@ Putting all these notifications together may cause you to want to revisit the al
 <img src="../img/webhooks22.png" width="550">
 </p>
 
-* The 1st applet can only create up to 2000 active rows in a given spreadsheet.  After that, the applet will automatically create a new spreadsheet.  For most alarms, it may take quite sometime to reach 2000 rows of info.  For other alerts, such as temp basals being set, that may fill up rather fast for the average looper.  You can either clean out the data rows periodically to make room, or update your filename in the 2nd applet periodically when a new spreadsheet is made.
-
+- The 1st applet can only create up to 2000 active rows in a given spreadsheet.
+  After that, the applet will automatically create a new spreadsheet. For most
+  alarms, it may take quite sometime to reach 2000 rows of info. For other
+  alerts, such as temp basals being set, that may fill up rather fast for the
+  average looper. You can either clean out the data rows periodically to make
+  room, or update your filename in the 2nd applet periodically when a new
+  spreadsheet is made.

--- a/docs/nightscout/reports.md
+++ b/docs/nightscout/reports.md
@@ -1,12 +1,14 @@
 # Reports
 
-Nightscout offer some fantastic data-crunching report tools in the settings area (the upper right corner, three horizontal lines).  You can play around with various date ranges, target ranges, and provide reports to your endocrinologist to review.
-
+Nightscout offer some fantastic data-crunching report tools in the settings area
+(the upper right corner, three horizontal lines). You can play around with
+various date ranges, target ranges, and provide reports to your endocrinologist
+to review.
 
 <p align="center">
 <img src="../img/distribution.jpg" width="700">
-</p> 
+</p>
 
 <p align="center">
 <img src="../img/percentile.jpg" width="y00">
-</p> 
+</p>

--- a/docs/nightscout/troublehoot.md
+++ b/docs/nightscout/troublehoot.md
@@ -1,55 +1,94 @@
 # Setup Troubleshooting
 
-If you have just tried to setup your Nightscout site and have problems with seeing all your data, please checkout the information below.
+If you have just tried to setup your Nightscout site and have problems with
+seeing all your data, please checkout the information below.
 
 ## Dexcom data not showing
 
-If you are using a Dexcom system, and your data is not appearing in Nightscout, there are only a limited number of reasons for that. You should check your (1) Heroku settings and (2) Dexcom Share.
+If you are using a Dexcom system, and your data is not appearing in Nightscout,
+there are only a limited number of reasons for that. You should check your (1)
+Heroku settings and (2) Dexcom Share.
 
-NOTE: The #1 reason why BGs aren't showing is because you have mismatched password and user names in Heroku settings and Dexcom. Please see blue box below for that error.
+NOTE: The #1 reason why BGs aren't showing is because you have mismatched
+password and user names in Heroku settings and Dexcom. Please see blue box below
+for that error.
 
 ### Heroku Settings
 
-Login to your Heroku account and from within Heroku settings, click on the  `Reveal Config Vars`
+Login to your Heroku account and from within Heroku settings, click on the
+`Reveal Config Vars`
 
 <p align="center">
 <img src="../img/config-vars.png" width="800">
-</p> 
+</p>
 
-Now from the `Config Vars` area, check the following (see screenshot below for reference):
+Now from the `Config Vars` area, check the following (see screenshot below for
+reference):
 
-1. You must use the same `BRIDGE_PASSWORD` or `BRIDGE_USER_NAME` that your Dexcom mobile app is using.
-2. You must have `bridge` and `careportal` on the `ENABLE` line (you can have other values there...but don't forget these two).
-3. If you are outside the USA, you must add `BRIDGE_SERVER` set to `EU` in Heroku settings.
-4. Your `careportal` must be one word in the `ENABLE` line, sometimes autocorrect makes it two words.
-5. If using `mmol`, make sure you have spelled that value correctly in the `DISPLAY_UNITS`.
+1. You must use the same `BRIDGE_PASSWORD` or `BRIDGE_USER_NAME` that your
+   Dexcom mobile app is using.
+2. You must have `bridge` and `careportal` on the `ENABLE` line (you can have
+   other values there...but don't forget these two).
+3. If you are outside the USA, you must add `BRIDGE_SERVER` set to `EU` in
+   Heroku settings.
+4. Your `careportal` must be one word in the `ENABLE` line, sometimes
+   autocorrect makes it two words.
+5. If using `mmol`, make sure you have spelled that value correctly in the
+   `DISPLAY_UNITS`.
 
 <p align="center">
 <img src="../img/bridge-settings.jpg" width="600">
-</p> 
+</p>
 
-One things that can happen if you have an incorrect Dexcom login/password in Loop's CGM Share account settings and/or in your Nightscout BRIDGE settings is that Dexcom will lock your account...and you won't see CGM data in Nightscout. If you notice your CGM readings disappeared, but everything else is flowing...check your heroku logs that are viewable by selecting "View Logs" from the drop down menu underneath the "More" option. 
+One things that can happen if you have an incorrect Dexcom login/password in
+Loop's CGM Share account settings and/or in your Nightscout BRIDGE settings is
+that Dexcom will lock your account...and you won't see CGM data in Nightscout.
+If you notice your CGM readings disappeared, but everything else is
+flowing...check your heroku logs that are viewable by selecting "View Logs" from
+the drop down menu underneath the "More" option.
 
 <p align="center">
 <img src="../img/heroku-logs.png" width="800">
-</p> 
+</p>
 
+Do your logs have "SSO authentication errors" like in the red box highlighted
+above? If you do, then:
 
-Do your logs have "SSO authentication errors" like in the red box highlighted above? If you do, then:
+1. Delete your share account entry from your Loop's CGM account settings...like
+   you should have NO ENTRY in your share account settings WITHIN LOOP CGM
+   SETTINGS.
 
-1. Delete your share account entry from your Loop's CGM account settings...like you should have NO ENTRY in your share account settings WITHIN LOOP CGM SETTINGS.
+2. Delete your BRIDGE entries within heroku settings. Don't delete the rows,
+   just delete the entries within BRIDGE_PASSWORD and BRIDGE_USER_NAME.
 
-2. Delete your BRIDGE entries within heroku settings.  Don't delete the rows, just delete the entries within BRIDGE_PASSWORD and BRIDGE_USER_NAME.
+3. Wait 15 minutes and then follow the directions in the blue box below. It is
+   important to wait the 15 minutes...the reason you can't login right now is
+   that your Dexcom account has a temporary lock from one of the passwords in
+   step 1 or 2 being incorrect. The temporary lock will expire after 10-15
+   minutes of giving the account login a break from the incorrect logins. So,
+   definitely wait or else you'll just keep prolonging the issue.
 
-3. Wait 15 minutes and then follow the directions in the blue box below. It is important to wait the 15 minutes...the reason you can't login right now is that your Dexcom account has a temporary lock from one of the passwords in step 1 or 2 being incorrect. The temporary lock will expire after 10-15 minutes of giving the account login a break from the incorrect logins. So, definitely wait or else you'll just keep prolonging the issue.
-
-
-!!!info "About your Bridge password and user name"
-    The `BRIDGE_PASSWORD` and `BRIDGE_USER_NAME` are NOT visible from within your Dexcom mobile app or online account. The values of them are what you entered into your Dexcom mobile app when you VERY FIRST logged into that app however long ago. If you have double-checked everything else that could be incorrect and BGs still aren't showing in Nightscout, then you likely have those Bridge values incorrect. To fix that, delete your Dexcom app (don't stop the session before deleting the app...just keep it going). Download the app again from the iPhone's App store and login to the freshly-downloaded Dexcom app. **Take note** that deleting the app will not stop your session, your session will pick right back up once the transmitter pairs again. The `BRIDGE_USER_NAME` is not an email address. Use that exact same login now in your Heroku settings. You can leave your Loop's Share account info blank...you just need the transmitter ID going forward.
-    
+!!!info "About your Bridge password and user name" The `BRIDGE_PASSWORD` and
+`BRIDGE_USER_NAME` are NOT visible from within your Dexcom mobile app or online
+account. The values of them are what you entered into your Dexcom mobile app
+when you VERY FIRST logged into that app however long ago. If you have
+double-checked everything else that could be incorrect and BGs still aren't
+showing in Nightscout, then you likely have those Bridge values incorrect. To
+fix that, delete your Dexcom app (don't stop the session before deleting the
+app...just keep it going). Download the app again from the iPhone's App store
+and login to the freshly-downloaded Dexcom app. **Take note** that deleting the
+app will not stop your session, your session will pick right back up once the
+transmitter pairs again. The `BRIDGE_USER_NAME` is not an email address. Use
+that exact same login now in your Heroku settings. You can leave your Loop's
+Share account info blank...you just need the transmitter ID going forward.
 
 ### Dexcom Share
-Make sure you have Dexcom Share turned ON in your Dexcom app. In the Dexcom app's main screen, find the triangle made of dots. If the dots are grey, you do not have Share turned on. Tap the triangle, and follow the directions to add a follower (yourself if you don't have someone else you'd like to invite) and turn on Share.
+
+Make sure you have Dexcom Share turned ON in your Dexcom app. In the Dexcom
+app's main screen, find the triangle made of dots. If the dots are grey, you do
+not have Share turned on. Tap the triangle, and follow the directions to add a
+follower (yourself if you don't have someone else you'd like to invite) and turn
+on Share.
 
 <p align="center">
 <img src="../img/sharing.jpg" width="250">
@@ -57,4 +96,8 @@ Make sure you have Dexcom Share turned ON in your Dexcom app. In the Dexcom app'
 
 ## Loop data not showing
 
-If your BG data is showing, but Loop data is not (like Loop pill is empty and carbs and boluses are not showing), please delete your Nightscout account in Loop settings area. Enter the information in freshly. Make sure to use `https://` to start the site URL. Make sure there is no trailing slash at the end of the URL. Make sure you have `loop` on the ENABLE line in Heroku settings.
+If your BG data is showing, but Loop data is not (like Loop pill is empty and
+carbs and boluses are not showing), please delete your Nightscout account in
+Loop settings area. Enter the information in freshly. Make sure to use
+`https://` to start the site URL. Make sure there is no trailing slash at the
+end of the URL. Make sure you have `loop` on the ENABLE line in Heroku settings.

--- a/docs/nightscout/update_user.md
+++ b/docs/nightscout/update_user.md
@@ -1,10 +1,14 @@
 # Adding Loop to Existing NS
 
-Many people may already have an existing Nightscout site setup from before adding Loop to their management strategies. In order to make the most of your Looping setup, you will need to modify your existing Nightscout site a bit specifically for Loop. The process is pretty easy and should not take long.
+Many people may already have an existing Nightscout site setup from before
+adding Loop to their management strategies. In order to make the most of your
+Looping setup, you will need to modify your existing Nightscout site a bit
+specifically for Loop. The process is pretty easy and should not take long.
 
 ## New Loopers Variables
 
-The modifications for retrofitting an existing NS site for new Loop users will require you to make some edits to your Heroku site.  There are five steps:
+The modifications for retrofitting an existing NS site for new Loop users will
+require you to make some edits to your Heroku site. There are five steps:
 
 1. Login to Heroku, Open Settings Tab
 2. Edit/Add Config Vars
@@ -14,19 +18,23 @@ The modifications for retrofitting an existing NS site for new Loop users will r
 
 ### Step 1: Login to Heroku, Settings Tab
 
-[Login to your Heroku account](https://id.heroku.com/login), select the `Settings` tab near the top of the screen on your Heroku app.
+[Login to your Heroku account](https://id.heroku.com/login), select the
+`Settings` tab near the top of the screen on your Heroku app.
 
 <p align="center">
 <img src="../img/settings_heroku.jpg" width="450">
-</p> 
+</p>
 
 ### Step 2: Edit/Add Config Vars
 
-Click on `Reveal Config Vars`.  Scroll down the bottom of the Config Vars lines until you find the last blank one.  You are going to add several additional lines of config vars for Loop use; the DEVICESTATUS_ADVANCED and ENABLE lines are required, the others just make Nightscout more useful when Looping.
+Click on `Reveal Config Vars`. Scroll down the bottom of the Config Vars lines
+until you find the last blank one. You are going to add several additional lines
+of config vars for Loop use; the DEVICESTATUS_ADVANCED and ENABLE lines are
+required, the others just make Nightscout more useful when Looping.
 
 <p align="center">
 <img src="../img/add_vars.jpg" width="450">
-</p> 
+</p>
 
 <table>
 <thead>
@@ -102,39 +110,67 @@ Click on `Open App` in the top right corner of your Heroku site.
 
 <p align="center">
 <img src="../img/open_app.jpg" width="450">
-</p> 
+</p>
 
 ### Step 4: Turn on Plugins
 
-Click on the settings (those three horizontal lines in upper right corner).  Now check that your basal render is selected to either default or icicle (personal preference for how the temp basals show as blue lines in NS site), check the boxes that you’d like display pills in the SHOW PLUGINS (usually all of them), and then press save. If you have not authenticated your site previously, you may be prompted to provide your API Secret prior to Nightscout saving your changes. 
+Click on the settings (those three horizontal lines in upper right corner). Now
+check that your basal render is selected to either default or icicle (personal
+preference for how the temp basals show as blue lines in NS site), check the
+boxes that you’d like display pills in the SHOW PLUGINS (usually all of them),
+and then press save. If you have not authenticated your site previously, you may
+be prompted to provide your API Secret prior to Nightscout saving your changes.
 
 <p align="center">
 <img src="../img/settings_ns.jpg" width="450">
-</p> 
+</p>
 
 ### Step 5: Update Profile Settings
 
-Double check that your NS Profile settings are current and that you have a basal profile entered, if you want to see the temp basals that Loop is setting. The values in your Nightscout Profile settings will not impact or affect your Loop, but it is just nice to have them match up in the event you are looking at your data with an endocrinologist or retrospectively looking at data.
+Double check that your NS Profile settings are current and that you have a basal
+profile entered, if you want to see the temp basals that Loop is setting. The
+values in your Nightscout Profile settings will not impact or affect your Loop,
+but it is just nice to have them match up in the event you are looking at your
+data with an endocrinologist or retrospectively looking at data.
 
 ## Nightscout Version Update
-If you are new to Loop and haven’t updated your NS site since before December 1, 2016, you will want to update your NS site. You can run either the "master" or "dev" branches of cgm-remote-monitor with Loop.  To check what version your Nightscout site is running, go to your Nightscout site and pull open the site settings by clicking on the three horizontal lines at the top right of the screen.  The version number is at the bottom.
 
-Nightscout has a tool to help you update your Nightscout site and you can find the [directions using to the update tool here](http://www.nightscout.info/wiki/welcome/how-to-update-to-latest-cgm-remote-monitor-aka-cookie).
+If you are new to Loop and haven’t updated your NS site since before December 1,
+2016, you will want to update your NS site. You can run either the "master" or
+"dev" branches of cgm-remote-monitor with Loop. To check what version your
+Nightscout site is running, go to your Nightscout site and pull open the site
+settings by clicking on the three horizontal lines at the top right of the
+screen. The version number is at the bottom.
 
-Simply put, the [Update tool](http://nightscout.github.io/pages/update-fork/) will look at your GitHub repository and check if your Nightscout code is old and needs updating.  You will have to be logged into your GitHub account in order for the tool to work, so do that before starting this process.
+Nightscout has a tool to help you update your Nightscout site and you can find
+the
+[directions using to the update tool here](http://www.nightscout.info/wiki/welcome/how-to-update-to-latest-cgm-remote-monitor-aka-cookie).
+
+Simply put, the [Update tool](http://nightscout.github.io/pages/update-fork/)
+will look at your GitHub repository and check if your Nightscout code is old and
+needs updating. You will have to be logged into your GitHub account in order for
+the tool to work, so do that before starting this process.
 
 <p align="center">
 <img src="../img/ns-tool.png" width="750">
 </p> 
 </br>
-You'll click on the green `Continue updating at GitHub` button, read the directions that will appear as a pop-up and then finish the update process. 
+You'll click on the green `Continue updating at GitHub` button, read the directions that will appear as a pop-up and then finish the update process.
 
-Click the big green `Create pull request` button. 
+Click the big green `Create pull request` button.
 
-* For most people, another screen will appear like shown in the screenshots below with a green `Able to merge` message. Fill in a title and click button to create the pull request, and then you can `Merge pull request`, and finally `Confirm merge`.</br>
+- For most people, another screen will appear like shown in the screenshots
+  below with a green `Able to merge` message. Fill in a title and click button
+  to create the pull request, and then you can `Merge pull request`, and finally
+  `Confirm merge`.</br>
 
-* However, for some of you may encounter a red error message `x Can't automatically merge` message. If you have that message, you may want to post in FB for help on resolving that error message before proceeding any further.
-*********
+- However, for some of you may encounter a red error message
+  `x Can't automatically merge` message. If you have that message, you may want
+  to post in FB for help on resolving that error message before proceeding any
+  further.
+
+---
+
 <p align="center">
 <img src="../img/update1.jpg" width="650">
 </p> 
@@ -149,7 +185,10 @@ Click the big green `Create pull request` button.
 **********
 Your cgm-remote-monitor repository is now up-to-date.  Nice work, and almost done.
 
-If you don’t have your Heroku set-up to automatically update when your repository is updated, you will have to go into your Heroku `Deploy` section and manually deploy your branch now that your repository has been updated.  Make sure you are connected to your GitHub cgm-remote-monitor repository.
+If you don’t have your Heroku set-up to automatically update when your
+repository is updated, you will have to go into your Heroku `Deploy` section and
+manually deploy your branch now that your repository has been updated. Make sure
+you are connected to your GitHub cgm-remote-monitor repository.
 
 <p align="center">
 <img src="../img/deploy_branch.jpg" width="750">

--- a/docs/operation/algorithm/bolus.md
+++ b/docs/operation/algorithm/bolus.md
@@ -1,15 +1,43 @@
 # Bolus Recommendations
 
-Loop will recommend bolus insulin corrections when the eventual blood glucose is greater than the correction target and the active insulin plus any active 30-minute temporary basal will not be sufficient to cover the predicted excursion above correction target. These recommendations are not proactively sent to the Loop user through any notification or banner alert; the recommendation is only viewable when the user clicks on the bolus tool. Note that Loop never issues a bolus command automatically; all boluses are initiated by the user. 
+Loop will recommend bolus insulin corrections when the eventual blood glucose is
+greater than the correction target and the active insulin plus any active
+30-minute temporary basal will not be sufficient to cover the predicted
+excursion above correction target. These recommendations are not proactively
+sent to the Loop user through any notification or banner alert; the
+recommendation is only viewable when the user clicks on the bolus tool. Note
+that Loop never issues a bolus command automatically; all boluses are initiated
+by the user.
 
-The bolus dose calculation is identical to the dose equation given in the basal recommendations section, with the exception that:
+The bolus dose calculation is identical to the dose equation given in the basal
+recommendations section, with the exception that:
 
-* the insulin contribution from the currently running temporary basal set by Loop is removed or subtracted from the recommended bolus amount, and  
-* the delta is calculated for the top of the correction range, rather than the average of the correction range.
+- the insulin contribution from the currently running temporary basal set by
+  Loop is removed or subtracted from the recommended bolus amount, and
+- the delta is calculated for the top of the correction range, rather than the
+  average of the correction range.
 
-For recently saved carbohydrates where the projected carbohydrate absorption will outlast the insulin activity duration (e.g., very slow-digesting meals like pizza or pasta), Loop’s algorithm will inherently decrease the initial meal bolus — to prevent hypoglycemia events that often occur after these meals — by only recommending enough bolus to prevent going below the correction range. As described above, the Loop algorithm computes the recommended bolus such that predicted glucose will not dip below the correction range. This may result in future blood glucose levels predicted above correction range, but will prevent a hypoglycemia event shortly after the meal (as is sometimes occurs for people giving a "pizza bolus" in traditional pump therapy). Loop will then later make corrections by issuing higher temporary basals. In effect, this algorithm behavior mimics traditional pump therapy of “extended” or “dual wave” bolusing, but with the benefit of added information about actual carbohydrate absorption effects as time goes by.
+For recently saved carbohydrates where the projected carbohydrate absorption
+will outlast the insulin activity duration (e.g., very slow-digesting meals like
+pizza or pasta), Loop’s algorithm will inherently decrease the initial meal
+bolus — to prevent hypoglycemia events that often occur after these meals — by
+only recommending enough bolus to prevent going below the correction range. As
+described above, the Loop algorithm computes the recommended bolus such that
+predicted glucose will not dip below the correction range. This may result in
+future blood glucose levels predicted above correction range, but will prevent a
+hypoglycemia event shortly after the meal (as is sometimes occurs for people
+giving a "pizza bolus" in traditional pump therapy). Loop will then later make
+corrections by issuing higher temporary basals. In effect, this algorithm
+behavior mimics traditional pump therapy of “extended” or “dual wave” bolusing,
+but with the benefit of added information about actual carbohydrate absorption
+effects as time goes by.
 
-Finally, Loop checks that the result of the calculations is below the maximum single bolus the Loop user specified in their settings. If the calculated bolus is less than the maximum single bolus setting, then the recommended bolus will be displayed in Loop’s bolus tool.
+Finally, Loop checks that the result of the calculations is below the maximum
+single bolus the Loop user specified in their settings. If the calculated bolus
+is less than the maximum single bolus setting, then the recommended bolus will
+be displayed in Loop’s bolus tool.
 
-!!!info "Bolusing safety feature"
-    If the current blood glucose, or any predicted blood glucose, falls below the suspend threshold, Loop will not return a recommended bolus. When the minimum blood glucose rises above the suspend threshold, the bolus tool will provide a recommended bolus.
+!!!info "Bolusing safety feature" If the current blood glucose, or any predicted
+blood glucose, falls below the suspend threshold, Loop will not return a
+recommended bolus. When the minimum blood glucose rises above the suspend
+threshold, the bolus tool will provide a recommended bolus.

--- a/docs/operation/algorithm/overview.md
+++ b/docs/operation/algorithm/overview.md
@@ -1,12 +1,15 @@
 # Overview
 
-Loop’s algorithm for adjusting insulin delivery is oriented around making a blood glucose prediction. Every five minutes, triggered by new blood glucose data, it generates a new prediction. Both [bolus recommendations](bolus) and [temporary basal rates](temp_basal) are set based on this prediction.
+Loop’s algorithm for adjusting insulin delivery is oriented around making a
+blood glucose prediction. Every five minutes, triggered by new blood glucose
+data, it generates a new prediction. Both [bolus recommendations](bolus) and
+[temporary basal rates](temp_basal) are set based on this prediction.
 
 ## Terminology
 
-This graph and legend illustrates terms commonly used in discussing Loop's algorithm,
-and shows them in the context of historical and forecasted blood glucose in style similar to the
-status screen of Loop.
+This graph and legend illustrates terms commonly used in discussing Loop's
+algorithm, and shows them in the context of historical and forecasted blood
+glucose in style similar to the status screen of Loop.
 
 ![Chart illustrating terms](img/terms_graph.png)
 
@@ -51,4 +54,3 @@ status screen of Loop.
 <dd>Active insulin is the remaining amount of insulin activity from boluses and temporary basal rates relative to a user’s scheduled basal rates. More specifically, it is the total amount of insulin activity due to all bolus and basal insulin delivered within the last N hours, where N is determined by the insulin activity duration. The amount of “active” insulin depends upon the insulin activity curve, and also accounts for the insulin withheld via basal suspensions. As such, it is possible that the active insulin can be negative. Negative active insulin will result in an increase in predicted blood glucose. The active insulin displayed in Loop's main display does not reflect the currently enacted temporary basal rate, as that basal rate may be canceled or modified before completion over the next 30 minutes. In others words, Loop doesn't count chickens before the eggs hatch...insulin delivery must be confirmed before being added to the active insulin reporting.</dt></br>
 
 </dl>
-

--- a/docs/operation/algorithm/prediction.md
+++ b/docs/operation/algorithm/prediction.md
@@ -1,82 +1,177 @@
 # Blood Glucose Prediction
 
-Loop uses an algorithm to maintain blood glucose in a correction range by predicting the contributions from four individual effects (insulin, carbohydrates, retrospective correction, and blood glucose momentum) at any time *t* to recommend temporary basal rate corrections and boluses. 
+Loop uses an algorithm to maintain blood glucose in a correction range by
+predicting the contributions from four individual effects (insulin,
+carbohydrates, retrospective correction, and blood glucose momentum) at any time
+_t_ to recommend temporary basal rate corrections and boluses.
 
 ![combined effects basic equation](img/predicted_glucose_equation.png)
 
-You can see the individual contributions of these effects by tapping on the predicted blood glucose chart on Loop's status screen. Loop updates this blood glucose prediction every five minutes when a new CGM value has been received and the pump's status has been updated.
+You can see the individual contributions of these effects by tapping on the
+predicted blood glucose chart on Loop's status screen. Loop updates this blood
+glucose prediction every five minutes when a new CGM value has been received and
+the pump's status has been updated.
 
-Just a note, this whole section is fairly technical. While perhaps not the most interesting topic for many readers, if you are seeking the detailed view of the Loop algorithm this discussion is quite useful. If you want a more surface understanding, the overview and temporary basal recommendations sections alone are probably sufficient.
+Just a note, this whole section is fairly technical. While perhaps not the most
+interesting topic for many readers, if you are seeking the detailed view of the
+Loop algorithm this discussion is quite useful. If you want a more surface
+understanding, the overview and temporary basal recommendations sections alone
+are probably sufficient.
 
 ## Overview
-Before we delve into each of the four individual effects, a general overview figure may be a helpful start. There are four effects summed together to produce Loop's final predicted blood glucose curve. Each individual effect, along with their combined effect, is illustrated in the figure below. Insulin, from boluses and temporary basals, will have a decreasing effect on the prediction. Carbohydrates will have an increasing effect on the prediction. Blood glucose momentum effect can have a positive or negative effect, depending on how blood glucose is trending in the most recent CGM values. As shown in the example below, blood glucose is trending slightly upwards at the time of the prediction. Therefore, the blood glucose momentum effect’s contribution is pulling up the overall prediction from the other three effects for a short time. Retrospective correction is having a decreasing effect on the prediction, indicating that the recent rise in blood glucose was not as large as had been previously predicted by Loop in the recent past. 
+
+Before we delve into each of the four individual effects, a general overview
+figure may be a helpful start. There are four effects summed together to produce
+Loop's final predicted blood glucose curve. Each individual effect, along with
+their combined effect, is illustrated in the figure below. Insulin, from boluses
+and temporary basals, will have a decreasing effect on the prediction.
+Carbohydrates will have an increasing effect on the prediction. Blood glucose
+momentum effect can have a positive or negative effect, depending on how blood
+glucose is trending in the most recent CGM values. As shown in the example
+below, blood glucose is trending slightly upwards at the time of the prediction.
+Therefore, the blood glucose momentum effect’s contribution is pulling up the
+overall prediction from the other three effects for a short time. Retrospective
+correction is having a decreasing effect on the prediction, indicating that the
+recent rise in blood glucose was not as large as had been previously predicted
+by Loop in the recent past.
 
 ![combined effects curve](img/combined_effects.png)
 
-The sections below provide detailed information on each of the four contributions. 
+The sections below provide detailed information on each of the four
+contributions.
 
 ## Insulin Effect
-Most traditional pump users and caregivers are already familiar with the concept of an insulin activity curve, where the insulin’s effect is time-dependent. Insulin takes a little while to affect blood glucose. The insulin effect typically peaks around one hour after giving insulin and then gradually decays. 
+
+Most traditional pump users and caregivers are already familiar with the concept
+of an insulin activity curve, where the insulin’s effect is time-dependent.
+Insulin takes a little while to affect blood glucose. The insulin effect
+typically peaks around one hour after giving insulin and then gradually decays.
 
 ![insulin actvity curve](img/insulin_activity_curve.png)
 
-Loop provides users with two different classes of insulin models (i.e., an exponential model and the Walsh model). All of the exponential models have an insulin activity duration of 6 hours, whereas the insulin activity duration is customizable for the Walsh model. The rapid-acting and Fiasp insulin activity curves are modeled as exponential curves that match the shape of the insulin activity curves from insulin labeling, and as observed in both adults and children.
+Loop provides users with two different classes of insulin models (i.e., an
+exponential model and the Walsh model). All of the exponential models have an
+insulin activity duration of 6 hours, whereas the insulin activity duration is
+customizable for the Walsh model. The rapid-acting and Fiasp insulin activity
+curves are modeled as exponential curves that match the shape of the insulin
+activity curves from insulin labeling, and as observed in both adults and
+children.
 
 ![insulin models](img/insulin_models.png)
 
-The amount of insulin effect remaining, or percent of remaining active insulin after an insulin bolus is delivered, is modeled mathematically in Loop with an exponential decay curve.
-
+The amount of insulin effect remaining, or percent of remaining active insulin
+after an insulin bolus is delivered, is modeled mathematically in Loop with an
+exponential decay curve.
 
 ### Insulin Effect Remaining
 
 ![insulin percent remaining](img/insulin_percent_remaining.png)
 
-If a user’s insulin sensitivity factor (ISF) is 50 mg/dL per 1 unit of insulin and the user gives 2 units of insulin, then the user’s blood glucose would be expected to drop 100 mg/dL within the 6 hours following the insulin delivery. This insulin effect can be visualized in several different ways: the expected active insulin, expected drop in blood glucose every 5 minutes after delivery, and the expected cumulative drop in blood glucose. The figures below use the Rapid Acting - Adult insulin model in Loop.
+If a user’s insulin sensitivity factor (ISF) is 50 mg/dL per 1 unit of insulin
+and the user gives 2 units of insulin, then the user’s blood glucose would be
+expected to drop 100 mg/dL within the 6 hours following the insulin delivery.
+This insulin effect can be visualized in several different ways: the expected
+active insulin, expected drop in blood glucose every 5 minutes after delivery,
+and the expected cumulative drop in blood glucose. The figures below use the
+Rapid Acting - Adult insulin model in Loop.
 
 ### Active Insulin
-This figure shows that 2 units of insulin are given initially, and the corresponding active insulin (i.e., insulin on board IOB) decays according to the curve below. 
+
+This figure shows that 2 units of insulin are given initially, and the
+corresponding active insulin (i.e., insulin on board IOB) decays according to
+the curve below.
 
 ![insulin remaining example](img/insulin_remaining_example.png)
 
-The active insulin at any time is the product of original insulin delivered and the percent of insulin activity remaining. Knowing the expected active insulin over the next 6 hours, and the insulin sensitivity factor (50 mg/dL, in this case), Loop can calculate the expected drop in blood glucose from that dose of insulin as shown in the figure below.
+The active insulin at any time is the product of original insulin delivered and
+the percent of insulin activity remaining. Knowing the expected active insulin
+over the next 6 hours, and the insulin sensitivity factor (50 mg/dL, in this
+case), Loop can calculate the expected drop in blood glucose from that dose of
+insulin as shown in the figure below.
 
 ![bg drop from 2 units](img/bg_drop.png)
 
-NOTE: ISF is also a function of time, which means if the user’s scheduled ISF changes during the insulin activity time, it will change the expected drop in blood glucose due to the insulin effect. 
+NOTE: ISF is also a function of time, which means if the user’s scheduled ISF
+changes during the insulin activity time, it will change the expected drop in
+blood glucose due to the insulin effect.
 
 ### Expected Change in Blood Glucose
-Lastly, taking the first derivative (i.e., the rate of change) of the cumulative drop in the blood glucose curve yields the expected change in blood glucose over the insulin activity duration. For each dose of insulin given, Loop calculates the expected discrete drop in blood glucose at each 5-minute period for the insulin activity duration, as shown below.
+
+Lastly, taking the first derivative (i.e., the rate of change) of the cumulative
+drop in the blood glucose curve yields the expected change in blood glucose over
+the insulin activity duration. For each dose of insulin given, Loop calculates
+the expected discrete drop in blood glucose at each 5-minute period for the
+insulin activity duration, as shown below.
 
 ![rate of bg change](img/derivative.png)
 
-###  Insulin Effect on Blood Glucose
-For this example, assuming a user’s blood glucose was 205 mg/dL at the time of insulin delivery, Loop would predict a drop in blood glucose due to the two units delivered at 12 pm as shown in the figure below. 
+### Insulin Effect on Blood Glucose
+
+For this example, assuming a user’s blood glucose was 205 mg/dL at the time of
+insulin delivery, Loop would predict a drop in blood glucose due to the two
+units delivered at 12 pm as shown in the figure below.
 
 ![two unit example](img/two_units.png)
 
 ### Scheduled Basal Rates
-In traditional basal/bolus pump therapy, basal rates are set to accommodate the user's endogenous glucose production (EGP) that causes blood glucose to rise. If a user's basal settings were exactly right in traditional pump therapy, the user would have perfectly flat blood glucose all day, all other factors being equal.
 
-In reality, people with type 1 diabetes, and their caregivers, know that basal settings are never exactly right. Every day is a little different, and a myriad of factors that affect blood glucose (e.g., including stress, hormones, sleep, etc.) may affect insulin needs. Some people have different basal profiles to accommodate these variations. Some people regularly tune and adjust their basal rates, and/or do so at their endocrinology clinic visits.
+In traditional basal/bolus pump therapy, basal rates are set to accommodate the
+user's endogenous glucose production (EGP) that causes blood glucose to rise. If
+a user's basal settings were exactly right in traditional pump therapy, the user
+would have perfectly flat blood glucose all day, all other factors being equal.
 
-Since the Loop algorithm assumes that the user-set basal rates are correct, it calculates the effect of insulin relative to scheduled basal rates. If basal rates are not entirely correct, Loop can compensate a bit through the retrospective correction and blood glucose momentum effects, discussed later in this document.
+In reality, people with type 1 diabetes, and their caregivers, know that basal
+settings are never exactly right. Every day is a little different, and a myriad
+of factors that affect blood glucose (e.g., including stress, hormones, sleep,
+etc.) may affect insulin needs. Some people have different basal profiles to
+accommodate these variations. Some people regularly tune and adjust their basal
+rates, and/or do so at their endocrinology clinic visits.
 
-The insulin delivery chart below displays a bar-graph history of the temporary basal rates enacted by Loop. The display is relative to the scheduled basal rates entered in the Loop settings. A rate displayed in this chart as +0 would indicate that no temporary basal rate was set and that the basal rate being delivered was the scheduled basal rate. Positive values indicate a temporary basal rate was set above the scheduled basal rate (i.e., more insulin delivered), and negative values indicate that a temporary basal rate was set below the scheduled basal rate (i.e., less insulin delivered).
+Since the Loop algorithm assumes that the user-set basal rates are correct, it
+calculates the effect of insulin relative to scheduled basal rates. If basal
+rates are not entirely correct, Loop can compensate a bit through the
+retrospective correction and blood glucose momentum effects, discussed later in
+this document.
+
+The insulin delivery chart below displays a bar-graph history of the temporary
+basal rates enacted by Loop. The display is relative to the scheduled basal
+rates entered in the Loop settings. A rate displayed in this chart as +0 would
+indicate that no temporary basal rate was set and that the basal rate being
+delivered was the scheduled basal rate. Positive values indicate a temporary
+basal rate was set above the scheduled basal rate (i.e., more insulin
+delivered), and negative values indicate that a temporary basal rate was set
+below the scheduled basal rate (i.e., less insulin delivered).
 
 ![Loop's temp basal chart](img/temp_basal_chart.png)
 
-For example, if the user’s scheduled basal rate is 1 U/hr, and Loop gives a temporary basal rate of 3 U/hr, then it will calculate the expected drop in blood glucose due to +2 U/hr of insulin.
+For example, if the user’s scheduled basal rate is 1 U/hr, and Loop gives a
+temporary basal rate of 3 U/hr, then it will calculate the expected drop in
+blood glucose due to +2 U/hr of insulin.
 
-Similarly if Loop sets a temporary basal rate of 0 U/hr for 1 hour, then the insulin effect will also be relative to the current scheduled basal rate of 1 U/hr, and Loop would predict the user’s blood glucose to increase by the amount of change from -1 U/hr of insulin. If the user’s ISF is 50 mg/dL, then Loop would predict blood glucose to rise 50 mg/dL over the insulin activity duration (6 hours). 
+Similarly if Loop sets a temporary basal rate of 0 U/hr for 1 hour, then the
+insulin effect will also be relative to the current scheduled basal rate of 1
+U/hr, and Loop would predict the user’s blood glucose to increase by the amount
+of change from -1 U/hr of insulin. If the user’s ISF is 50 mg/dL, then Loop
+would predict blood glucose to rise 50 mg/dL over the insulin activity duration
+(6 hours).
 
-Here is a real-world example where Loop is setting many temporary basal rates over the course of the day. The light orange bars are the temporary basal rates delivered and the solid orange line is the active insulin at any given time during the day.  
+Here is a real-world example where Loop is setting many temporary basal rates
+over the course of the day. The light orange bars are the temporary basal rates
+delivered and the solid orange line is the active insulin at any given time
+during the day.
 
 ![Loop's temp basal chart over day](img/temp_basal_day.png)
 
-###  Total Insulin Effect (combining boluses and temporary basal rates)
-Loop will combine or stack the active insulin of all the discrete (individual) boluses and temporary basal rates over the past insulin activity duration (6 hours), to predict the active insulin for the next 6 hours. As demonstrated above, using the predicted active insulin Loop can predict the blood glucose drop over the next 6 hours. 
+### Total Insulin Effect (combining boluses and temporary basal rates)
 
-Lastly, the combined effect of bolus and basal insulin are visually represented for the user by Loop’s insulin charts:
+Loop will combine or stack the active insulin of all the discrete (individual)
+boluses and temporary basal rates over the past insulin activity duration (6
+hours), to predict the active insulin for the next 6 hours. As demonstrated
+above, using the predicted active insulin Loop can predict the blood glucose
+drop over the next 6 hours.
+
+Lastly, the combined effect of bolus and basal insulin are visually represented
+for the user by Loop’s insulin charts:
 
 ![Loop's iob and temp basals](img/insulin_delivery_iob.jpg)
 
@@ -84,41 +179,93 @@ The insulin effect can be expressed mathematically:
 
 ![insulin effect equation ](img/insulin_effect_equation.png)
 
-where BG is the expected change in blood glucose with the units (mg/dL/5min), ISF is the insulin sensitivity factor (mg/dL/U) at time t, and IA is the insulin activity (U/5min) at time <i>t</i>. Insulin activity can also be thought of as a velocity or rate of change in blood glucose due to insulin. The insulin activity accounts for the EGP and any active insulin from basals and boluses.
+where BG is the expected change in blood glucose with the units (mg/dL/5min),
+ISF is the insulin sensitivity factor (mg/dL/U) at time t, and IA is the insulin
+activity (U/5min) at time <i>t</i>. Insulin activity can also be thought of as a
+velocity or rate of change in blood glucose due to insulin. The insulin activity
+accounts for the EGP and any active insulin from basals and boluses.
 
 ## Carbohydrate Effect
 
-Carbohydrates will raise blood glucose, but the speed and degree to which they impact blood glucose are dependent on the type of carbohydrates. High glycemic index (GI) carbohydrates will raise blood glucose quickly over a shorter time, whereas low GI foods will raise blood glucose more slowly over a longer period. Foods like candy, juice, and fruits tend to be high GI foods, while pizza, burritos, and quesadillas are usually lower GI foods. Digestion issues like gastroparesis may also contribute to variations in carbohydrate absorption.
+Carbohydrates will raise blood glucose, but the speed and degree to which they
+impact blood glucose are dependent on the type of carbohydrates. High glycemic
+index (GI) carbohydrates will raise blood glucose quickly over a shorter time,
+whereas low GI foods will raise blood glucose more slowly over a longer period.
+Foods like candy, juice, and fruits tend to be high GI foods, while pizza,
+burritos, and quesadillas are usually lower GI foods. Digestion issues like
+gastroparesis may also contribute to variations in carbohydrate absorption.
 
-Because carbohydrate absorption can be quite variable, Loop has a model that dynamically adjusts the expected remaining time of carbohydrate absorption. To start with, Loop allows the user to input a rough guess of how long they think the food or drink will take to absorb. The user’s guess is used as a middle of the road estimate, and Loop’s algorithm will shorten or lengthen it based on observed blood glucose change.
+Because carbohydrate absorption can be quite variable, Loop has a model that
+dynamically adjusts the expected remaining time of carbohydrate absorption. To
+start with, Loop allows the user to input a rough guess of how long they think
+the food or drink will take to absorb. The user’s guess is used as a middle of
+the road estimate, and Loop’s algorithm will shorten or lengthen it based on
+observed blood glucose change.
 
-For all carbohydrate entries, Loop assumes carbohydrates will not start absorbing for 10 minutes, so there is a 10-minute period of no absorption that is modeled prior to the absorption modeled in the next sections.
+For all carbohydrate entries, Loop assumes carbohydrates will not start
+absorbing for 10 minutes, so there is a 10-minute period of no absorption that
+is modeled prior to the absorption modeled in the next sections.
 
 ### Linear Carbohydrate Absorption
-Loop takes a conservative view of how fast the remaining carbohydrates will absorb.  Because it is safer to under-deliver insulin for long-duration meals, Loop starts out at a minimum rate of absorption based on extending the entered carbohydrate duration by 50%. Said another way, the minimum carbohydrate absorption rate is the total number of grams of carbohydrates over 150% of the entered duration. 
 
-Using this initial minimum absorption rate, the remaining carbohydrates are modeled to absorb linearly. For example, if the user enters a 72g carbohydrate meal, and selects an estimated absorption time of 4 hours, then Loop will forecast a 12g/hr absorption rate for the next 6 hours. This rate can be termed the minimum absorption rate, which can be represented mathematically as:
+Loop takes a conservative view of how fast the remaining carbohydrates will
+absorb. Because it is safer to under-deliver insulin for long-duration meals,
+Loop starts out at a minimum rate of absorption based on extending the entered
+carbohydrate duration by 50%. Said another way, the minimum carbohydrate
+absorption rate is the total number of grams of carbohydrates over 150% of the
+entered duration.
+
+Using this initial minimum absorption rate, the remaining carbohydrates are
+modeled to absorb linearly. For example, if the user enters a 72g carbohydrate
+meal, and selects an estimated absorption time of 4 hours, then Loop will
+forecast a 12g/hr absorption rate for the next 6 hours. This rate can be termed
+the minimum absorption rate, which can be represented mathematically as:
 
 ![linear carb effect equation ](img/linear_carb_effect_equation.png)
 
-where MAR is the minimum absorption rate (g/hr), CA is the number of carbohydrates (g) and d is the expected duration (hr) it will take the carbohydrates to absorb. 
+where MAR is the minimum absorption rate (g/hr), CA is the number of
+carbohydrates (g) and d is the expected duration (hr) it will take the
+carbohydrates to absorb.
 
 ### Dynamic Carbohydrate Absorption
-The linear model above is modulated by an additional calculation that uses recently observed blood glucose data to estimate how fast carbohydrates have been absorbing. The expected change in blood glucose due to insulin effects alone is compared to the actual observed changes in blood glucose. This difference is termed the insulin counteraction effect (ICE):
+
+The linear model above is modulated by an additional calculation that uses
+recently observed blood glucose data to estimate how fast carbohydrates have
+been absorbing. The expected change in blood glucose due to insulin effects
+alone is compared to the actual observed changes in blood glucose. This
+difference is termed the insulin counteraction effect (ICE):
 
 ![dynamic carb effect equation ](img/dynamic_carb_effect.png)
 
-where, ICE (mg/dL/5 min) is the insulin counteraction effect, OA is the observed activity (mg/dL/5min) or observed change in blood glucose at time <i>t</i>, and IA is the insulin activity (mg/dL/5min). 
+where, ICE (mg/dL/5 min) is the insulin counteraction effect, OA is the observed
+activity (mg/dL/5min) or observed change in blood glucose at time <i>t</i>, and
+IA is the insulin activity (mg/dL/5min).
 
-Insulin counteraction effects are caused by more than just carbohydrates, and can include exercise, sensitivity changes, or incorrectly configured insulin delivery settings (e.g., basal rate, ISF, etc.). However, since the effect of carbohydrates is often dominant (after insulin), Loop can still make useful ongoing adjustments to its carbohydrate model by assuming that the increase in blood glucose is mainly carbohydrate absorption in the period following recorded meal entries.  
+Insulin counteraction effects are caused by more than just carbohydrates, and
+can include exercise, sensitivity changes, or incorrectly configured insulin
+delivery settings (e.g., basal rate, ISF, etc.). However, since the effect of
+carbohydrates is often dominant (after insulin), Loop can still make useful
+ongoing adjustments to its carbohydrate model by assuming that the increase in
+blood glucose is mainly carbohydrate absorption in the period following recorded
+meal entries.
 
-The insulin counteraction effect is converted into an estimated carbohydrate absorption amount by using the current carbohydrate-to-insulin ratio and the insulin sensitivity factor at the time of the recorded meal entry.
+The insulin counteraction effect is converted into an estimated carbohydrate
+absorption amount by using the current carbohydrate-to-insulin ratio and the
+insulin sensitivity factor at the time of the recorded meal entry.
 
 ![ice carb effect equation ](img/ice_carb_effect_equation.png)
 
-where AC is the number of carbohydrates absorbed (g/5min), ICE is the insulin counteraction effect, CIR is the carbohydrate-to-insulin ratio (g/U), and ISF is the insulin sensitivity factor (mg/dL/U) at time <i>t</i>. 
+where AC is the number of carbohydrates absorbed (g/5min), ICE is the insulin
+counteraction effect, CIR is the carbohydrate-to-insulin ratio (g/U), and ISF is
+the insulin sensitivity factor (mg/dL/U) at time <i>t</i>.
 
-If multiple meal entries are active (i.e., still absorbing), the estimated absorption is split between each carbohydrate entry in proportion to each carbohydrate entry’s minimum absorption rate. For example, if 72g carbohydrates with an expected absorption time of 4 hours was consumed at 12 pm, and another 72g of carbohydrates with an expected absorption time of 2 hours was consumed at 3 pm, then the minimum absorption rate (see MAR equation above) would be 12 g/hr and 6 g/hr respectively, or 1 g/5min and 0.5 g/5min.
+If multiple meal entries are active (i.e., still absorbing), the estimated
+absorption is split between each carbohydrate entry in proportion to each
+carbohydrate entry’s minimum absorption rate. For example, if 72g carbohydrates
+with an expected absorption time of 4 hours was consumed at 12 pm, and another
+72g of carbohydrates with an expected absorption time of 2 hours was consumed at
+3 pm, then the minimum absorption rate (see MAR equation above) would be 12 g/hr
+and 6 g/hr respectively, or 1 g/5min and 0.5 g/5min.
 
 ![mar meal 1 equation ](img/mar_12.png)
 
@@ -130,50 +277,83 @@ Examining just the simple linear carbohydrate effect of these two meals:
 
 If we further expand this example, by assuming the following at 4pm:
 
-* that there are still carbohydrates left to be absorbed from both meals, 
-* that the estimated insulin counteraction effect (ICE) is +15 ![ICE units](img/ice_units.png), and 
-* the user’s CIR is 10 g/U and the ISF is 50 mg/dL/U,
+- that there are still carbohydrates left to be absorbed from both meals,
+- that the estimated insulin counteraction effect (ICE) is +15
+  ![ICE units](img/ice_units.png), and
+- the user’s CIR is 10 g/U and the ISF is 50 mg/dL/U,
 
 then the estimated amount of carbohydrates absorbed at 4pm would be 3g:
 
 ![combined meal entries](img/at_4.png)
 
-Those 3g of carbohydrates would then be split amongst the meals proportional to their minimum absorption rates:
+Those 3g of carbohydrates would then be split amongst the meals proportional to
+their minimum absorption rates:
 
 ![combined meal entries](img/meal1.png)
 
 ![combined meal entries](img/meal2.png)
 
-resulting in 2g of absorption being attributed to Meal 1 and 1g attributed to Meal 2.
+resulting in 2g of absorption being attributed to Meal 1 and 1g attributed to
+Meal 2.
 
 ### Minimum Carbohydrate Absorption Rate
-If the estimated carbohydrate absorption of a meal entry is less what would have been absorbed using the minimum absorption rate, then the minimum absorption rate is used instead. This is to ensure that meal entries expire in a reasonable amount of time.
+
+If the estimated carbohydrate absorption of a meal entry is less what would have
+been absorbed using the minimum absorption rate, then the minimum absorption
+rate is used instead. This is to ensure that meal entries expire in a reasonable
+amount of time.
 
 ### Modeling Remaining Active Carbohydrates
-After the estimated absorbed carbohydrates have been subtracted from each meal entry, the remaining carbohydrates (for each entry) are then forecasted to decay or absorb using the minimum absorption rate. Loop uses this forecast to estimate the effect (active carbohydrates, or carbohydrate activity) of the remaining carbohydrates. The carbohydrate effect can be expressed mathematically using the terms described above:
+
+After the estimated absorbed carbohydrates have been subtracted from each meal
+entry, the remaining carbohydrates (for each entry) are then forecasted to decay
+or absorb using the minimum absorption rate. Loop uses this forecast to estimate
+the effect (active carbohydrates, or carbohydrate activity) of the remaining
+carbohydrates. The carbohydrate effect can be expressed mathematically using the
+terms described above:
 
 ![combined meal entries](img/combined_bgc.png)
 
 ## Retrospective Correction Effect
 
-!!!note ""
-    The retrospective correction effect allows the Loop algorithm to account for effects that are not modeled with the insulin and carbohydrate effects, by comparing historical predictions to the actual blood glucose.
+!!!note "" The retrospective correction effect allows the Loop algorithm to
+account for effects that are not modeled with the insulin and carbohydrate
+effects, by comparing historical predictions to the actual blood glucose.
 
-In addition to the modeled effects of insulin and carbohydrates, there are many other factors that affect blood glucose (e.g., exercise, stress, hormones, etc.). Many of these effects are active for a period of time. By observing its own forecast error, Loop can estimate the magnitude of these effects and, by assuming that they will continue for some short period of time, incorporate them into the forecast to improve forecast accuracy.
+In addition to the modeled effects of insulin and carbohydrates, there are many
+other factors that affect blood glucose (e.g., exercise, stress, hormones,
+etc.). Many of these effects are active for a period of time. By observing its
+own forecast error, Loop can estimate the magnitude of these effects and, by
+assuming that they will continue for some short period of time, incorporate them
+into the forecast to improve forecast accuracy.
 
-To do this, Loop calculates a retrospective forecast with a start time of 30 minutes in the past, ending at the current time. Loop compares the retrospective forecast to the actual observed change in blood glucose, and the difference is summed into a blood glucose velocity or rate of difference:
+To do this, Loop calculates a retrospective forecast with a start time of 30
+minutes in the past, ending at the current time. Loop compares the retrospective
+forecast to the actual observed change in blood glucose, and the difference is
+summed into a blood glucose velocity or rate of difference:
 
 ![blood glucose velocity equation](img/bgvel.png)
 
-where BG*vel* is a velocity term (mg/dL per 5min) that represents the average blood glucose difference between the retrospective forecast (RF) and the actual blood glucose (BG) over the last 30 minutes. This term is applied to the current forecast from the insulin and carb effects with a linear decay over the next hour. For example, the first forecast point (t=5) is approximately 100% of this velocity, the forecast point one-half hour from now is adjusted by 50% of the velocity, and points from one hour or more in the future are not affected by this term.
+where BG*vel* is a velocity term (mg/dL per 5min) that represents the average
+blood glucose difference between the retrospective forecast (RF) and the actual
+blood glucose (BG) over the last 30 minutes. This term is applied to the current
+forecast from the insulin and carb effects with a linear decay over the next
+hour. For example, the first forecast point (t=5) is approximately 100% of this
+velocity, the forecast point one-half hour from now is adjusted by 50% of the
+velocity, and points from one hour or more in the future are not affected by
+this term.
 
 The retrospective correction effect can be expressed mathematically:
 
 ![blood glucose retrospective equation](img/bgrc.png)
 
-where BG is the predicted change in blood glucose with the units (mg/dL/5min) at time *t* over the time range of 5 to 60 minutes, and the other term gives the percentage of BG*vel* that is applied to this effect.
+where BG is the predicted change in blood glucose with the units (mg/dL/5min) at
+time _t_ over the time range of 5 to 60 minutes, and the other term gives the
+percentage of BG*vel* that is applied to this effect.
 
-The retrospective correction effect can be illustrated with an example: if the BG*vel* over the past 30 minutes was -10 mg/dL per 5min, then the retrospective correction effect over the next 60 minutes would be as follows:
+The retrospective correction effect can be illustrated with an example: if the
+BG*vel* over the past 30 minutes was -10 mg/dL per 5min, then the retrospective
+correction effect over the next 60 minutes would be as follows:
 
 <table>
 <thead>
@@ -248,26 +428,53 @@ The retrospective correction effect can be illustrated with an example: if the B
 </tbody>
 </table>
 
-Here’s an example below that shows the retrospective correction effect when the BG*vel* over the past 30 minutes was -10mg/dL/5min.   
+Here’s an example below that shows the retrospective correction effect when the
+BG*vel* over the past 30 minutes was -10mg/dL/5min.
 
 ![bg retrospective graph example](img/bgrc_graphic.png)
 
-## Blood Glucose Momentum Effect 
+## Blood Glucose Momentum Effect
 
-!!!note ""
-    The blood glucose momentum effect incorporates a prediction component based on the assumption that recent blood glucose trends tend to persist for a short period of time. In other words, the best predictor of the future is the recent past.
+!!!note "" The blood glucose momentum effect incorporates a prediction component
+based on the assumption that recent blood glucose trends tend to persist for a
+short period of time. In other words, the best predictor of the future is the
+recent past.
 
-The blood glucose momentum portion of the algorithm gives weight or importance to recent blood glucose to improve the near-future forecast. Loop calculates the slope of the last 3 continuous CGM readings (i.e., the last 15 minutes) using linear regression. Using multiple points helps filter out noise in the CGM data while still responding fast to changing situations. That momentum slope (Mslope) is the approximate or average rate of change over the last 15 minutes, though it is normalized to 5 minutes so that the units are (mg/dL/5min). 
+The blood glucose momentum portion of the algorithm gives weight or importance
+to recent blood glucose to improve the near-future forecast. Loop calculates the
+slope of the last 3 continuous CGM readings (i.e., the last 15 minutes) using
+linear regression. Using multiple points helps filter out noise in the CGM data
+while still responding fast to changing situations. That momentum slope (Mslope)
+is the approximate or average rate of change over the last 15 minutes, though it
+is normalized to 5 minutes so that the units are (mg/dL/5min).
 
-The momentum slope is then blended into the next 20 minutes of predicted blood glucose from the other effects (i.e., insulin, carbohydrates, and retrospective correction effects). This, in essence, makes the next 20 minutes of blood glucose prediction more sensitive to recent blood glucose trends. The blending of the recent trend slope into the next 20 minutes is weighted so that the first prediction point (5 minutes into the future) is highly influenced by the slope, and the influence of the slope gradually decays over the 20 minute time period. The momentum effect can be expressed mathematically as:
+The momentum slope is then blended into the next 20 minutes of predicted blood
+glucose from the other effects (i.e., insulin, carbohydrates, and retrospective
+correction effects). This, in essence, makes the next 20 minutes of blood
+glucose prediction more sensitive to recent blood glucose trends. The blending
+of the recent trend slope into the next 20 minutes is weighted so that the first
+prediction point (5 minutes into the future) is highly influenced by the slope,
+and the influence of the slope gradually decays over the 20 minute time period.
+The momentum effect can be expressed mathematically as:
 
 ![blood glucose momentum equation](img/momentum_equation.png)
 
-NOTE: The term ![blood glucose momentum term](img/momentum_term.png) is also applied to the combined insulin, carbohydrates, and retrospective correction effects to get the delta blood glucose prediction. 
+NOTE: The term ![blood glucose momentum term](img/momentum_term.png) is also
+applied to the combined insulin, carbohydrates, and retrospective correction
+effects to get the delta blood glucose prediction.
 
-The momentum effect can be illustrated with an example: if the last 3 blood glucose readings were 100, 103, and 106 mg/dL, then the slope would be 3 mg/dL per 5 minutes (0.6 mg/dL per minute). The amount of that recent trend or slope applied to the next 20 minutes of predictions (i.e., the next 4 predictions from the other effects) is roughly 100% (3 mg/dL per 5 min) at 5 minutes, 66% (2 mg/dL per 5 min) at 10 minutes, 33% (1 mg/dL per 5 min) at 15 minutes, and 0% (0 mg/dL per 5 min) at 20 minutes.
+The momentum effect can be illustrated with an example: if the last 3 blood
+glucose readings were 100, 103, and 106 mg/dL, then the slope would be 3 mg/dL
+per 5 minutes (0.6 mg/dL per minute). The amount of that recent trend or slope
+applied to the next 20 minutes of predictions (i.e., the next 4 predictions from
+the other effects) is roughly 100% (3 mg/dL per 5 min) at 5 minutes, 66% (2
+mg/dL per 5 min) at 10 minutes, 33% (1 mg/dL per 5 min) at 15 minutes, and 0% (0
+mg/dL per 5 min) at 20 minutes.
 
-Also, if the combined effect from the insulin, carbohydrates, and retrospective correction is assumed to be a constant 6 mg/dL/5min over the next 20 minutes, then the expected overall effect and the predicted blood glucose can be calculated as follows. 
+Also, if the combined effect from the insulin, carbohydrates, and retrospective
+correction is assumed to be a constant 6 mg/dL/5min over the next 20 minutes,
+then the expected overall effect and the predicted blood glucose can be
+calculated as follows.
 
 <table>
 <thead>
@@ -325,20 +532,33 @@ This example is illustrated in the figure below.
 
 ![blood glucose momentum graphic](img/momentum_graphic.png)
 
-It is also worth noting that Loop will not calculate blood glucose momentum in instances where CGM data is not continuous (i.e., must have at least three continuous CGM readings to draw the best-fit straight line trend). It also will not calculate blood glucose momentum when the last three CGM readings contain any calibration points, as those may not be representative of true blood glucose momentum trends. 
+It is also worth noting that Loop will not calculate blood glucose momentum in
+instances where CGM data is not continuous (i.e., must have at least three
+continuous CGM readings to draw the best-fit straight line trend). It also will
+not calculate blood glucose momentum when the last three CGM readings contain
+any calibration points, as those may not be representative of true blood glucose
+momentum trends.
 
 ## Predicting Glucose
-As described in the momentum effect section, the momentum effect is blended with the insulin, carbohydrate, and retrospective correction effects to predict the change in blood glucose:
+
+As described in the momentum effect section, the momentum effect is blended with
+the insulin, carbohydrate, and retrospective correction effects to predict the
+change in blood glucose:
 
 ![predicted glucose equation](img/delta_predicted_equation.png)
 
-Lastly, the forecast or predicted blood glucose BG at time *t* is the current blood glucose BG plus the sum of all blood glucose effects BG over the time interval [t5, t]:
+Lastly, the forecast or predicted blood glucose BG at time _t_ is the current
+blood glucose BG plus the sum of all blood glucose effects BG over the time
+interval [t5, t]:
 
 ![adding all the deltas](img/sigma_bg_delta.png)
 
-Each individual effect along with the combined effects are illustrated in the figure below. As shown, blood glucose is trending slightly upwards at the time of the prediction. Therefore, the blood glucose momentum effect’s contribution is pulling up the overall prediction from the other three effects for a short time. Retrospective correction is having a dampening effect on the prediction, indicating that the recent rise in blood glucose was not as great as had been previously predicted in the recent past. 
+Each individual effect along with the combined effects are illustrated in the
+figure below. As shown, blood glucose is trending slightly upwards at the time
+of the prediction. Therefore, the blood glucose momentum effect’s contribution
+is pulling up the overall prediction from the other three effects for a short
+time. Retrospective correction is having a dampening effect on the prediction,
+indicating that the recent rise in blood glucose was not as great as had been
+previously predicted in the recent past.
 
 ![combined effects curve](img/combined_effects.png)
-
-
-

--- a/docs/operation/algorithm/temp-basal.md
+++ b/docs/operation/algorithm/temp-basal.md
@@ -1,80 +1,139 @@
 # Basal Adjustments
 
-The Loop algorithm takes one of four actions depending upon the eventual blood glucose, predicted glucose, and suspend threshold. Note that all temporary basal rate commands are issued for 30 minutes, however they may be updated (re-issued) every 5 minutes. Said another way, Loop may enact a new temporary basal rate every 5 minutes. But, if communication with the pump is lost, the last issued temporary basal rate will last for at most 30 minutes before the pump reverts to the user’s scheduled basal rates. Note: If a user is operating Loop in open-loop mode, the Loop will only recommend basal dosing actions and will not automatically enact those recommendations.
+The Loop algorithm takes one of four actions depending upon the eventual blood
+glucose, predicted glucose, and suspend threshold. Note that all temporary basal
+rate commands are issued for 30 minutes, however they may be updated (re-issued)
+every 5 minutes. Said another way, Loop may enact a new temporary basal rate
+every 5 minutes. But, if communication with the pump is lost, the last issued
+temporary basal rate will last for at most 30 minutes before the pump reverts to
+the user’s scheduled basal rates. Note: If a user is operating Loop in open-loop
+mode, the Loop will only recommend basal dosing actions and will not
+automatically enact those recommendations.
 
 ## Four Possible Actions
-Loop implements one of four possible basal actions: **decrease**, **increase**, **suspend**, or **resume** a scheduled basal rate.
 
-###  Decrease Basal Rate
-If the eventual blood glucose is less than the correction range and all of the predicted glucose values are above the suspend threshold, then Loop will issue a temporary basal rate that is lower than the current scheduled basal rate to bring the eventual blood glucose up to the correction target.
+Loop implements one of four possible basal actions: **decrease**, **increase**,
+**suspend**, or **resume** a scheduled basal rate.
+
+### Decrease Basal Rate
+
+If the eventual blood glucose is less than the correction range and all of the
+predicted glucose values are above the suspend threshold, then Loop will issue a
+temporary basal rate that is lower than the current scheduled basal rate to
+bring the eventual blood glucose up to the correction target.
 
 ![decrease basal rate example](img/decrease.png)
 
 ### Increase Basal Rate
-If the eventual blood glucose is greater than the correction range and all of the predicted glucose values are above the suspend threshold, then Loop will issue a temporary basal rate that is higher than the current basal rate to bring the eventual blood glucose down to the correction target.
+
+If the eventual blood glucose is greater than the correction range and all of
+the predicted glucose values are above the suspend threshold, then Loop will
+issue a temporary basal rate that is higher than the current basal rate to bring
+the eventual blood glucose down to the correction target.
 
 ![increase basal rate example](img/increase.png)
 
 ### Suspend Basal Rate
-If the minimum predicted blood glucose goes below the suspend threshold, then Loop will issue a temporary basal rate of zero units per hour, regardless of the eventual blood glucose.
+
+If the minimum predicted blood glucose goes below the suspend threshold, then
+Loop will issue a temporary basal rate of zero units per hour, regardless of the
+eventual blood glucose.
 
 ![suspend basal rate example](img/suspend.png)
 
 ### Resume Basal Rate
-There are three situations where the Loop algorithm will resume the current scheduled basal rate.
 
-If the eventual blood glucose is within the correction range, and all of the predicted glucose values are above the suspend threshold, then Loop will resume the current scheduled basal rate.
+There are three situations where the Loop algorithm will resume the current
+scheduled basal rate.
+
+If the eventual blood glucose is within the correction range, and all of the
+predicted glucose values are above the suspend threshold, then Loop will resume
+the current scheduled basal rate.
 
 ![first resume basal rate example](img/resume2.png)
 
-If the eventual blood glucose is above the correction range, and the predicted glucose values have a temporary excursion below the correction range but still above the suspend threshold, then Loop will resume the current scheduled basal rate.
+If the eventual blood glucose is above the correction range, and the predicted
+glucose values have a temporary excursion below the correction range but still
+above the suspend threshold, then Loop will resume the current scheduled basal
+rate.
 
 ![second resume basal rate example](img/resume.png)
 
-If the Loop algorithm does not have ALL of the data it needs to make a prediction, it will let the remaining temporary basal rate run its duration (maximum of 30 minutes), and then the basal rate will default back to the current scheduled basal rate, thus returning to the same therapy pattern that they would receive using a traditional insulin pump.
+If the Loop algorithm does not have ALL of the data it needs to make a
+prediction, it will let the remaining temporary basal rate run its duration
+(maximum of 30 minutes), and then the basal rate will default back to the
+current scheduled basal rate, thus returning to the same therapy pattern that
+they would receive using a traditional insulin pump.
 
 ## Determining the Temporary Basal Rate
-To determine the corrective temporary basal rate to implement, Loop calculates a “dose” in the same way doses are calculated in both open-loop and traditional insulin pump therapy. It's also the same math many people on multiple-daily injection therapy use. The benefit of Loop (and all other close-loop algorithms) is that it does this math every 5 minutes, and is far less prone to error than humans doing the math. Loop also does its math based on predicting into the future, which traditional pumps and humans, do not always have the time or inclination to do.
 
-The amount of insulin needed, or dose, is calculated using the desired reduction in blood glucose and the user’s ISF. For the Loop algorithm, the desired reduction in blood glucose is the delta between the eventual blood glucose and the correction target:
+To determine the corrective temporary basal rate to implement, Loop calculates a
+“dose” in the same way doses are calculated in both open-loop and traditional
+insulin pump therapy. It's also the same math many people on multiple-daily
+injection therapy use. The benefit of Loop (and all other close-loop algorithms)
+is that it does this math every 5 minutes, and is far less prone to error than
+humans doing the math. Loop also does its math based on predicting into the
+future, which traditional pumps and humans, do not always have the time or
+inclination to do.
+
+The amount of insulin needed, or dose, is calculated using the desired reduction
+in blood glucose and the user’s ISF. For the Loop algorithm, the desired
+reduction in blood glucose is the delta between the eventual blood glucose and
+the correction target:
 
 ![basal dose equation](img/dose_equation.png)
 
-!!!note ""
-    A major difference between traditional pump therapy and how the Loop calculates dose is that in pump therapy the current blood glucose is used to estimate the dose, whereas in the Loop algorithm the eventual and minimum blood glucose predictions are also used in determining dosing decisions.
+!!!note "" A major difference between traditional pump therapy and how the Loop
+calculates dose is that in pump therapy the current blood glucose is used to
+estimate the dose, whereas in the Loop algorithm the eventual and minimum blood
+glucose predictions are also used in determining dosing decisions.
 
-Loop then converts the dose into a basal rate using the Loop’s temporary basal rate duration of 30 minutes:
+Loop then converts the dose into a basal rate using the Loop’s temporary basal
+rate duration of 30 minutes:
 
 ![basal dose equation](img/br.png)![basal dose equation](img/br2.png)
 
-where BR is the basal rate (U/hr), which is the amount of insulin needed over the next 30 minutes to bring the eventual blood glucose to the correction target. The basal rate, however, is the amount of basal rate needed beyond the user’s scheduled basal rate. As such, the required basal rate can be determined by:
+where BR is the basal rate (U/hr), which is the amount of insulin needed over
+the next 30 minutes to bring the eventual blood glucose to the correction
+target. The basal rate, however, is the amount of basal rate needed beyond the
+user’s scheduled basal rate. As such, the required basal rate can be determined
+by:
 
 ![recommended basal](img/rbr.png)
 
 where RBR is the required basal rate and SBR is the scheduled basal rate.
 
-Finally, Loop compares the RBR with the user-specified maximum temporary basal rate setting to determine the temporary basal to issue:
+Finally, Loop compares the RBR with the user-specified maximum temporary basal
+rate setting to determine the temporary basal to issue:
 
-* If RBR ≥ maximum basal rate, then Loop will issue the maximum basal rate  
+- If RBR ≥ maximum basal rate, then Loop will issue the maximum basal rate
 
-* If RBR < maximum temporary basal rate, then Loop will issue RBR 
+- If RBR < maximum temporary basal rate, then Loop will issue RBR
 
-After running the temporary basal calculation described above, Loop checks whether there is already an appropriate basal running with at least 10 minutes remaining. If so, Loop will not reissue the temporary basal. However, if the recommended temporary basal differs from the currently running temporary basal — or the current scheduled basal if no temporary is running —  then Loop will replace the current basal rate with the recommended temporary basal rate. 
+After running the temporary basal calculation described above, Loop checks
+whether there is already an appropriate basal running with at least 10 minutes
+remaining. If so, Loop will not reissue the temporary basal. However, if the
+recommended temporary basal differs from the currently running temporary basal —
+or the current scheduled basal if no temporary is running — then Loop will
+replace the current basal rate with the recommended temporary basal rate.
 
-As mentioned at the beginning of this section, the process of determining whether a temporary basal should be issued is repeated every 5 minutes.
+As mentioned at the beginning of this section, the process of determining
+whether a temporary basal should be issued is repeated every 5 minutes.
 
 ## Temporary Basal Rate Calculation Example
-To illustrate how the Loop calculates the temporary basal rate to issue, consider the calculation for the following scenario:
 
-* Eventual blood glucose = 200 mg/dL  
+To illustrate how the Loop calculates the temporary basal rate to issue,
+consider the calculation for the following scenario:
 
-* Correction target = 100 mg/dL  
+- Eventual blood glucose = 200 mg/dL
 
-* ISF = 50 mg/dL/U  
+- Correction target = 100 mg/dL
 
-* Current scheduled basal rate (SBR) is 1 U/hr  
+- ISF = 50 mg/dL/U
 
-* Maximum basal setting (set by user in Loop) = 6 U/hr  
+- Current scheduled basal rate (SBR) is 1 U/hr
+
+- Maximum basal setting (set by user in Loop) = 6 U/hr
 
 </br>First, calculate the dose:
 
@@ -88,4 +147,7 @@ Next, calculate the required basal rate:
 
 ![example rbr](img/rbr_example.png)
 
-Lastly, compare the required basal rate to the maximum temporary basal rate, and find that Loop will enact a temporary basal rate of 5 U/hr for 30 minutes since this temporary basal rate is below the maximum temporary basal rate of 6 U/hr, which was set by the user in Loop app settings.
+Lastly, compare the required basal rate to the maximum temporary basal rate, and
+find that Loop will enact a temporary basal rate of 5 U/hr for 30 minutes since
+this temporary basal rate is below the maximum temporary basal rate of 6 U/hr,
+which was set by the user in Loop app settings.

--- a/docs/operation/features/battery.md
+++ b/docs/operation/features/battery.md
@@ -1,99 +1,188 @@
 # Pump Battery
 
-One common confusion point for new Loop users is how to interpret their pump's battery levels and whether they need to change their pump batteries based on which pieces of information.
+One common confusion point for new Loop users is how to interpret their pump's
+battery levels and whether they need to change their pump batteries based on
+which pieces of information.
 
 ## Discharge Curves
 
-There are generally two different types of AAA batteries that we use in these Medtronic pumps; alkaline or lithium.
+There are generally two different types of AAA batteries that we use in these
+Medtronic pumps; alkaline or lithium.
 
-To understand pump battery levels, you first need to know a little about **battery discharge curves**.  It's not a hard concept...basically how a battery dies over time as it is used or sits in a drawer.  More technically said, a battery discharge curve is the measure of volts that a battery puts out over time.  Batteries start at a higher voltage output and slowly that voltage output degrades over time (or use) until the battery no longer provides enough "ummph" to keep the electronic gadget going.  BUT, alkaline batteries and lithium batteries have different discharge curves due to the chemistry inside them, and the curves can be slightly different depending on the environment (temperature) and battery manufacturer.
+To understand pump battery levels, you first need to know a little about
+**battery discharge curves**. It's not a hard concept...basically how a battery
+dies over time as it is used or sits in a drawer. More technically said, a
+battery discharge curve is the measure of volts that a battery puts out over
+time. Batteries start at a higher voltage output and slowly that voltage output
+degrades over time (or use) until the battery no longer provides enough "ummph"
+to keep the electronic gadget going. BUT, alkaline batteries and lithium
+batteries have different discharge curves due to the chemistry inside them, and
+the curves can be slightly different depending on the environment (temperature)
+and battery manufacturer.
 
-Alkaline batteries have a relatively steady voltage drop over time, as shown below.  Notice the shape of the curve has a significant amount of time in the 1.3 to 1.2 volts range, and a relatively smooth decline to about 1.2 volts.
+Alkaline batteries have a relatively steady voltage drop over time, as shown
+below. Notice the shape of the curve has a significant amount of time in the 1.3
+to 1.2 volts range, and a relatively smooth decline to about 1.2 volts.
 
 <p align="center">
 <img src="../img/alkaline.jpg" width="250">
 </p>
 
-Lithium batteries have a much steadier voltage output over time, as shown below.  Notice how the shape of the curve is relatively flat for a large portion of the battery life before suddenly off around 1.3 volts.
+Lithium batteries have a much steadier voltage output over time, as shown below.
+Notice how the shape of the curve is relatively flat for a large portion of the
+battery life before suddenly off around 1.3 volts.
 
 <p align="center">
 <img src="../img/lithium.jpg" width="250">
 </p>
 
-What does the above information mean in terms of Looping?  A lithium battery at 1.3v is going to have a much quicker time to death than an alkaline battery sitting at 1.3v.  You might only get a couple of hours of looping left when a lithium battery is at 1.3v, but an alkaline battery at 1.3v might go for several more days.  So when we talk about setting alarm levels in either system, your battery type is an important consideration.
+What does the above information mean in terms of Looping? A lithium battery at
+1.3v is going to have a much quicker time to death than an alkaline battery
+sitting at 1.3v. You might only get a couple of hours of looping left when a
+lithium battery is at 1.3v, but an alkaline battery at 1.3v might go for several
+more days. So when we talk about setting alarm levels in either system, your
+battery type is an important consideration.
 
 ## Medtronic Pump Battery Level Indicator
 
-If you read Medtronic's literature, it will tell you to use Energizer alkaline batteries in their pumps.  Why would that be?  Hint: the answer doesn't mean that Duracell batteries are inherently worse than Energizer or that lithium batteries won't work in Medtronic pumps.
+If you read Medtronic's literature, it will tell you to use Energizer alkaline
+batteries in their pumps. Why would that be? Hint: the answer doesn't mean that
+Duracell batteries are inherently worse than Energizer or that lithium batteries
+won't work in Medtronic pumps.
 
-**The answer is all about the accuracy of their little pump battery level indicator on their pump's screen.**  Medtronic calibrated their pump battery level indicator to:
+**The answer is all about the accuracy of their little pump battery level
+indicator on their pump's screen.** Medtronic calibrated their pump battery
+level indicator to:
 
-* Energizer alkaline batteries
-* Normal (non-Loop) uses
-* Temperatures between 37°F (3°C) to 104°F (40°C).
+- Energizer alkaline batteries
+- Normal (non-Loop) uses
+- Temperatures between 37°F (3°C) to 104°F (40°C).
 
-In other words, Medtronic ran experiments to see exactly how long an Energizer alkaline battery will last in normal pump use and made their own discharge curve.  They programmed their pump battery level indicator to change from 4 bars to 3 bars to 2 bars to 1 bar based on that particular discharge curve.
+In other words, Medtronic ran experiments to see exactly how long an Energizer
+alkaline battery will last in normal pump use and made their own discharge
+curve. They programmed their pump battery level indicator to change from 4 bars
+to 3 bars to 2 bars to 1 bar based on that particular discharge curve.
 
-However, Loop users are slightly more demanding on the pump's battery/voltage than simply delivering insulin.  We are also asking for the pump to perform radio communications, in addition to delivering insulin.  Those radio communications needs a slightly higher voltage than the typical "normal" pump use.  So while a non-Looper might be ok running their pump until a voltage of about 1.12 for insulin delivery, radio communications might stop at a voltage output of about 1.17.  If you experiment with your Looping pump, you'll find Loop will turn red from failed pump comms before the pump actually fails at insulin delivery.  This difference between "failure" voltages needs to be considered when determining how much useful battery life is left for a pump battery.
+However, Loop users are slightly more demanding on the pump's battery/voltage
+than simply delivering insulin. We are also asking for the pump to perform radio
+communications, in addition to delivering insulin. Those radio communications
+needs a slightly higher voltage than the typical "normal" pump use. So while a
+non-Looper might be ok running their pump until a voltage of about 1.12 for
+insulin delivery, radio communications might stop at a voltage output of about
+1.17. If you experiment with your Looping pump, you'll find Loop will turn red
+from failed pump comms before the pump actually fails at insulin delivery. This
+difference between "failure" voltages needs to be considered when determining
+how much useful battery life is left for a pump battery.
 
-In summary, that little pump battery indicator on the Medtronic pump screen is ONLY useful if you are:
+In summary, that little pump battery indicator on the Medtronic pump screen is
+ONLY useful if you are:
 
-* not using the pump for Looping,
-* using Energizer alkaline batteries, and
-* in the temperature environment similar to their testing.
+- not using the pump for Looping,
+- using Energizer alkaline batteries, and
+- in the temperature environment similar to their testing.
 
-!!!info ""
-    Loop users should not rely on their Medtronic pump screen's pump battery indicator, and instead use the Loop's pump battery level indicator.
-
+!!!info "" Loop users should not rely on their Medtronic pump screen's pump
+battery indicator, and instead use the Loop's pump battery level indicator.
 
 ## Loop's Pump Battery Level Indicator
 
-Keeping the information about battery discharge curves in mind, Loop developers tested various battery brands and types to develop discharge curves for Loop users.  These discharge curves form the basis of the pump battery level indicator found in the top right of the Loop's main display screen and the pump battery notifications provided by the Loop app.  The pump battery level indicator will also report in %.
+Keeping the information about battery discharge curves in mind, Loop developers
+tested various battery brands and types to develop discharge curves for Loop
+users. These discharge curves form the basis of the pump battery level indicator
+found in the top right of the Loop's main display screen and the pump battery
+notifications provided by the Loop app. The pump battery level indicator will
+also report in %.
 
-* For x23 and x54 model users, the Loop's pump battery level will move in 25% increments.
-* For x15 and x22 model users, the Loop's pump battery level will move in discrete % increments.
+- For x23 and x54 model users, the Loop's pump battery level will move in 25%
+  increments.
+- For x15 and x22 model users, the Loop's pump battery level will move in
+  discrete % increments.
 
-Based on the battery type selected and the pump model being used, the Loop's pump battery level notifications are designed to give the user about 8 hours of notice before pump communications are likely to fail.  The Loop user should have some additional time after pump comms fail before actual insulin delivery would stop.
-
+Based on the battery type selected and the pump model being used, the Loop's
+pump battery level notifications are designed to give the user about 8 hours of
+notice before pump communications are likely to fail. The Loop user should have
+some additional time after pump comms fail before actual insulin delivery would
+stop.
 
 ## Nightscout Pump Battery Display
 
-The Nightscout information regarding pump battery levels will depend on pump model being used.
+The Nightscout information regarding pump battery levels will depend on pump
+model being used.
 
-* If you use an x23 or x54 pump and MySentry, the pump levels are reported as a **percent** to NS, because that's how MySentry reports the data to Loop.  The packets use 100%, 75%, 50%, and 25% increments, and the Loop's main display matches the NS pump display.
-* If you use an x22 or x15 pump, the pump levels are reported as **voltage** readings to NS because Loop has to specifically request the voltage reading from the pump.  The Loop's main display will show pump battery level as discrete %, not the individual voltage measurement.
-* No matter what pump you are using, you can always get the current pump battery's voltage by using the RileyLink's `Read Pump Status` command.
-* The extra communications effort for non-MySentry model pumps will mean slightly shorter battery life vs. MySentry model pumps.
+- If you use an x23 or x54 pump and MySentry, the pump levels are reported as a
+  **percent** to NS, because that's how MySentry reports the data to Loop. The
+  packets use 100%, 75%, 50%, and 25% increments, and the Loop's main display
+  matches the NS pump display.
+- If you use an x22 or x15 pump, the pump levels are reported as **voltage**
+  readings to NS because Loop has to specifically request the voltage reading
+  from the pump. The Loop's main display will show pump battery level as
+  discrete %, not the individual voltage measurement.
+- No matter what pump you are using, you can always get the current pump
+  battery's voltage by using the RileyLink's `Read Pump Status` command.
+- The extra communications effort for non-MySentry model pumps will mean
+  slightly shorter battery life vs. MySentry model pumps.
 
 ## Nightscout Pump Battery Alarms
 
-The Nightscout alarms are based on the Heroku settings that you have input specifically.  If you don't specifically set them, Nightscout will use the default settings for pump battery alerts as shown below:
+The Nightscout alarms are based on the Heroku settings that you have input
+specifically. If you don't specifically set them, Nightscout will use the
+default settings for pump battery alerts as shown below:
 
 <p align="center">
 <img src="../img/pump-ns.png" width="650">
 </p>
 
-Nightscout pump battery levels, if you leave things at default installation, will not trigger alarms.  If however you add a setting of `PUMP_ENABLE_ALERTS` to `true`, you will receive pump battery notifications according to the levels shown in the parenthesis above.  For example, your x23 pump is reporting its levels in percent, therefore you'd receive a yellow warning alarm at 30% and an urgent red alarm at 20%.  Your x22 pump however is reporting its levels at voltage readings, therefore you'd receive a warning yellow alarm at 1.35v and an urgent red alarm at 1.30v.
+Nightscout pump battery levels, if you leave things at default installation,
+will not trigger alarms. If however you add a setting of `PUMP_ENABLE_ALERTS` to
+`true`, you will receive pump battery notifications according to the levels
+shown in the parenthesis above. For example, your x23 pump is reporting its
+levels in percent, therefore you'd receive a yellow warning alarm at 30% and an
+urgent red alarm at 20%. Your x22 pump however is reporting its levels at
+voltage readings, therefore you'd receive a warning yellow alarm at 1.35v and an
+urgent red alarm at 1.30v.
 
-!!!info ""
-    Are the default NS alarm levels going to work for you?  The answer depends on what type of battery level you are using, what model pump you are using, and how much advance notification you want to receive before needing to change a pump battery.  There is a bit of personal preference and experimentation to finding what works for you.
+!!!info "" Are the default NS alarm levels going to work for you? The answer
+depends on what type of battery level you are using, what model pump you are
+using, and how much advance notification you want to receive before needing to
+change a pump battery. There is a bit of personal preference and experimentation
+to finding what works for you.
 
 <p align="center">
 <u><b>For x22 or x15 pump users, the NS alert settings that may need to be adjusted are the ones based on voltage.</b></u>
 </p>
 Generally speaking, for a x22 or x15 pump using alkaline batteries, the default NS alarm levels will be too early to be useful and lead you to change out your battery too frequently.  Alkaline batteries can go to low 1.2s or high 1.1s before Looping starts to have communication problems.  How much lower than the default voltage 1.35/1.30 alarm levels you want to go will depend on how far in advance you want to be warned about an upcoming battery change.
 
-If however, you are using a x22 or x15 pump with lithium batteries, the default 1.35v/1.30v alarm levels may be completely appropriate.  Remember how the lithium battery curves at the start of this discussion died off quickly around 1.3v?  You won't get hardly any heads-up notice for a lithium battery if you set the alarm below 1.3v.
+If however, you are using a x22 or x15 pump with lithium batteries, the default
+1.35v/1.30v alarm levels may be completely appropriate. Remember how the lithium
+battery curves at the start of this discussion died off quickly around 1.3v? You
+won't get hardly any heads-up notice for a lithium battery if you set the alarm
+below 1.3v.
 
 <p align="center">
 <u><b>For x23 or x54 pump users, the NS alert settings that may need to be adjusted are the ones based on percentage settings.</b></u>
 </p>
 
-Alkaline and lithium batteries should have automatically had their percentage-remaining based on the correct battery type in your Loop settings.  So, generally speaking the default NS alert levels don't generally need adjusting.  However, if you are using lithium batteries, the drop off between 75% to 25% can be quite dramatic and not be easy to anticipate (especially if the drop happens overnight).
+Alkaline and lithium batteries should have automatically had their
+percentage-remaining based on the correct battery type in your Loop settings.
+So, generally speaking the default NS alert levels don't generally need
+adjusting. However, if you are using lithium batteries, the drop off between 75%
+to 25% can be quite dramatic and not be easy to anticipate (especially if the
+drop happens overnight).
 
-As an alternative method of tracking pump battery changes, you could use the insulin age (IAGE) plug-in to anticipate your pump battery changes as well.  For example, after tracking pump battery life on my 723 using energizer batteries lithium batteries for the last several months, I know that we get about 15 days plus a handful of hours.  The amount of hours more beyond 15 days varies depending on how much we've interacted with the pump buttons directly, whether we've looped the full 15-days solid, and if the pump has been in extreme weather (cold weather can sap pump battery life).  By tracking the pump battery changes with NS's careportal "insulin cartridge change", I can see in advance if we are nearing an overnight on a 15 day battery and decide to change batteries before overnight to prevent any middle-of-night battery issues.
+As an alternative method of tracking pump battery changes, you could use the
+insulin age (IAGE) plug-in to anticipate your pump battery changes as well. For
+example, after tracking pump battery life on my 723 using energizer batteries
+lithium batteries for the last several months, I know that we get about 15 days
+plus a handful of hours. The amount of hours more beyond 15 days varies
+depending on how much we've interacted with the pump buttons directly, whether
+we've looped the full 15-days solid, and if the pump has been in extreme weather
+(cold weather can sap pump battery life). By tracking the pump battery changes
+with NS's careportal "insulin cartridge change", I can see in advance if we are
+nearing an overnight on a 15 day battery and decide to change batteries before
+overnight to prevent any middle-of-night battery issues.
 
-!!!info ""
-    * Lithium batteries will get a significantly longer life than an alkaline battery.
-    * Experiment and track your particular pump model and battery type to understand what NS settings will work best for you.
-    * Do not rely on the pump's on-screen pump battery indicator, especially when using lithium batteries.
+!!!info "" _ Lithium batteries will get a significantly longer life than an
+alkaline battery. _ Experiment and track your particular pump model and battery
+type to understand what NS settings will work best for you. \* Do not rely on
+the pump's on-screen pump battery indicator, especially when using lithium
+batteries.

--- a/docs/operation/features/bolus.md
+++ b/docs/operation/features/bolus.md
@@ -2,58 +2,152 @@
 
 <p align="center">
 <img src="../img/toolbar.png" width="300">
-</p> 
+</p>
 
-Bolus entries can be made manually through the bolus tool (double orange triangles) in the toolbar, either as part of a meal bolus or as a correction for a high BG.
+Bolus entries can be made manually through the bolus tool (double orange
+triangles) in the toolbar, either as part of a meal bolus or as a correction for
+a high BG.
 
 ## Meal Bolus
-Loop has a bolus tool, similar to a pump’s bolus wizard. After a carb entry is saved, Loop will provide a bolus screen with a recommended bolus amount. The only time the bolus screen wouldn't appear is if Loop believes the insulin-on-board is already sufficient to cover the added carbs or you are missing current blood glucose data. If you want to deliver the total amount of the recommended bolus, simply tap on the recommended amount of units and the bolus delivery line will automatically be filled in with the same units. If you want to give fewer units than the recommended amount, you can manually enter the desired amount to be delivered.
 
-The bolus tool will not offer a recommended bolus if your BG is predicted to go below your specified suspend threshold. A screen will appear letting you know the reason no bolus is being recommended, as well as the status of your active COB and IOB. You can choose to override that warning and give a bolus, or treat the low BG and come back to the bolus tool when your BG has recovered.
+Loop has a bolus tool, similar to a pump’s bolus wizard. After a carb entry is
+saved, Loop will provide a bolus screen with a recommended bolus amount. The
+only time the bolus screen wouldn't appear is if Loop believes the
+insulin-on-board is already sufficient to cover the added carbs or you are
+missing current blood glucose data. If you want to deliver the total amount of
+the recommended bolus, simply tap on the recommended amount of units and the
+bolus delivery line will automatically be filled in with the same units. If you
+want to give fewer units than the recommended amount, you can manually enter the
+desired amount to be delivered.
+
+The bolus tool will not offer a recommended bolus if your BG is predicted to go
+below your specified suspend threshold. A screen will appear letting you know
+the reason no bolus is being recommended, as well as the status of your active
+COB and IOB. You can choose to override that warning and give a bolus, or treat
+the low BG and come back to the bolus tool when your BG has recovered.
 
 <p align="center">
 <img src="../img/below_min.png" width="400">
-</p> 
+</p>
 
 ## Correction Bolus
-Occasionally, a recommended bolus will be offered in the bolus tool unrelated to a newly saved carb entry. In those cases, Loop is calculating that it will not be able to stay in the BG correction range through the use of high temp basals alone and is offering a “correction bolus”. Correction boluses will not be delivered automatically by Loop, they must be delivered by the user. Loop will also not give an alert when a correction bolus is being offered, the bolus entry tool must be clicked to check for one. The Loop pill in Nightscout will display when Loop has a recommended bolus calculated. In a well-tuned Loop with decent carb counting, correction boluses should be infrequently needed.
+
+Occasionally, a recommended bolus will be offered in the bolus tool unrelated to
+a newly saved carb entry. In those cases, Loop is calculating that it will not
+be able to stay in the BG correction range through the use of high temp basals
+alone and is offering a “correction bolus”. Correction boluses will not be
+delivered automatically by Loop, they must be delivered by the user. Loop will
+also not give an alert when a correction bolus is being offered, the bolus entry
+tool must be clicked to check for one. The Loop pill in Nightscout will display
+when Loop has a recommended bolus calculated. In a well-tuned Loop with decent
+carb counting, correction boluses should be infrequently needed.
 
 ## Starting Bolus Notification
-A new status line will appear when Loop is sending a bolus command to the pump. Just above the main screen's glucose chart, you will see a "starting bolus" indicator.
+
+A new status line will appear when Loop is sending a bolus command to the pump.
+Just above the main screen's glucose chart, you will see a "starting bolus"
+indicator.
 
 <p align="center">
 <img src="/setup/update/img/starting_bolus.png" width="250">
 </p>
 
 ## Bolus Failure Notifications
-On occasion, you will receive notification that a bolus may have failed. In some of these cases, the bolus actually will begin delivery. Therefore, you should always check the pump screen to verify the bolus status before attempting to redeliver a failed bolus.
 
-!!!info ""
-    There is a known issue with some x15 WW pumps falsely stating bolus failure notifications with every bolus.  Please read [here](https://github.com/LoopKit/Loop/issues/587) for additional information about how to fix the issue until Loop code is updated with a permanent fix.
+On occasion, you will receive notification that a bolus may have failed. In some
+of these cases, the bolus actually will begin delivery. Therefore, you should
+always check the pump screen to verify the bolus status before attempting to
+redeliver a failed bolus.
+
+!!!info "" There is a known issue with some x15 WW pumps falsely stating bolus
+failure notifications with every bolus. Please read
+[here](https://github.com/LoopKit/Loop/issues/587) for additional information
+about how to fix the issue until Loop code is updated with a permanent fix.
 
 ## Pre-Meal
 
-The pre-meal override target can be used prior to bolusing in order to help control post-prandial BGs. Most users will set a lower pre-meal target than what their normal correction range is. For example, a pre-meal target might be 80 - 80 mg/dL while your normal correction range might be 100-110 mg/dL. If you engage the pre-meal targets up to an hour before the meal, Loop will deliver an "extra" amount of insulin while it aims for that lower BG target. By getting the insulin in a little sooner, there will be more active insulin awaiting the carb absorption when the meal is eaten.
+The pre-meal override target can be used prior to bolusing in order to help
+control post-prandial BGs. Most users will set a lower pre-meal target than what
+their normal correction range is. For example, a pre-meal target might be 80 -
+80 mg/dL while your normal correction range might be 100-110 mg/dL. If you
+engage the pre-meal targets up to an hour before the meal, Loop will deliver an
+"extra" amount of insulin while it aims for that lower BG target. By getting the
+insulin in a little sooner, there will be more active insulin awaiting the carb
+absorption when the meal is eaten.
 
-The pre-meal target will remain active until (1) 60 minutes has passed since it was activated, or (2) a carbohydrate entry has been saved in Loop, or (3) the Loop user manually cancels the pre-meal target by tapping on the icon again. Whichever of these happens first will cancel the pre-meal targets. If no action is taken, the pre-meal target will end on its own after 60 minutes.
+The pre-meal target will remain active until (1) 60 minutes has passed since it
+was activated, or (2) a carbohydrate entry has been saved in Loop, or (3) the
+Loop user manually cancels the pre-meal target by tapping on the icon again.
+Whichever of these happens first will cancel the pre-meal targets. If no action
+is taken, the pre-meal target will end on its own after 60 minutes.
 
-If you are using the pre-meal target and save the carbs for the meal entry, Loop will cancel the pre-meal target and revert back to your normal correction range. Loop will account for the insulin it has "pre-bolused" while trying to reach the lower pre-meal target, and use your normal correction range when making the bolus recommendation.
+If you are using the pre-meal target and save the carbs for the meal entry, Loop
+will cancel the pre-meal target and revert back to your normal correction range.
+Loop will account for the insulin it has "pre-bolused" while trying to reach the
+lower pre-meal target, and use your normal correction range when making the
+bolus recommendation.
 
 ## Square or Dual Waves
-Unfortunately, Loop cannot enact temp basals while the pump is delivering a square- or dual-wave bolus. Therefore, you will need to use alternate bolusing strategies for situation where you would've previously used those extended bolusing techniques.
 
-The good news is that Loop has the only "smart" bolus tool available in any DIY or commercial loop. Because you are entering a carb absorption time with each carb entry, Loop is also using that information to predict how well your insulin bolusing and carb absorption will align. So when Loop offers you a bolus, it may actually offer less of a bolus upfront for long, slow-carb meals...and will make up the remaining bolus amount via high temp basals later.
+Unfortunately, Loop cannot enact temp basals while the pump is delivering a
+square- or dual-wave bolus. Therefore, you will need to use alternate bolusing
+strategies for situation where you would've previously used those extended
+bolusing techniques.
 
-In understanding Loop's smart bolusing, it may help to think back to the reason you originally used square- or dual-wave boluses. Typically, you used those extended bolusing strategies because if you had entered all the insulin, based on carb ratio alone, upfront at the beginning of the meal...you would have gone low shortly after bolusing. The food would simply be absorbing too slow and the whole amount of insulin working too fast...and you'd go low until the rest of the meal would kick in later. The extended bolusing was a way of avoiding the early low and also addressing the later high for meals like pizza or Chinese food.
+The good news is that Loop has the only "smart" bolus tool available in any DIY
+or commercial loop. Because you are entering a carb absorption time with each
+carb entry, Loop is also using that information to predict how well your insulin
+bolusing and carb absorption will align. So when Loop offers you a bolus, it may
+actually offer less of a bolus upfront for long, slow-carb meals...and will make
+up the remaining bolus amount via high temp basals later.
 
-Loop emulates that extended bolusing when you enter long-duration carb absorptions. Let's use an example of a pizza meal where carb ratios alone would've required a 10 unit bolus for the meal.  By telling Loop the meal will take a long (aka 4+ hours) carb absorption time, Loop may only offer 6 units up-front as an initial bolus. After you eat though, Loop knows that it has not provided all the insulin that will be necessary to account for the carbs. Loop will provide the remaining 4 units via high temp basals as soon as predicted BGs are showing that there is no danger of a post-prandial low. In other words, Loop waits until the danger of a quick low is over and then will high temp to cover the late digesting carbs. If you don't want to wait for Loop to deliver the remaining "second" bolus via high temps, you can click on the bolus tool when BGs start to rise and deliver the remaining bolus needed. Loop will have a recommended bolus awaiting when the predicted BGs are above correction range.
+In understanding Loop's smart bolusing, it may help to think back to the reason
+you originally used square- or dual-wave boluses. Typically, you used those
+extended bolusing strategies because if you had entered all the insulin, based
+on carb ratio alone, upfront at the beginning of the meal...you would have gone
+low shortly after bolusing. The food would simply be absorbing too slow and the
+whole amount of insulin working too fast...and you'd go low until the rest of
+the meal would kick in later. The extended bolusing was a way of avoiding the
+early low and also addressing the later high for meals like pizza or Chinese
+food.
 
-You can read another example of this extended bolusing technique over on [LoopTips.org](https://kdisimone.github.io/looptips/how-to/bolus/).
+Loop emulates that extended bolusing when you enter long-duration carb
+absorptions. Let's use an example of a pizza meal where carb ratios alone
+would've required a 10 unit bolus for the meal. By telling Loop the meal will
+take a long (aka 4+ hours) carb absorption time, Loop may only offer 6 units
+up-front as an initial bolus. After you eat though, Loop knows that it has not
+provided all the insulin that will be necessary to account for the carbs. Loop
+will provide the remaining 4 units via high temp basals as soon as predicted BGs
+are showing that there is no danger of a post-prandial low. In other words, Loop
+waits until the danger of a quick low is over and then will high temp to cover
+the late digesting carbs. If you don't want to wait for Loop to deliver the
+remaining "second" bolus via high temps, you can click on the bolus tool when
+BGs start to rise and deliver the remaining bolus needed. Loop will have a
+recommended bolus awaiting when the predicted BGs are above correction range.
 
-While you adapt to new bolusing techniques, it is important to monitor closely to see what works for you. It will take some trial and error to get it right. For meals like Chinese food, where there is a mix of fast carbs and slow carbs, you may want to break the total meal entry into a couple mixed carb entries to help Loop provide the best bolus recommendation upfront. Additionally, some people account for the fats/proteins that digest by adding slow carbs with long absorption times for meals that cause late BG rises.
+You can read another example of this extended bolusing technique over on
+[LoopTips.org](https://kdisimone.github.io/looptips/how-to/bolus/).
 
-A very useful tool is to check back on your Insulin Counteraction Effects graph to see how your original entry compared to how Loop perceived your final meal impacts. You can read more about that tool [here](https://loopkit.github.io/loopdocs/operation/features/ice/).
+While you adapt to new bolusing techniques, it is important to monitor closely
+to see what works for you. It will take some trial and error to get it right.
+For meals like Chinese food, where there is a mix of fast carbs and slow carbs,
+you may want to break the total meal entry into a couple mixed carb entries to
+help Loop provide the best bolus recommendation upfront. Additionally, some
+people account for the fats/proteins that digest by adding slow carbs with long
+absorption times for meals that cause late BG rises.
+
+A very useful tool is to check back on your Insulin Counteraction Effects graph
+to see how your original entry compared to how Loop perceived your final meal
+impacts. You can read more about that tool
+[here](https://loopkit.github.io/loopdocs/operation/features/ice/).
 
 ## Glucodyn
-Using the [Glucodyn](http://perceptus.org) model can help you simulate new bolusing strategies.  Glucodyn allows you to simulate your post-prandial BGs based on your particular ISF, carb ratio, and carbs. You can simulate split boluses and watch their impact on simulated BG responses.  The underlying math of the Glucodyn model was the basis of Loop's insulin/carb calculations in early Loop versions. The math has changed since then, however the model still provides a useful visualization about the interactions between DIA, carb absorption times and insulin dosing.
 
+Using the [Glucodyn](http://perceptus.org) model can help you simulate new
+bolusing strategies. Glucodyn allows you to simulate your post-prandial BGs
+based on your particular ISF, carb ratio, and carbs. You can simulate split
+boluses and watch their impact on simulated BG responses. The underlying math of
+the Glucodyn model was the basis of Loop's insulin/carb calculations in early
+Loop versions. The math has changed since then, however the model still provides
+a useful visualization about the interactions between DIA, carb absorption times
+and insulin dosing.

--- a/docs/operation/features/carbs.md
+++ b/docs/operation/features/carbs.md
@@ -4,11 +4,20 @@
 <img src="../img/toolbar.png" width="400">
 </p>
 
-New carb entries can be made by using the green carb tool in the toolbar at the bottom of the status screen.  Do not use your pump's bolus wizard or pump's carb entry to record carbs into the Loop app.  Nor should you use Nightscout's careportal to enter carbs, as Loop does not read carb entries remotely.
+New carb entries can be made by using the green carb tool in the toolbar at the
+bottom of the status screen. Do not use your pump's bolus wizard or pump's carb
+entry to record carbs into the Loop app. Nor should you use Nightscout's
+careportal to enter carbs, as Loop does not read carb entries remotely.
 
 ## New Carbs
 
-To begin a new meal entry, simply enter the number of carbs to be eaten in the `amount consumed` line.  By default, the carb absorption time for a new carb entry will correspond to the taco icon.  If you haven't made any customizations to the lollipop, taco, or pizza icons during your Loop build, then the default carb absorption time will display as 3 hours.  The default time entry is for the current time and date.  Once you press `Save` on the carb entry screen, the Loop's bolus tool will open to provide a recommended bolus.
+To begin a new meal entry, simply enter the number of carbs to be eaten in the
+`amount consumed` line. By default, the carb absorption time for a new carb
+entry will correspond to the taco icon. If you haven't made any customizations
+to the lollipop, taco, or pizza icons during your Loop build, then the default
+carb absorption time will display as 3 hours. The default time entry is for the
+current time and date. Once you press `Save` on the carb entry screen, the
+Loop's bolus tool will open to provide a recommended bolus.
 
 <p align="center">
 <img src="../img/carb_entry.png" width="300">
@@ -16,11 +25,14 @@ To begin a new meal entry, simply enter the number of carbs to be eaten in the `
 
 ## Avoid Double Carb Entries
 
-!!!info "Be Aware"
-    When you press `Save` for a carb entry, Loop will consider that carb entry saved and use it for calculating temp basals and recommended boluses.  Be cautious about repeated attempts to enter the same meal...Loop will continue to save the carb entries UNLESS you push cancel on the carb entry screen.</br></br>
-    **Simply canceling a bolus does not cancel the carb entry.**</br></br>
-    If you have accidentally made multiple entries for the same carbs, click on the Carbs Chart in the main Loop display and you can delete the redundant carb entries by swiping left on the entries.
-
+!!!info "Be Aware" When you press `Save` for a carb entry, Loop will consider
+that carb entry saved and use it for calculating temp basals and recommended
+boluses. Be cautious about repeated attempts to enter the same meal...Loop will
+continue to save the carb entries UNLESS you push cancel on the carb entry
+screen.</br></br> **Simply canceling a bolus does not cancel the carb
+entry.**</br></br> If you have accidentally made multiple entries for the same
+carbs, click on the Carbs Chart in the main Loop display and you can delete the
+redundant carb entries by swiping left on the entries.
 
 ## Carb Absorption Time
 
@@ -28,9 +40,16 @@ To begin a new meal entry, simply enter the number of carbs to be eaten in the `
 <img src="../img/food_icons_times.png" width="300">
 </p>
 
-To select your carb entry's absorption time, you can either click on the default food emojis or manually enter carb absorption time by selecting the `absorption time` line in the carb entry tool.
+To select your carb entry's absorption time, you can either click on the default
+food emojis or manually enter carb absorption time by selecting the
+`absorption time` line in the carb entry tool.
 
-The plate emoji, found to the right of the pizza emoji, can also be used if you are unsure of a new food.  There are other food emojis grouped into fast, medium, and slow absorbing foods.  This may be particularly useful for teens that are trying to learn new foods/meals.  Additionally, if you select the plate icon, you can add text to your `food type` by selecting the `abc` button in the bottom left corner of the screen.
+The plate emoji, found to the right of the pizza emoji, can also be used if you
+are unsure of a new food. There are other food emojis grouped into fast, medium,
+and slow absorbing foods. This may be particularly useful for teens that are
+trying to learn new foods/meals. Additionally, if you select the plate icon, you
+can add text to your `food type` by selecting the `abc` button in the bottom
+left corner of the screen.
 
 <p align="center">
 <img src="../img/plate.png" width="300">
@@ -40,32 +59,79 @@ The plate emoji, found to the right of the pizza emoji, can also be used if you 
 <img src="../img/ns-plate.png" width="900">
 </p>
 
-The default carb absorption times in Loop app are average representations for high, medium, and low glycemic index foods.  Ever since Loop v1.4.0, the algorithm incorporates dynamic carb absorption.  Previous Loop versions were based on a curve that assumed the rate of carb absorption would start out slow, increase to a mid-point, and then taper off.  However, in the real world, carb absorption is quite variable.  Dynamic carb absorption model is able to model some of this variability and allow Loop to respond more reasonably when actual carb absorption is not matching well with the selected carb absorption time for a meal.  In short, while entering a carb absorption time is still part of recording meals in Loop, it is much less critical to get it right.  Now your entry serves more as a guideline, than a rule, for Loop to model carb absorption.  For a more detailed explanation of the new dynamic carb absorption model, please read about it [here](https://github.com/LoopKit/Loop/pull/507).
+The default carb absorption times in Loop app are average representations for
+high, medium, and low glycemic index foods. Ever since Loop v1.4.0, the
+algorithm incorporates dynamic carb absorption. Previous Loop versions were
+based on a curve that assumed the rate of carb absorption would start out slow,
+increase to a mid-point, and then taper off. However, in the real world, carb
+absorption is quite variable. Dynamic carb absorption model is able to model
+some of this variability and allow Loop to respond more reasonably when actual
+carb absorption is not matching well with the selected carb absorption time for
+a meal. In short, while entering a carb absorption time is still part of
+recording meals in Loop, it is much less critical to get it right. Now your
+entry serves more as a guideline, than a rule, for Loop to model carb
+absorption. For a more detailed explanation of the new dynamic carb absorption
+model, please read about it [here](https://github.com/LoopKit/Loop/pull/507).
 
-To help Loop adjust for carbs that may digest slower than your original estimate, Loop will initially apply a 1.5x multiplier to your entered carb absorption time.  So, a meal entered using the taco icon will initially be treated as a 4.5 hour absorption meal.  As Loop observes the BG impacts of the meal, Loop will shorten the meal's absorption time if BGs are showing quicker impacts than expected, as well as adjust insulin deliveries (e.g., increase temp basals).  You can watch the progression of the Loop's observations of your meal by clicking on the Carbs Chart and watching the insulin counteraction effects.
+To help Loop adjust for carbs that may digest slower than your original
+estimate, Loop will initially apply a 1.5x multiplier to your entered carb
+absorption time. So, a meal entered using the taco icon will initially be
+treated as a 4.5 hour absorption meal. As Loop observes the BG impacts of the
+meal, Loop will shorten the meal's absorption time if BGs are showing quicker
+impacts than expected, as well as adjust insulin deliveries (e.g., increase temp
+basals). You can watch the progression of the Loop's observations of your meal
+by clicking on the Carbs Chart and watching the insulin counteraction effects.
 
 ## Mixed Carb Meals
 
-You do not have to enter all carbs for a meal at the same absorption or eating time.  If you want to enter some of the meal's carbs as faster, and some slower, you can log the meal over several individual carb entries.  For example, for meals that have sugary carbs as well as slow acting carbs (Chinese food), you may wish to do part of the carbs as lollipop and part of the carbs as pizza.
+You do not have to enter all carbs for a meal at the same absorption or eating
+time. If you want to enter some of the meal's carbs as faster, and some slower,
+you can log the meal over several individual carb entries. For example, for
+meals that have sugary carbs as well as slow acting carbs (Chinese food), you
+may wish to do part of the carbs as lollipop and part of the carbs as pizza.
 
-Pressing the `Save` button in the top right corner will save the carbs into the Loop app and bring up the Loop's bolus tool.  When entering multiple carb absorption durations for a single meal, press save on the carb entry and then press cancel on the bolus tool when it appears.  When you have entered your last carb entry for the meal, then use the bolus tool to deliver the bolus for the entire meal.  Loop will provide a recommendation based on all the saved carbs and their respective absorption durations in total.
+Pressing the `Save` button in the top right corner will save the carbs into the
+Loop app and bring up the Loop's bolus tool. When entering multiple carb
+absorption durations for a single meal, press save on the carb entry and then
+press cancel on the bolus tool when it appears. When you have entered your last
+carb entry for the meal, then use the bolus tool to deliver the bolus for the
+entire meal. Loop will provide a recommendation based on all the saved carbs and
+their respective absorption durations in total.
 
-## Prebolus 
-You can let Loop know you are going to prebolus a meal by adjusting the time of the carb entry on the “date” line of the carb entry.  If you are prebolusing by 20 minutes, simply add 20 minutes to the carb entry time.  
+## Prebolus
+
+You can let Loop know you are going to prebolus a meal by adjusting the time of
+the carb entry on the “date” line of the carb entry. If you are prebolusing by
+20 minutes, simply add 20 minutes to the carb entry time.
 
 ## Edit Carbs
 
-Clicking on the Carbohydrate chart in the Loop's main status screen will open the carb entry history and previous entries can be modified or deleted through this screen.  If you need to change a prebolus time, add/subtract carbs, adjust carb absorption times (even mid-meal), just go into that edit screen and tap on the carb entry you'd like to edit, or left-swipe to delete the entry entirely.  This can be a particularly useful tool when:
+Clicking on the Carbohydrate chart in the Loop's main status screen will open
+the carb entry history and previous entries can be modified or deleted through
+this screen. If you need to change a prebolus time, add/subtract carbs, adjust
+carb absorption times (even mid-meal), just go into that edit screen and tap on
+the carb entry you'd like to edit, or left-swipe to delete the entry entirely.
+This can be a particularly useful tool when:
 
-* You did not finish an entire meal that you bolused for,
-* You did not get to eat meal at the time you originally expected,
-* You ate more servings than originally entered, or
-* You suspect your carb count was in error because BGs are rising more/less than expected.
+- You did not finish an entire meal that you bolused for,
+- You did not get to eat meal at the time you originally expected,
+- You ate more servings than originally entered, or
+- You suspect your carb count was in error because BGs are rising more/less than
+  expected.
 
 <p align="center">
 <img src="../img/carb_edit.png" width="300">
 </p>
 
 ## Third Party Apps
-If you use a 3rd party app, such as My Fitness Pal, to enter and track carbs and that app also stores the carb values in HealthKit, Loop will read those values from Apple HealthKit and display and use them in calculating temp basal rates. Entries from 3rd party apps can not be removed from within Loop.  You will have to edit them in the third party app, or from the Health app. Because of this potential for confusion, it is recommended to turn off Loop's ability to read other apps' carbohydrate data from HealthKit. You are asked if you want to enable this when Loop is first installed. After installation, you can also go to the Settings App -> Privacy -> Health -> Loop and turn off `Read Data for Carbohydrates`.
 
+If you use a 3rd party app, such as My Fitness Pal, to enter and track carbs and
+that app also stores the carb values in HealthKit, Loop will read those values
+from Apple HealthKit and display and use them in calculating temp basal rates.
+Entries from 3rd party apps can not be removed from within Loop. You will have
+to edit them in the third party app, or from the Health app. Because of this
+potential for confusion, it is recommended to turn off Loop's ability to read
+other apps' carbohydrate data from HealthKit. You are asked if you want to
+enable this when Loop is first installed. After installation, you can also go to
+the Settings App -> Privacy -> Health -> Loop and turn off
+`Read Data for Carbohydrates`.

--- a/docs/operation/features/healthapp.md
+++ b/docs/operation/features/healthapp.md
@@ -1,24 +1,38 @@
 # Health App
 
-Loop app uses the iPhone's Health app to store BGs, insulin, and carbohydrate data.  Insulin Data is a new feature with iOS 11.  You can check your Health App settings for Loop by opening the Health App, clicking on Sources at the bottom bar, and then clicking on the Loop app.
+Loop app uses the iPhone's Health app to store BGs, insulin, and carbohydrate
+data. Insulin Data is a new feature with iOS 11. You can check your Health App
+settings for Loop by opening the Health App, clicking on Sources at the bottom
+bar, and then clicking on the Loop app.
 
 <p align="center">
 <img src="../img/healthapp.jpg" width="350">
 </p>
 
-Summaries of your carbohydrates, insulin, and BG results can be found by clicking on the Health Data at the bottom bar, and then selecting either the large Nutrition box (for carbohydrates) or smaller Results line (for insulin deliveries and BG results).
+Summaries of your carbohydrates, insulin, and BG results can be found by
+clicking on the Health Data at the bottom bar, and then selecting either the
+large Nutrition box (for carbohydrates) or smaller Results line (for insulin
+deliveries and BG results).
 
 <p align="center">
 <img src="../img/health_data.jpg" width="350">
 </p>
 
-If you toggle on the "add to favorites" slider for the individual data categories (insulin, BGs, carbohydrates), the data from those categories will be added to your Today view for easy quick reference and access.
+If you toggle on the "add to favorites" slider for the individual data
+categories (insulin, BGs, carbohydrates), the data from those categories will be
+added to your Today view for easy quick reference and access.
 
 <p align="center">
 <img src="../img/todayhealth.jpg" width="500">
 </p>
 
-The summary data for the categories can help you follow monthly trends, help identify periods of insulin sensitivity/resistance, evaluate total daily insulin use, breakdown of basal vs bolus insulin, and carbohydrate consumptions.  You can sort your data trends by day, week, month, or year views and scroll back through time in each of those data trends.  You can even quickly use these data for endocrinology appointments discussions...as they provide the endocrinologist with a very quick and useful set of data points directly from your Loop system.
+The summary data for the categories can help you follow monthly trends, help
+identify periods of insulin sensitivity/resistance, evaluate total daily insulin
+use, breakdown of basal vs bolus insulin, and carbohydrate consumptions. You can
+sort your data trends by day, week, month, or year views and scroll back through
+time in each of those data trends. You can even quickly use these data for
+endocrinology appointments discussions...as they provide the endocrinologist
+with a very quick and useful set of data points directly from your Loop system.
 
 <p align="center">
 <img src="../img/health1.jpg" width="750">

--- a/docs/operation/features/ice.md
+++ b/docs/operation/features/ice.md
@@ -1,57 +1,112 @@
 # Insulin Counteraction Effects
 
-Tapping on your Carbohydrates graph will open up a page that tracks your carb entries for the day (since midnight).  At the top of the page is a useful graphic called Insulin Counteraction Effects (ICE for short).  What is it?  Basically, a graphical representation of **<i>predicted</i>** upward-BG effects vs. <i>**encountered</i>** upward-BG effects.
+Tapping on your Carbohydrates graph will open up a page that tracks your carb
+entries for the day (since midnight). At the top of the page is a useful graphic
+called Insulin Counteraction Effects (ICE for short). What is it? Basically, a
+graphical representation of **<i>predicted</i>** upward-BG effects vs.
+<i>**encountered</i>** upward-BG effects.
 
-Consider the possible sources of triggers that counteract insulin (in other words, make BGs go up)
+Consider the possible sources of triggers that counteract insulin (in other
+words, make BGs go up)
 
-* food
-* stress
-* illness
-* someone sat too close to you
+- food
+- stress
+- illness
+- someone sat too close to you
 
-As we all know, this list can be long but, on "normal" days FOOD will be the single strongest "insulin counteracter".  Food will be the most influence on making BGs go up.  There are also other reasons that BGs climb when we may have expected them to be steady; basals being set too low, failed infusion site, etc.
+As we all know, this list can be long but, on "normal" days FOOD will be the
+single strongest "insulin counteracter". Food will be the most influence on
+making BGs go up. There are also other reasons that BGs climb when we may have
+expected them to be steady; basals being set too low, failed infusion site, etc.
 
-If we assume that it's a "normal" day (basals are close to correct, illness is not an issue, the site is good), Loop will expect most of the UPWARD pressure on BGs are from food.  Loop is calling that upward pressure Insulin Counteraction Effect (ICE).  This is a pretty reasonable assumption so let's use that for the rest of this discussion.
+If we assume that it's a "normal" day (basals are close to correct, illness is
+not an issue, the site is good), Loop will expect most of the UPWARD pressure on
+BGs are from food. Loop is calling that upward pressure Insulin Counteraction
+Effect (ICE). This is a pretty reasonable assumption so let's use that for the
+rest of this discussion.
 
 ## ICE display
 
-Let's take a look at an example day using the screenshot below.  The graph at the top of your ICE page represents that upward pressure Loop expects from the food entries.  The predicted ICE is shown as grey bars.  As a meal is tracked by Loop, you'll see green bars of observed ICE.
+Let's take a look at an example day using the screenshot below. The graph at the
+top of your ICE page represents that upward pressure Loop expects from the food
+entries. The predicted ICE is shown as grey bars. As a meal is tracked by Loop,
+you'll see green bars of observed ICE.
 
 <p align="center">
 <img src="../img/ice-3.png" width="700">
 </p>
 
-When you make a food entry originally, Loop will save your entry as you've made it.  On the line below your original entry, Loop will also start tracking your food entry assuming a 1.5 times longer carb absorption time.  This helps Loop track carbs that may actually be absorbing longer than you expected (part of that whole dynamic carb absorption modeling).  Loop will be updating that value of "observed" carb absorption time as well as absorbed carbs as your meal goes on.
-
+When you make a food entry originally, Loop will save your entry as you've made
+it. On the line below your original entry, Loop will also start tracking your
+food entry assuming a 1.5 times longer carb absorption time. This helps Loop
+track carbs that may actually be absorbing longer than you expected (part of
+that whole dynamic carb absorption modeling). Loop will be updating that value
+of "observed" carb absorption time as well as absorbed carbs as your meal goes
+on.
 
 ## Practical use
 
-So how can we use this information to make our Looping experience better?  The answer is probably best illustrated using a real-world example.  Chinese food...in fact, THIS Chinese dish.  General Tso's chicken.  As you can see in the recipe, loads of fast carbs with ingredients like hoisin sauce, brown sugar, and cornstarch.  But also slower carbs like chicken.  Rice can be a difficult one because for us, it acts fast but also seems to have a long tail.
+So how can we use this information to make our Looping experience better? The
+answer is probably best illustrated using a real-world example. Chinese
+food...in fact, THIS Chinese dish. General Tso's chicken. As you can see in the
+recipe, loads of fast carbs with ingredients like hoisin sauce, brown sugar, and
+cornstarch. But also slower carbs like chicken. Rice can be a difficult one
+because for us, it acts fast but also seems to have a long tail.
 
 <p align="center">
 <img src="../img/ice.jpg" width="500">
 </p>
 
-It was a busy day and I really didn't want to count carbs.  Ok, even on the slow days I don't want to count carbs.  I just eyeballed the bowl of food and guessed.  As I entered the food in originally, I was still trying to come up with a good guess on the ratio of fast:slow carbs but kid was in a hurry to eat.  My initial guess around 3:30pm was 70g of carbs at 5 hours absorption (note: it gets edited to 80g in a little bit), we bolused for that and she started to eat.  About 10 minutes later, I decided to add 10g of fast-acting carbs at 1-hour absorption to help with the sauce's speedy carbs.
+It was a busy day and I really didn't want to count carbs. Ok, even on the slow
+days I don't want to count carbs. I just eyeballed the bowl of food and guessed.
+As I entered the food in originally, I was still trying to come up with a good
+guess on the ratio of fast:slow carbs but kid was in a hurry to eat. My initial
+guess around 3:30pm was 70g of carbs at 5 hours absorption (note: it gets edited
+to 80g in a little bit), we bolused for that and she started to eat. About 10
+minutes later, I decided to add 10g of fast-acting carbs at 1-hour absorption to
+help with the sauce's speedy carbs.
 
 <p align="center">
 <img src="../img/ice-2.jpg" width="700">
 </p>
 
-Watching what was going on a little later...BGs were rising at a decent clip and I had a feeling I really didn't cover things super well...so I edited the original 70g entry, adding 10g and making it 80g instead.  (That's why there is a 2U bolus around 4:20pm.)  And of course around 5:40pm there was a little bit of nibbling on the leftovers as we put them into the fridge.  We gave 10g for that.  BGs climbed a bit more, not surprising given how we were underestimating fast carbs at this point...but still not so bad at 180 peak BG.  (Anna gave 2 units correction at the peak because there was dessert coming later that night and she wanted to be ready for it without too much pre-bolus.)
+Watching what was going on a little later...BGs were rising at a decent clip and
+I had a feeling I really didn't cover things super well...so I edited the
+original 70g entry, adding 10g and making it 80g instead. (That's why there is a
+2U bolus around 4:20pm.) And of course around 5:40pm there was a little bit of
+nibbling on the leftovers as we put them into the fridge. We gave 10g for that.
+BGs climbed a bit more, not surprising given how we were underestimating fast
+carbs at this point...but still not so bad at 180 peak BG. (Anna gave 2 units
+correction at the peak because there was dessert coming later that night and she
+wanted to be ready for it without too much pre-bolus.)
 
 <p align="center">
 <img src="../img/ice-5.png" width="500">
 </p>
 
-So, how can I use the ICE info to make this meal better?  I can look at the observed ICE information and the observed carb entry Loop has recorded to adjust my insulin bolusing the next time we eat this meal.
+So, how can I use the ICE info to make this meal better? I can look at the
+observed ICE information and the observed carb entry Loop has recorded to adjust
+my insulin bolusing the next time we eat this meal.
 
-For example, the biggest weakness I had in this (and suspected it even as I did the initial bolus) was that I underestimated the sauce's fast carbs.  I can see this in the observed ICE graph having the early green peaks after the meal, and in the way that the observed carb distribution was more like 7:2 vs my original guess of 8:1 (slow:fast carbs).  Overall, it appears that I guess on overall carb content pretty closely (90g vs. 89g observed).  Next time we have General Tso's chicken, I will likely bolus it as 70g at 5 hours and 20g at 2 hours.
+For example, the biggest weakness I had in this (and suspected it even as I did
+the initial bolus) was that I underestimated the sauce's fast carbs. I can see
+this in the observed ICE graph having the early green peaks after the meal, and
+in the way that the observed carb distribution was more like 7:2 vs my original
+guess of 8:1 (slow:fast carbs). Overall, it appears that I guess on overall carb
+content pretty closely (90g vs. 89g observed). Next time we have General Tso's
+chicken, I will likely bolus it as 70g at 5 hours and 20g at 2 hours.
 
 <p align="center">
 <img src="../img/ice-6.jpg" width="700">
 </p>
 
-So remember to check your ICE page at the end of a meal's absorption.  By checking in on the meal's observed behaviors, you'll have a good starting point to fine-tuning any new or unknown carb breakdown.
+So remember to check your ICE page at the end of a meal's absorption. By
+checking in on the meal's observed behaviors, you'll have a good starting point
+to fine-tuning any new or unknown carb breakdown.
 
-Side note:  remember this conversation is assuming you have basals fairly well set and are not sick.  If other factors could be significantly causing your BGs to swing that Loop doesn't know about (bad sites, illness, or basal rates that need to be adjusted), they may be attributed to ICE when they really aren't food-related.  In those cases, address the underlying cause and then use the ICE pages when you've come back to "normal".
+Side note: remember this conversation is assuming you have basals fairly well
+set and are not sick. If other factors could be significantly causing your BGs
+to swing that Loop doesn't know about (bad sites, illness, or basal rates that
+need to be adjusted), they may be attributed to ICE when they really aren't
+food-related. In those cases, address the underlying cause and then use the ICE
+pages when you've come back to "normal".

--- a/docs/operation/features/notifications.md
+++ b/docs/operation/features/notifications.md
@@ -1,81 +1,113 @@
-# Loop Notifications 
+# Loop Notifications
 
-Loop provides discrete notifications on the iPhone and Watch which will appear on the (locked) screen and vibrate, depending on your notification settings of Loop.
+Loop provides discrete notifications on the iPhone and Watch which will appear
+on the (locked) screen and vibrate, depending on your notification settings of
+Loop.
 
 <font color ="orange">**Omnipod**</font>  
-Most beep alarms are disabled for a much more discrete use of the omnipod. Only the following audible acknowledgments or alarms are currently used:
+Most beep alarms are disabled for a much more discrete use of the omnipod. Only
+the following audible acknowledgments or alarms are currently used:
 
-* Pod activated acknowledgment when filling the pod with enough insulin when pairing a new Pod.
-* Pod expiration advisory alarm at 72 hours/3 days (which you can silence in the [pod status  settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status))
-* Pod empty reservoir (which you can silence in the [pod status  settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status))
-* Pod deactivation acknowledgment 
-* Pod fault alarm (also called a screamer) when reaching the max life of the Pod: 80 hours (3 days + 8 hours) or a fault/occlusion happens. (which you can silence using the [replace pod](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#pod-commands)) command in the pod settings page)
+- Pod activated acknowledgment when filling the pod with enough insulin when
+  pairing a new Pod.
+- Pod expiration advisory alarm at 72 hours/3 days (which you can silence in the
+  [pod status settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status))
+- Pod empty reservoir (which you can silence in the
+  [pod status settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status))
+- Pod deactivation acknowledgment
+- Pod fault alarm (also called a screamer) when reaching the max life of the
+  Pod: 80 hours (3 days + 8 hours) or a fault/occlusion happens. (which you can
+  silence using the
+  [replace pod](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#pod-commands))
+  command in the pod settings page)
+
 ## Notification settings for Loop
 
-You can customize the way notifications of Loop are behaving in the Settings App of the iPhone:
+You can customize the way notifications of Loop are behaving in the Settings App
+of the iPhone:
+
 <p align="center">
 <img src="../img/iphone-settings-notifications.png" width="250">
-</p> 
+</p>
 
 Settings of Loop:
+
 <p align="center">
 <img src="../img/iphone-notifications-loop.png" width="250">
-</p> 
+</p>
 
 ## Loop Failure
 
-At 20, 40, 60, and 120 minutes, there is a Loop Failure notification.
-This mostly happens when the connection is lost for a longer period of time between the CGM or the Rileylink and Loop.
+At 20, 40, 60, and 120 minutes, there is a Loop Failure notification. This
+mostly happens when the connection is lost for a longer period of time between
+the CGM or the Rileylink and Loop.
 
 <p align="center">
 <img src="../img/loop-failure.png" width="250">
-</p> 
+</p>
 
 ## Bolus Failure
-If Loop detects that a bolus was not able to be delivered, it will provide a notification.  Bolus failures are usually due to stale pump data.  Try fetching recent history from the RileyLink menu to update pump data.  Loop will also notify of partial bolus deliveries.
+
+If Loop detects that a bolus was not able to be delivered, it will provide a
+notification. Bolus failures are usually due to stale pump data. Try fetching
+recent history from the RileyLink menu to update pump data. Loop will also
+notify of partial bolus deliveries.
 
 <p align="center">
 <img src="../img/loop-bolus-failure.png" width="250">
-</p> 
+</p>
 
 ## Low Reservoir
 
 <font color ="orange">**Medtronic**</font>  
-At 20% and 10% remaining reservoir volume, there is a Low Reservoir notification.
+At 20% and 10% remaining reservoir volume, there is a Low Reservoir
+notification.
 
 <font color ="orange">**Omnipod**</font>  
-At <30U, <20U, <10U  
+At <30U, <20U, <10U
 
 <p align="center">
 <img src="../img/pod-reservoir-10U.png" width="250">
-</p> 
-
+</p>
 
 ## Empty Reservoir
 
-Loop will notify when the reservoir is empty. Loop will notify you every minute with this notification. 
+Loop will notify when the reservoir is empty. Loop will notify you every minute
+with this notification.
 
 <font color ="orange">**Omnipod**</font>  
-Normally you will have 5-30 minutes to replace the pod, but do know the pod can [scream](https://soundcloud.com/eelke-jager/1f-nibble-f) at any moment from this point on.
+Normally you will have 5-30 minutes to replace the pod, but do know the pod can
+[scream](https://soundcloud.com/eelke-jager/1f-nibble-f) at any moment from this
+point on.
 
 <p align="center">
 <img src="../img/loop-reservoir-empty.png" width="250">
-</p> 
+</p>
 
 ## Pod Expiration (Omnipod)
- 
-You can customize the time of notification when to replace your pod any time from 1 hour up to 71 hours (3 days - 1 hour) [after staring a new pod](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#expiration-reminder) or you change the time later in the [pod configuration settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#configuration).
-The expiry alarm will always sound when the pod reaches a running full 3 days (72 hours) which you can silence [in the pod status settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status).
+
+You can customize the time of notification when to replace your pod any time
+from 1 hour up to 71 hours (3 days - 1 hour)
+[after staring a new pod](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#expiration-reminder)
+or you change the time later in the
+[pod configuration settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#configuration).
+The expiry alarm will always sound when the pod reaches a running full 3 days
+(72 hours) which you can silence
+[in the pod status settings](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/#status).
 
 <p align="center">
 <img src="../img/pod-expiration-notice.png" width="250">
-</p> 
+</p>
 
 ## Low Battery (Medtronic)
 
-Loop will notify when battery levels have approximately 8-10 hours of battery life remaining.
-
+Loop will notify when battery levels have approximately 8-10 hours of battery
+life remaining.
 
 ## Remote Notifications
 
-Loop does not have a remote notification to other devices.  If you are a remotely monitoring parent, you will want to read [here](https://loopkit.github.io/loopdocs/nightscout/pushover/#pushover) about setting up pushover alerts using your Nightscout site if you want proactive notifications of looping related information.
+Loop does not have a remote notification to other devices. If you are a remotely
+monitoring parent, you will want to read
+[here](https://loopkit.github.io/loopdocs/nightscout/pushover/#pushover) about
+setting up pushover alerts using your Nightscout site if you want proactive
+notifications of looping related information.

--- a/docs/operation/features/watch.md
+++ b/docs/operation/features/watch.md
@@ -4,14 +4,33 @@
 <img src="../img/watch.png" width="150">
 </p>
 
-If you add an Apple Watch after building Loop, you will need to pair your watch to your iPhone and then rebuild Loop to enable the Loop watch app to show up as an available watch app.
+If you add an Apple Watch after building Loop, you will need to pair your watch
+to your iPhone and then rebuild Loop to enable the Loop watch app to show up as
+an available watch app.
 
-Loop is currently supported with all released versions of the Apple Watch and Apple watchOS 4.1 and newer.  The cool factor is increased since the Loop user can directly enter carbs and boluses straight from the watch, without needing to access the iPhone.  The Loop watch app shows the Loop status, current BG, eventual BG, carb tool, and bolus tool.
+Loop is currently supported with all released versions of the Apple Watch and
+Apple watchOS 4.1 and newer. The cool factor is increased since the Loop user
+can directly enter carbs and boluses straight from the watch, without needing to
+access the iPhone. The Loop watch app shows the Loop status, current BG,
+eventual BG, carb tool, and bolus tool.
 
-By tapping on the carb or bolus tools, you can adjust the entries using the crown to dial in more/less.  The default installation of the Loop's watch app auto-fills in 75% of the recommended bolus, and you can manually scroll to get the full bolus amount.  Please check the [Apple Watch customizations section](https://loopkit.github.io/loopdocs/build/code_customization/#apple-watch-customizations) if you wish to change that to 100% recommended bolus as the initial autofill.
+By tapping on the carb or bolus tools, you can adjust the entries using the
+crown to dial in more/less. The default installation of the Loop's watch app
+auto-fills in 75% of the recommended bolus, and you can manually scroll to get
+the full bolus amount. Please check the
+[Apple Watch customizations section](https://loopkit.github.io/loopdocs/build/code_customization/#apple-watch-customizations)
+if you wish to change that to 100% recommended bolus as the initial autofill.
 
-If you swipe the Apple Watch Loop screen from right-to-left, a second screen is available.  This second screen displays a graph of recent BG and predicted BG data.  The crown can be turned to display IOB and COB as well.
+If you swipe the Apple Watch Loop screen from right-to-left, a second screen is
+available. This second screen displays a graph of recent BG and predicted BG
+data. The crown can be turned to display IOB and COB as well.
 
-A loop complication exists to show BG on the watch face but the update rate is limited to ~30mins due to limitations imposed by Apple to increase battery life. If constant, real-time monitoring is desired, you should use the Loop app as the main screen. This can be achieved by setting the watch to always show the last opened app on wake. Loop will always have to be the last app opened for this to work.  (Note: recent watchOS seems to be a bit flakey on actually bringing up the last app used, and instead often defaults to the user's watch face instead.  If you have a Loop complication installed in the watch face, you can simply tap the complication to open Loop's watch app.)
-
-
+A loop complication exists to show BG on the watch face but the update rate is
+limited to ~30mins due to limitations imposed by Apple to increase battery life.
+If constant, real-time monitoring is desired, you should use the Loop app as the
+main screen. This can be achieved by setting the watch to always show the last
+opened app on wake. Loop will always have to be the last app opened for this to
+work. (Note: recent watchOS seems to be a bit flakey on actually bringing up the
+last app used, and instead often defaults to the user's watch face instead. If
+you have a Loop complication installed in the watch face, you can simply tap the
+complication to open Loop's watch app.)

--- a/docs/operation/features/widget.md
+++ b/docs/operation/features/widget.md
@@ -1,6 +1,12 @@
 #iPhone Widget
 
-The Loop app will automatically build a widget that will be available on your iPhone.  The widget is available in the Today view of your iPhone.  Swipe right on your iPhone home screen and your widgets will be available.  The Loop widget maybe at the bottom of your widget list.  Scroll down to the bottom of the screen and press the `edit` button.  That opens an "Add Widgets" screen.  If you hold and drag the three horizontal lines on the Loop widget row, you can drag it up to the order you'd like it to appear on your widget list.
+The Loop app will automatically build a widget that will be available on your
+iPhone. The widget is available in the Today view of your iPhone. Swipe right on
+your iPhone home screen and your widgets will be available. The Loop widget
+maybe at the bottom of your widget list. Scroll down to the bottom of the screen
+and press the `edit` button. That opens an "Add Widgets" screen. If you hold and
+drag the three horizontal lines on the Loop widget row, you can drag it up to
+the order you'd like it to appear on your widget list.
 
 <p align="center">
 <img src="../img/widget_bar.png" width="600">

--- a/docs/operation/features/workout.md
+++ b/docs/operation/features/workout.md
@@ -4,15 +4,27 @@
 <img src="../img/workout_screen.png" width="200">
 </p>
 
-Workout mode enables a temporary override target from what would normally be scheduled. The default durations for the workout mode override target are 1 hour, 2 hours, or indefinitely. If you want more options for duration, you can [customize them during your Loop build](https://loopkit.github.io/loopdocs/build/code_customization/#workout-range-duration).
+Workout mode enables a temporary override target from what would normally be
+scheduled. The default durations for the workout mode override target are 1
+hour, 2 hours, or indefinitely. If you want more options for duration, you can
+[customize them during your Loop build](https://loopkit.github.io/loopdocs/build/code_customization/#workout-range-duration).
 
-Workout mode is used to temporarily set higher BG targets ahead of exercise that would normally cause BG to drop.  This should give the user less chance of going low during exercise because Loop will be less aggressive on setting high temp basals.  The success of the workout targets to control/prevent exercise-related BG drops will depend on the type, duration, and intensity of the activity.  Generally the more intense the workout, the farther in advance you would want to set a workout target.
+Workout mode is used to temporarily set higher BG targets ahead of exercise that
+would normally cause BG to drop. This should give the user less chance of going
+low during exercise because Loop will be less aggressive on setting high temp
+basals. The success of the workout targets to control/prevent exercise-related
+BG drops will depend on the type, duration, and intensity of the activity.
+Generally the more intense the workout, the farther in advance you would want to
+set a workout target.
 
-If you find that workout targets alone aren't sufficient to prevent exercise related lows, try to implement ways of decreasing the IOB you are carrying into the workout:
+If you find that workout targets alone aren't sufficient to prevent exercise
+related lows, try to implement ways of decreasing the IOB you are carrying into
+the workout:
 
-* Set the workout target farther in advance of workout activity,
-* Set the workout target higher than previously set, and/or
-* Decrease meal boluses prior to workout.
+- Set the workout target farther in advance of workout activity,
+- Set the workout target higher than previously set, and/or
+- Decrease meal boluses prior to workout.
 
-If you are the type to experience lows after workouts due to increased insulin sensitivity, you may want to extend your workout override target for a period of time after workout to help prevent lows. 
-
+If you are the type to experience lows after workouts due to increased insulin
+sensitivity, you may want to extend your workout override target for a period of
+time after workout to help prevent lows.

--- a/docs/operation/loop-settings/cgm.md
+++ b/docs/operation/loop-settings/cgm.md
@@ -1,6 +1,7 @@
 # Add CGM
 
-Now we need to add a CGM source so that Loop has BG data. From the Loop settings screen, select `Add CGM`.
+Now we need to add a CGM source so that Loop has BG data. From the Loop settings
+screen, select `Add CGM`.
 
 <p align="center">
 <img src="../img/add-cgm.png" width="550">
@@ -8,35 +9,72 @@ Now we need to add a CGM source so that Loop has BG data. From the Loop settings
 
 The standard selections available will be:
 
-* Dexcom G6
-* Dexcom G5
-* Dexcom G4
-* Dexcom Share
+- Dexcom G6
+- Dexcom G5
+- Dexcom G4
+- Dexcom Share
 
-!!!info ""
-    If you added a compatible Medtronic pump earlier in the setup process, then you will also see an option for the compatible Medtronic sensor that works with that same pump. If you are using a compatible MDT sensor, select that option and the CGM data will be uploaded to Loop when pump status is updated.
+!!!info "" If you added a compatible Medtronic pump earlier in the setup
+process, then you will also see an option for the compatible Medtronic sensor
+that works with that same pump. If you are using a compatible MDT sensor, select
+that option and the CGM data will be uploaded to Loop when pump status is
+updated.
 
 ## Dexcom G5 and G6
 
-The Dexcom G5 and G6 options only require the addition of the active transmitter ID, and the matching Dexcom app to be running on the Loop iPhone. You do not have to add your Dexcom Share account credentials, but if you do, make sure they match what you originally entered into your Dexcom app. 
+The Dexcom G5 and G6 options only require the addition of the active transmitter
+ID, and the matching Dexcom app to be running on the Loop iPhone. You do not
+have to add your Dexcom Share account credentials, but if you do, make sure they
+match what you originally entered into your Dexcom app.
 
-When you change transmitters, you will need to select the `Delete CGM` button at the very bottom of the CGM info page in Loop. Then you will select your Dexcom system again and add the new transmitter ID. You cannot just tap on your old transmitter ID to update it. 
+When you change transmitters, you will need to select the `Delete CGM` button at
+the very bottom of the CGM info page in Loop. Then you will select your Dexcom
+system again and add the new transmitter ID. You cannot just tap on your old
+transmitter ID to update it.
 
-If you don't update your transmitter ID when you change active transmitters, your Loop will be forced to go to your Dexcom Share server to get your CGM data and will not work without cell or wifi connection. When Loop is using data from Dexcom Share servers, a small cloud will appear above the BG reading in Loop and should tip you off that maybe you forgot to update your transmitter ID.
+If you don't update your transmitter ID when you change active transmitters,
+your Loop will be forced to go to your Dexcom Share server to get your CGM data
+and will not work without cell or wifi connection. When Loop is using data from
+Dexcom Share servers, a small cloud will appear above the BG reading in Loop and
+should tip you off that maybe you forgot to update your transmitter ID.
 
 ## Dexcom G4
-Dexcom G4 users will need the Dexcom G4 Share2 app active on their iPhone and paired to their Dexcom G4 Share receiver.
+
+Dexcom G4 users will need the Dexcom G4 Share2 app active on their iPhone and
+paired to their Dexcom G4 Share receiver.
 
 ## Dexcom Share
 
-The Dexcom Share selection is primarily for people who wish to test Loop function without a local CGM source and who are not running the Dexcom app on their Loop iPhone. This selection will require login access to a Dexcom Share account with live data and active internet connection in order to work.
+The Dexcom Share selection is primarily for people who wish to test Loop
+function without a local CGM source and who are not running the Dexcom app on
+their Loop iPhone. This selection will require login access to a Dexcom Share
+account with live data and active internet connection in order to work.
 
 ## About Dexcom Share credentials
-For all selections, the Dexcom Share credentials (in other words, account login) is the same as what you used to log in to the active Dexcom app on your iPhone. **Dexcom Share account is not always the same login info as your Dexcom Clarity account.** For G4 users, the Share account is found in the account tab on the app. For G5/G6 users, unfortunately, there is no information in the app displaying what your account name is. The information is entered when you first log in to the app and then is never displayed again, nor visible under any information screens. If you have forgotten your G5/G6 account info, you can delete the Dexcom app and redownload it to try logging in again. This will not cause a restart of any sensor sessions in progress.
+
+For all selections, the Dexcom Share credentials (in other words, account login)
+is the same as what you used to log in to the active Dexcom app on your iPhone.
+**Dexcom Share account is not always the same login info as your Dexcom Clarity
+account.** For G4 users, the Share account is found in the account tab on the
+app. For G5/G6 users, unfortunately, there is no information in the app
+displaying what your account name is. The information is entered when you first
+log in to the app and then is never displayed again, nor visible under any
+information screens. If you have forgotten your G5/G6 account info, you can
+delete the Dexcom app and redownload it to try logging in again. This will not
+cause a restart of any sensor sessions in progress.
 
 ## Spike Users
-Users who are using Spike app to access other CGM types (or to avoid using the Dexcom app), you will need to follow the directions contained within the Spike app in order to build/modify Loop with Spike. Loop does not natively support Spike app and does not currently plan to. You are responsible for modifying or adapting Loop in order to use Spike so that it is an available option as a CGM source.
+
+Users who are using Spike app to access other CGM types (or to avoid using the
+Dexcom app), you will need to follow the directions contained within the Spike
+app in order to build/modify Loop with Spike. Loop does not natively support
+Spike app and does not currently plan to. You are responsible for modifying or
+adapting Loop in order to use Spike so that it is an available option as a CGM
+source.
 
 ## Next Step: Configuration
 
-Now that you have added your CGM source, we need to complete the configuration and settings in your Loop. Please head over to the [Configuration page](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/) for guidance with this important part of Loop's setup.
+Now that you have added your CGM source, we need to complete the configuration
+and settings in your Loop. Please head over to the
+[Configuration page](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/)
+for guidance with this important part of Loop's setup.

--- a/docs/operation/loop-settings/configurations.md
+++ b/docs/operation/loop-settings/configurations.md
@@ -1,10 +1,17 @@
 # Configuration
 
-This page will cover two general parts of the Loop's settings, circled in red in the screenshot below. The headings will match the flow of the screen, top to bottom.
+This page will cover two general parts of the Loop's settings, circled in red in
+the screenshot below. The headings will match the flow of the screen, top to
+bottom.
 
-* The first circled section covers your Loop's closed/open loop status and Loop's Issue Report.
+- The first circled section covers your Loop's closed/open loop status and
+  Loop's Issue Report.
 
-* The second circled section is the configuration section. This section contains a lot of really important settings that control how your Loop will calculate your predicted BG curve. Given the importance of your predicted BG curve to Loop's actions, please make sure you read over this page carefully to know how to navigate the selections and entries.
+- The second circled section is the configuration section. This section contains
+  a lot of really important settings that control how your Loop will calculate
+  your predicted BG curve. Given the importance of your predicted BG curve to
+  Loop's actions, please make sure you read over this page carefully to know how
+  to navigate the selections and entries.
 
 <p align="center">
 <img src="../img/configurations.jpg" width="350">
@@ -12,122 +19,271 @@ This page will cover two general parts of the Loop's settings, circled in red in
 
 ## Closed/Open Loop
 
-The Closed Loop switch controls whether Loop automatically enacts its recommended temporary basal adjustments (closed loop mode) or whether you have to manually tap to enact the recommendations (open loop mode). In addition to the visual indicator on this switch discussed below, the [Loop's status icon on the main screen](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/#loop-status) will also appear differently depending on the mode selected. Open loop mode will have an incomplete circle for the Loop's status icon.</br></br>. 
+The Closed Loop switch controls whether Loop automatically enacts its
+recommended temporary basal adjustments (closed loop mode) or whether you have
+to manually tap to enact the recommendations (open loop mode). In addition to
+the visual indicator on this switch discussed below, the
+[Loop's status icon on the main screen](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/#loop-status)
+will also appear differently depending on the mode selected. Open loop mode will
+have an incomplete circle for the Loop's status icon.</br></br>.
 
 #### <u>Open Loop Mode</u>
 
 <p align="center">
 <img src="../img/open_loop.png" width="400">
-</p> 
+</p>
 
-When the Closed Loop switch is in the (Off&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;   ) position, Loop WILL NOT enact recommended temp basals automatically. Instead, Loop will display recommended temp basals on the main status display, just above the blood glucose graph. This is called **open loop**, and is a good way to understand how Loop will function, and what type of recommendations it would make. If you click on the recommended temp basal line while in open loop mode, Loop will implement the temp basal.</br></br>
+When the Closed Loop switch is in the (Off&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; )
+position, Loop WILL NOT enact recommended temp basals automatically. Instead,
+Loop will display recommended temp basals on the main status display, just above
+the blood glucose graph. This is called **open loop**, and is a good way to
+understand how Loop will function, and what type of recommendations it would
+make. If you click on the recommended temp basal line while in open loop mode,
+Loop will implement the temp basal.</br></br>
 
 #### <u>Closed Loop Mode</u>
+
 <p align="center">
 <img src="../img/closed_loop.png" width="400">
-</p> 
+</p>
 
-When the Closed Loop switch is in the (&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;   On) position, Loop WILL automatically enact recommended temp basals on the configured insulin pump. This is known as **closed loop**. Typically, Loop will show the recommended temp basal just above the blood glucose graph prior to automatically enacting it. It may take a minute or so for the Loop to enact the recommended basal. Once the temp basal has been enacted successfully on the pump, the recommended temp basal will disappear from the screen and the new temp basal rate will be represented in the insulin delivery graphs.
+When the Closed Loop switch is in the (&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; On)
+position, Loop WILL automatically enact recommended temp basals on the
+configured insulin pump. This is known as **closed loop**. Typically, Loop will
+show the recommended temp basal just above the blood glucose graph prior to
+automatically enacting it. It may take a minute or so for the Loop to enact the
+recommended basal. Once the temp basal has been enacted successfully on the
+pump, the recommended temp basal will disappear from the screen and the new temp
+basal rate will be represented in the insulin delivery graphs.
 
 ## Issue Report
-If you run into problems or errors with your Loop, an Issue Report can be used to help identify where the problem is occurring. The Issue Report is automatically generated and you can share it via email. Frequently, if you seek help with a technical problem, an Issue Report will provide insight for the developers and troubleshooters. Please email yourself an Issue Report anytime you are questioning Loop actions or displays. You can then use that Issue Report later to help debug the problem.
 
-!!!info "Before you continue further, a word about BG units"
-    Entries into the configuration section will be available in mg/dL or mmol/L automatically, based upon how your blood glucose values are received. By default they are set to mg/dL, however once CGM values arrive in mmol/L these Loop settings can be entered in mmol/L. **If you are planning to use mmol/L, be sure to wait to set your entries until after you have started to receive CGM values in Loop.** If you do these in the wrong order, then your charts and entries may have incorrect units.
+If you run into problems or errors with your Loop, an Issue Report can be used
+to help identify where the problem is occurring. The Issue Report is
+automatically generated and you can share it via email. Frequently, if you seek
+help with a technical problem, an Issue Report will provide insight for the
+developers and troubleshooters. Please email yourself an Issue Report anytime
+you are questioning Loop actions or displays. You can then use that Issue Report
+later to help debug the problem.
+
+!!!info "Before you continue further, a word about BG units" Entries into the
+configuration section will be available in mg/dL or mmol/L automatically, based
+upon how your blood glucose values are received. By default they are set to
+mg/dL, however once CGM values arrive in mmol/L these Loop settings can be
+entered in mmol/L. **If you are planning to use mmol/L, be sure to wait to set
+your entries until after you have started to receive CGM values in Loop.** If
+you do these in the wrong order, then your charts and entries may have incorrect
+units.
 
 ## Correction Range
 
-The correction range is your blood glucose range that you would like Loop to correct to. Correction range is not necessarily the same target blood glucose range that you have discussed with your endocrinologist; generally the doctor's range may be much wider. For example, you may keep a correction target of 100-110 for Loop to aim to, but use a desired BG target range of 80-180 when discussing things with your endo about "time in range".
+The correction range is your blood glucose range that you would like Loop to
+correct to. Correction range is not necessarily the same target blood glucose
+range that you have discussed with your endocrinologist; generally the doctor's
+range may be much wider. For example, you may keep a correction target of
+100-110 for Loop to aim to, but use a desired BG target range of 80-180 when
+discussing things with your endo about "time in range".
 
 <p align="center">
 <img src="../img/premeal_entry.jpg" width="250">
 </p>
 </br></br>
 
-Click the + in the upper right corner to add correction BG range(s). You can have multiple ranges based on time of day, but the first setting of the day needs to begin at midnight.
+Click the + in the upper right corner to add correction BG range(s). You can
+have multiple ranges based on time of day, but the first setting of the day
+needs to begin at midnight.
 
-Correction ranges can be a single number, such as 100-100 mg/dL, or a range such as 100-120 mg/dL. Generally speaking, if you choose to use a range, keeping the range between about 10-30 mg/dL between the lowest and highest value is a good starting place.
+Correction ranges can be a single number, such as 100-100 mg/dL, or a range such
+as 100-120 mg/dL. Generally speaking, if you choose to use a range, keeping the
+range between about 10-30 mg/dL between the lowest and highest value is a good
+starting place.
 
 ### Override Ranges
-Below the Correction Range entry is a section called "Overrides". Override ranges provide temporary alternate correction ranges. These override ranges will only be enacted when you specifically activate pre-meal or workout mode using the buttons on the main Loop display or watchface. While active, they replace the correction range for Loop's recommendations. If the override ranges are not entered in this section, the buttons will remain grey and unusable on the main screen's toolbar.
 
-**Pre-Meal:**
-The pre-meal override target can be used to as an easy way to get a small amount of insulin delivered before a meal in order to help control post-meal blood glucose spikes.
+Below the Correction Range entry is a section called "Overrides". Override
+ranges provide temporary alternate correction ranges. These override ranges will
+only be enacted when you specifically activate pre-meal or workout mode using
+the buttons on the main Loop display or watchface. While active, they replace
+the correction range for Loop's recommendations. If the override ranges are not
+entered in this section, the buttons will remain grey and unusable on the main
+screen's toolbar.
 
-If your normal target is 100-110 mg/dL and pre-meal target is 80-80 mg/dL, for example, Loop will give you an extra push to get you to the lower target number before the meal. This early insulin brings you into the meal with a mini-prebolus. The pre-meal target, when activated by pressing on the icon, will stay active for one hour, until carbs are entered, or until it is manually cancelled...whichever comes first.
+**Pre-Meal:** The pre-meal override target can be used to as an easy way to get
+a small amount of insulin delivered before a meal in order to help control
+post-meal blood glucose spikes.
 
-Loop will adjust any insulin bolus as needed based on the extra insulin provided during this pre-meal time.
+If your normal target is 100-110 mg/dL and pre-meal target is 80-80 mg/dL, for
+example, Loop will give you an extra push to get you to the lower target number
+before the meal. This early insulin brings you into the meal with a
+mini-prebolus. The pre-meal target, when activated by pressing on the icon, will
+stay active for one hour, until carbs are entered, or until it is manually
+cancelled...whichever comes first.
 
-**Workout Mode:**
-Workout override target is designed to temporarily set your target higher in anticipation of exercise or other activities which tend to make the user more insulin sensitive or need less insulin. By setting a higher temp target such as 140-160 mg/dL ahead of activity, Loop will recommend smaller basal rate(s) than normally scheduled in order to to bring blood glucose up to the higher target.
+Loop will adjust any insulin bolus as needed based on the extra insulin provided
+during this pre-meal time.
 
-The success of this strategy will be dependent on how far in advance of activity the override target is set. Generally, users set the target approximately 1-2 hours in advance of planned activities, but the optimal timing will depend on the activity, duration, and intensity. Additionally, any insulin on board from recent boluses may overwhelm the Loop's ability to counteract exercise-induced lows through lower temp basals alone. Please see LoopTips.org for additional information about [exercise and Loop](https://kdisimone.github.io/looptips/how-to/exercise/).
+**Workout Mode:** Workout override target is designed to temporarily set your
+target higher in anticipation of exercise or other activities which tend to make
+the user more insulin sensitive or need less insulin. By setting a higher temp
+target such as 140-160 mg/dL ahead of activity, Loop will recommend smaller
+basal rate(s) than normally scheduled in order to to bring blood glucose up to
+the higher target.
+
+The success of this strategy will be dependent on how far in advance of activity
+the override target is set. Generally, users set the target approximately 1-2
+hours in advance of planned activities, but the optimal timing will depend on
+the activity, duration, and intensity. Additionally, any insulin on board from
+recent boluses may overwhelm the Loop's ability to counteract exercise-induced
+lows through lower temp basals alone. Please see LoopTips.org for additional
+information about
+[exercise and Loop](https://kdisimone.github.io/looptips/how-to/exercise/).
 
 ## Suspend Threshold
-The suspend threshold must be set up for successful configuration of Loop. **Your Loop will not turn green without setting this value.** This value affects both bolus and basal recommendations by Loop.
+
+The suspend threshold must be set up for successful configuration of Loop.
+**Your Loop will not turn green without setting this value.** This value affects
+both bolus and basal recommendations by Loop.
 
 #### Bolus
 
-* If you are trying to bolus a meal while any part of the predicted BG curve is below this suspend threshold value, Loop will not recommend a bolus.  Instead, you will need to wait until your prediction curve is above the suspend threshold value in order to bolus.
+- If you are trying to bolus a meal while any part of the predicted BG curve is
+  below this suspend threshold value, Loop will not recommend a bolus. Instead,
+  you will need to wait until your prediction curve is above the suspend
+  threshold value in order to bolus.
 
 #### Basal
 
-* If your current or any point on your predicted BG curve is below the suspend threshold, Loop will always recommend a temporary basal rate of 0 U/hr.
+- If your current or any point on your predicted BG curve is below the suspend
+  threshold, Loop will always recommend a temporary basal rate of 0 U/hr.
 
-Reasonable settings for suspend threshold will depend on user preference, but recommended not set lower than 65 mg/dL.
+Reasonable settings for suspend threshold will depend on user preference, but
+recommended not set lower than 65 mg/dL.
 
 ## Basal Rates
 
-Your basal rates have already been initially populated when you finished the `Add Pump` part of the setup previously.  Only one basal schedule may be set in each Loop app. The basal increments are available according to the increments of the particular pump/pod you are using. Not all pumps provide the same increments for basal deliveries. Basal schedule must start at midnight and cannot contain rates of 0 U/hr.
+Your basal rates have already been initially populated when you finished the
+`Add Pump` part of the setup previously. Only one basal schedule may be set in
+each Loop app. The basal increments are available according to the increments of
+the particular pump/pod you are using. Not all pumps provide the same increments
+for basal deliveries. Basal schedule must start at midnight and cannot contain
+rates of 0 U/hr.
 
-If you need to edit your basal schedule, simply make the edits as needed and then click on `Save to Pump...` or `Sync With Pod` button, depending on which pump you are using. 
+If you need to edit your basal schedule, simply make the edits as needed and
+then click on `Save to Pump...` or `Sync With Pod` button, depending on which
+pump you are using.
 
-!!!info ""
-    If you make any basal edits and use the `Cancel` button to go back to the menu without successfully saving/syncing to pump/pod, the changes you made will not be saved. Loop makes saving/syncing to pump a mandatory step to successfully editing basal rates. If you get an error message while trying to save/sync the edited basal rates, please retry until successful.
+!!!info "" If you make any basal edits and use the `Cancel` button to go back to
+the menu without successfully saving/syncing to pump/pod, the changes you made
+will not be saved. Loop makes saving/syncing to pump a mandatory step to
+successfully editing basal rates. If you get an error message while trying to
+save/sync the edited basal rates, please retry until successful.
 
 ## Delivery Limits
 
-The maximum basal rate and maximum bolus settings are collectively referred to as Delivery Limits. This section will have been initially populated when you finished the `Add Pump` part of the setup previously. For safety, similar to basal schedule, you must keep these values the same on both the Loop app and within the pump/pod settings. If you edit these settings in Loop app, always use the `Save to Pump...` or `Sync With Pod` button, depending on which pump you are using.
+The maximum basal rate and maximum bolus settings are collectively referred to
+as Delivery Limits. This section will have been initially populated when you
+finished the `Add Pump` part of the setup previously. For safety, similar to
+basal schedule, you must keep these values the same on both the Loop app and
+within the pump/pod settings. If you edit these settings in Loop app, always use
+the `Save to Pump...` or `Sync With Pod` button, depending on which pump you are
+using.
 
 #### **Maximum Basal Rate**
-Maximum basal rate will cap the the maximum temporary basal rate that the Loop is allowed to enact to meet your correction range. Typically, Loop users set their maximum basal rate around 3-4 times their highest scheduled basal rate. When you are first beginning to use Loop, it is wise to start conservative (low) in setting your maximum basal rate. If your settings are incorrect in other areas (basal rates, insulin sensitivity, carb ratio, etc), you may need time to identify where settings need to be adjusted. This process is easier if Loop is given less latitude to set high basal rates. Gradually increase your maximum basal rate as your comfort and confidence in Loop increases. If you need help with your settings adjustment, head over to LoopTips for some [initial settings help](https://kdisimone.github.io/looptips/settings/settings/)
+
+Maximum basal rate will cap the the maximum temporary basal rate that the Loop
+is allowed to enact to meet your correction range. Typically, Loop users set
+their maximum basal rate around 3-4 times their highest scheduled basal rate.
+When you are first beginning to use Loop, it is wise to start conservative (low)
+in setting your maximum basal rate. If your settings are incorrect in other
+areas (basal rates, insulin sensitivity, carb ratio, etc), you may need time to
+identify where settings need to be adjusted. This process is easier if Loop is
+given less latitude to set high basal rates. Gradually increase your maximum
+basal rate as your comfort and confidence in Loop increases. If you need help
+with your settings adjustment, head over to LoopTips for some
+[initial settings help](https://kdisimone.github.io/looptips/settings/settings/)
 
 #### **Maximum Bolus**
-Enter your desired single bolus maximum here. For safety, don't set a maximum bolus limit any higher than your typical large meal bolus.
+
+Enter your desired single bolus maximum here. For safety, don't set a maximum
+bolus limit any higher than your typical large meal bolus.
 
 ## Insulin Model
-There are four insulin models to choose from; Walsh, Rapid-Acting Adults, Rapid-Acting Children, and Fiasp. If you want to read the nitty-gritty discussion that went into the development of the Rapid-Acting and Fiasp curves (collectively called "exponential insulin models"), you can see that in GitHub [here](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473).
 
-**We highly recommend selecting one of the exponential insulin models (in other words, not the Walsh model).** 
+There are four insulin models to choose from; Walsh, Rapid-Acting Adults,
+Rapid-Acting Children, and Fiasp. If you want to read the nitty-gritty
+discussion that went into the development of the Rapid-Acting and Fiasp curves
+(collectively called "exponential insulin models"), you can see that in GitHub
+[here](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473).
 
-A common new Loop user error is to select Walsh model in order to easily shorten their insulin duration (DIA) to one like they used prior to Looping. This almost invariably leads to insulin stacking. If you would like to read more about why the duration of insulin action is important in Loop vs how you've traditionally used it, please click [here](https://seemycgm.com/2017/08/09/why-dia-matters/) to read a blog post about the subject. In summary, choosing Walsh curve just to shorten your DIA will lead to insulin stacking and less than desired bolusing recommendations.
+**We highly recommend selecting one of the exponential insulin models (in other
+words, not the Walsh model).**
 
-You can click on each model and see what each model's insulin activity curve looks like, active one selected in blue. 
+A common new Loop user error is to select Walsh model in order to easily shorten
+their insulin duration (DIA) to one like they used prior to Looping. This almost
+invariably leads to insulin stacking. If you would like to read more about why
+the duration of insulin action is important in Loop vs how you've traditionally
+used it, please click [here](https://seemycgm.com/2017/08/09/why-dia-matters/)
+to read a blog post about the subject. In summary, choosing Walsh curve just to
+shorten your DIA will lead to insulin stacking and less than desired bolusing
+recommendations.
+
+You can click on each model and see what each model's insulin activity curve
+looks like, active one selected in blue.
 
 <p align="center">
 <img src="../img/models.jpg" width="350">
 </p>
 
-The differences between the three exponential models (two Rapid-Acting and Fiasp) models has to do with the timing of the peak insulin activity timing. Not surprising, since Fiasp is marketed as the "faster acting" insulin. Currently all the exponential models are defaulted to an insulin duration of 6 hours, but the peak activity of the curves differs:
+The differences between the three exponential models (two Rapid-Acting and
+Fiasp) models has to do with the timing of the peak insulin activity timing. Not
+surprising, since Fiasp is marketed as the "faster acting" insulin. Currently
+all the exponential models are defaulted to an insulin duration of 6 hours, but
+the peak activity of the curves differs:
 
-* Rapid-acting adult curve peaks at 75 minutes
-* Rapid-acting child curve peaks at 65 minutes
-* Fiasp peaks curve peaks at 55 minutes
+- Rapid-acting adult curve peaks at 75 minutes
+- Rapid-acting child curve peaks at 65 minutes
+- Fiasp peaks curve peaks at 55 minutes
 
 ## Carb Ratios
-Click the + in the upper right to add carb ratios for various times of day. Loop works best if you have [tested and optimized](https://kdisimone.github.io/looptips/settings/settings/) your carb ratio settings for accuracy.
 
-!!!info "Beware of other apps writing carbs to Health app"
-    If you are using a third-party app (such as Spike or MyFitness) that can write carbohydrates to the phone's Health app, you will need to edit the permissions to make sure Loop doesn't double carb entries.  You should disable the third-party app's permissions in Health so that they can only `read` and not `write`.  See [Carb Entries with Third Party apps](https://loopkit.github.io/loopdocs/operation/features/carbs/#third-party-apps) for more information about this setting.
+Click the + in the upper right to add carb ratios for various times of day. Loop
+works best if you have
+[tested and optimized](https://kdisimone.github.io/looptips/settings/settings/)
+your carb ratio settings for accuracy.
+
+!!!info "Beware of other apps writing carbs to Health app" If you are using a
+third-party app (such as Spike or MyFitness) that can write carbohydrates to the
+phone's Health app, you will need to edit the permissions to make sure Loop
+doesn't double carb entries. You should disable the third-party app's
+permissions in Health so that they can only `read` and not `write`. See
+[Carb Entries with Third Party apps](https://loopkit.github.io/loopdocs/operation/features/carbs/#third-party-apps)
+for more information about this setting.
 
 ## Insulin Sensitivities
-Insulin Sensitivity Factor (ISF) is the same term as Correction Factor used in some clinics and endocrinology offices. ISF represents the drop in blood glucose levels expected from one unit of insulin. Click the + in the upper right to add insulin sensitivities for various times of day. Loop works best if you have [tested and optimized](https://kdisimone.github.io/looptips/settings/settings/) your ISF settings for accuracy. Insulin sensitivities can change for many reasons including waiting too long to change your infusion set. Loop will not auto-detect changes in ISF.
 
-Incorrectly set ISF is the most common cause of roller coaster BGs for new Loop users. You will need to raise (increase) your ISF value/number to help smooth a roller coaster BG trend. You can read about that topic more over in LoopTips [here](https://kdisimone.github.io/looptips/settings/settings/#3rd-insulin-sensitivity-factor). 
+Insulin Sensitivity Factor (ISF) is the same term as Correction Factor used in
+some clinics and endocrinology offices. ISF represents the drop in blood glucose
+levels expected from one unit of insulin. Click the + in the upper right to add
+insulin sensitivities for various times of day. Loop works best if you have
+[tested and optimized](https://kdisimone.github.io/looptips/settings/settings/)
+your ISF settings for accuracy. Insulin sensitivities can change for many
+reasons including waiting too long to change your infusion set. Loop will not
+auto-detect changes in ISF.
+
+Incorrectly set ISF is the most common cause of roller coaster BGs for new Loop
+users. You will need to raise (increase) your ISF value/number to help smooth a
+roller coaster BG trend. You can read about that topic more over in LoopTips
+[here](https://kdisimone.github.io/looptips/settings/settings/#3rd-insulin-sensitivity-factor).
 
 ## Next Step: Loop Services
 
-You have completed the required configurations and settings in your Loop app. If you have a Nightscout site you'd like to connect Loop to, please continue on to the [Loop Services page](https://loopkit.github.io/loopdocs/operation/loop-settings/services). 
+You have completed the required configurations and settings in your Loop app. If
+you have a Nightscout site you'd like to connect Loop to, please continue on to
+the
+[Loop Services page](https://loopkit.github.io/loopdocs/operation/loop-settings/services).
 
-If you are not integrating with a Nightscout site and don't want any optional logging services connected, then please proceed to the [Loop's displays page](https://loopkit.github.io/loopdocs/operation/loop-settings/displays). Understanding the Loop displays can be a valuable tool to understanding your Loop's actions, and also for troubleshooting, if you are having issues.
-
+If you are not integrating with a Nightscout site and don't want any optional
+logging services connected, then please proceed to the
+[Loop's displays page](https://loopkit.github.io/loopdocs/operation/loop-settings/displays).
+Understanding the Loop displays can be a valuable tool to understanding your
+Loop's actions, and also for troubleshooting, if you are having issues.

--- a/docs/operation/loop-settings/displays.md
+++ b/docs/operation/loop-settings/displays.md
@@ -1,33 +1,53 @@
 # Loop Displays
 
-This section of the docs will go over the Loop displays available and what information they offer.  Information about your Loop's actions (or inactions) can often be found simply by looking at the visuals presented in the app.  
+This section of the docs will go over the Loop displays available and what
+information they offer. Information about your Loop's actions (or inactions) can
+often be found simply by looking at the visuals presented in the app.
 
 ## Status Screen
-The Status Screen is the main root navigation screen in Loop. It is broken up into 3 main display areas; Heads Up Display (HUD), Charts, and Toolbar. The HUD is the top area of the screen. This shows the status of the last time loop ran, current BG Reading, current temp basal, and current pump information. The next area is the charting area. This includes, glucose trend and prediction, Active Insulin, Insulin Delivery, and Carbohydrates. The final display area is the toolbar which has buttons for Carbs, Pre-Meal, Bolus, Workout Mode, and Settings.
+
+The Status Screen is the main root navigation screen in Loop. It is broken up
+into 3 main display areas; Heads Up Display (HUD), Charts, and Toolbar. The HUD
+is the top area of the screen. This shows the status of the last time loop ran,
+current BG Reading, current temp basal, and current pump information. The next
+area is the charting area. This includes, glucose trend and prediction, Active
+Insulin, Insulin Delivery, and Carbohydrates. The final display area is the
+toolbar which has buttons for Carbs, Pre-Meal, Bolus, Workout Mode, and
+Settings.
 
 <p align="center">
 <img src="../img/main_screen.jpg" width="550">
 </p>
 
-
 ### Heads Up Display
 
-The Heads Up Display (HUD) is a very useful quick reference guide to your Loop's status. Every 5 minutes, Loop updates CGM and pump/pod data. Loop timestamps the HUD data with the last data point that came in. If a timestamp goes older than 5 minutes old, that is a valuable indicator to where your Loop is failing to get the needed information. The HUD's first three icons, from left to right, are the same no matter whether you are using a Medtronic pump or Omnipod; status of the last time loop ran, current BG Reading, and current temp basal. The last two icons will change depending on what type of pump you are using.
+The Heads Up Display (HUD) is a very useful quick reference guide to your Loop's
+status. Every 5 minutes, Loop updates CGM and pump/pod data. Loop timestamps the
+HUD data with the last data point that came in. If a timestamp goes older than 5
+minutes old, that is a valuable indicator to where your Loop is failing to get
+the needed information. The HUD's first three icons, from left to right, are the
+same no matter whether you are using a Medtronic pump or Omnipod; status of the
+last time loop ran, current BG Reading, and current temp basal. The last two
+icons will change depending on what type of pump you are using.
 
-Medtronic users: The last two icons are the most recent (1) pump/reservoir status and (2) pump percentage battery remaining.
+Medtronic users: The last two icons are the most recent (1) pump/reservoir
+status and (2) pump percentage battery remaining.
 
 <p align="center">
 <img src="../img/mdt-hud.jpeg" width="400">
 </p></br>
 
-Omnipod users: The last two icons are the most recent (1) pod/reservoir status and (2) hours of pod use.
+Omnipod users: The last two icons are the most recent (1) pod/reservoir status
+and (2) hours of pod use.
 
 <p align="center">
 <img src="../img/pod-hud.jpeg" width="400">
 </p></br>
 
 #### Loop Status
-The Loop Status is the colored circle in the upper left corner of the main Loop display.  There are four colors that are typically displayed.
+
+The Loop Status is the colored circle in the upper left corner of the main Loop
+display. There are four colors that are typically displayed.
 
 <table>
 <tr>
@@ -52,8 +72,9 @@ The Loop Status is the colored circle in the upper left corner of the main Loop 
 </tr>
 </table>
 
-
-The loop status circle will pulse slightly when the RileyLink is giving the pump a new temp basal setting.  The pulsing will stop when the temp basal has been set by the pump.
+The loop status circle will pulse slightly when the RileyLink is giving the pump
+a new temp basal setting. The pulsing will stop when the temp basal has been set
+by the pump.
 
 #### Glucose
 
@@ -119,7 +140,8 @@ The loop status circle will pulse slightly when the RileyLink is giving the pump
 
 ## Charts
 
-There are several charts that help you navigate your Loop actions.  Clicking on each of the charts will also open up additional information.
+There are several charts that help you navigate your Loop actions. Clicking on
+each of the charts will also open up additional information.
 
 ### Glucose Chart
 
@@ -127,15 +149,34 @@ There are several charts that help you navigate your Loop actions.  Clicking on 
 <img src="../img/glucose_graph.jpg" width="400">
 </p>
 
-The glucose chart displays BG values in your preferred units. The vertical scale of the chart is calculated on the fly by Loop to be as useful as possible while including the highest and lowest readings in the chart.
+The glucose chart displays BG values in your preferred units. The vertical scale
+of the chart is calculated on the fly by Loop to be as useful as possible while
+including the highest and lowest readings in the chart.
 
-The horizontal axis is set to go forward from the current time until your DIA forward (so you can see what Loop eventually thinks BG will be). It then goes back in time as far as it can, based upon the width in pixels of your screen. Note, if you turn your device to landscape mode you will have more screen real estate and thus will be able to see further back in time.
+The horizontal axis is set to go forward from the current time until your DIA
+forward (so you can see what Loop eventually thinks BG will be). It then goes
+back in time as far as it can, based upon the width in pixels of your screen.
+Note, if you turn your device to landscape mode you will have more screen real
+estate and thus will be able to see further back in time.
 
-The BG correction range is shown as a blue bar on the glucose chart.  Single-value target BG range (such as 100-100 mg/dl), will have a narrower blue range.  When a temporary override range is enabled, a darker blue bar where the overrides are set will be displayed, as well as the normal correction target in lighter blue.
+The BG correction range is shown as a blue bar on the glucose chart.
+Single-value target BG range (such as 100-100 mg/dl), will have a narrower blue
+range. When a temporary override range is enabled, a darker blue bar where the
+overrides are set will be displayed, as well as the normal correction target in
+lighter blue.
 
-The eventual BG displayed on the right side of the chart does NOT take into account a recently enacted temp basal.  In other words, if you are above BG target and Loop just enacted a high temp basal to help, the eventual BG does not reflect the expected lowering of BGs that would result from that recently enacted temp basal.  Loop waits until the insulin has actually been delivery before it "uses" the insulin in its calculations for BG impacts.  If you suspended your pump or had a "no delivery" alarm shortly after the temp basal was started, you would want that accurately reflected in the insulin on board and associated eventual BG.
+The eventual BG displayed on the right side of the chart does NOT take into
+account a recently enacted temp basal. In other words, if you are above BG
+target and Loop just enacted a high temp basal to help, the eventual BG does not
+reflect the expected lowering of BGs that would result from that recently
+enacted temp basal. Loop waits until the insulin has actually been delivery
+before it "uses" the insulin in its calculations for BG impacts. If you
+suspended your pump or had a "no delivery" alarm shortly after the temp basal
+was started, you would want that accurately reflected in the insulin on board
+and associated eventual BG.
 
-If you tap on the Glucose Chart itself, it will open the Predicted Glucose chart described below.
+If you tap on the Glucose Chart itself, it will open the Predicted Glucose chart
+described below.
 
 ### Predicted Glucose Chart
 
@@ -143,9 +184,21 @@ If you tap on the Glucose Chart itself, it will open the Predicted Glucose chart
 <img src="../img/glucose_hidden.png" width="200">
 </p>
 
-The predicted glucose view is a great way to gain insight into the various components’ importance in Loop’s prediction of eventual BG. The graph at the top of this view will match your Glucose Chart. Below this chart you will see a very detailed explanation of all of the variables that Loop takes into account in predicting your future BG value. Each of those effects (including Carbohydrates, Insulin, Glucose Momentum and Retrospective Correction) includes details of the calculation used. You can tap on any of the entries to turn them off and on for visualization. The resulting changes can be viewed by the changes in the dashed lines.
+The predicted glucose view is a great way to gain insight into the various
+components’ importance in Loop’s prediction of eventual BG. The graph at the top
+of this view will match your Glucose Chart. Below this chart you will see a very
+detailed explanation of all of the variables that Loop takes into account in
+predicting your future BG value. Each of those effects (including Carbohydrates,
+Insulin, Glucose Momentum and Retrospective Correction) includes details of the
+calculation used. You can tap on any of the entries to turn them off and on for
+visualization. The resulting changes can be viewed by the changes in the dashed
+lines.
 
-Additionally, at the bottom of this screen there is a setting to `Enable Retrospective Correction`. By enabling it, it will more aggressively increase or decrease basal delivery when BG movement doesn’t match the carbohydrates and insulin-based model.  Most Loopers have found this setting to be quite useful and keep the slider on.
+Additionally, at the bottom of this screen there is a setting to
+`Enable Retrospective Correction`. By enabling it, it will more aggressively
+increase or decrease basal delivery when BG movement doesn’t match the
+carbohydrates and insulin-based model. Most Loopers have found this setting to
+be quite useful and keep the slider on.
 
 ### Active Insulin Chart
 
@@ -153,7 +206,15 @@ Additionally, at the bottom of this screen there is a setting to `Enable Retrosp
 <img src="../img/active_insulin.jpg" width="400">
 </p>
 
-The Active Insulin chart displays the total insulin contribution from both temp basals and boluses.  Active IOB can be either positive and negative IOB.  Negative IOB results from the suspension of normally scheduled basals.  The active insulin displayed in the upper right corner of the chart does NOT include insulin contributions from a recently enacted temp basal or bolus until the pump’s reservoir volume is read and confirms a drop in reservoir volume (confirming the insulin has actually been delivered).  So long as you have Event History as the Preferred Data Source in Loop settings, primed insulin deliveries (e.g., cannula fills or manual primes) will not be counted towards IOB.
+The Active Insulin chart displays the total insulin contribution from both temp
+basals and boluses. Active IOB can be either positive and negative IOB. Negative
+IOB results from the suspension of normally scheduled basals. The active insulin
+displayed in the upper right corner of the chart does NOT include insulin
+contributions from a recently enacted temp basal or bolus until the pump’s
+reservoir volume is read and confirms a drop in reservoir volume (confirming the
+insulin has actually been delivered). So long as you have Event History as the
+Preferred Data Source in Loop settings, primed insulin deliveries (e.g., cannula
+fills or manual primes) will not be counted towards IOB.
 
 ### Insulin Delivery Chart
 
@@ -161,9 +222,23 @@ The Active Insulin chart displays the total insulin contribution from both temp 
 <img src="../img/insulin_delivery.jpg" width="400">
 </p>
 
-The Insulin Delivery chart displays a history of the temp basals enacted by Loop.  The display is relative to the scheduled basal rates entered in the Loop settings.  So, a rate displayed in this chart as `+0 units` would indicate no temp basal was set, and Loop defaulted to the scheduled basal rate.  Individual boluses are indicated by an orange triangle on the chart (shown in the graphic above, near the left-most time).  The total insulin delivered since midnight, including all basals and boluses **AND priming insulin**, is given in the upper right corner of the graph.
+The Insulin Delivery chart displays a history of the temp basals enacted by
+Loop. The display is relative to the scheduled basal rates entered in the Loop
+settings. So, a rate displayed in this chart as `+0 units` would indicate no
+temp basal was set, and Loop defaulted to the scheduled basal rate. Individual
+boluses are indicated by an orange triangle on the chart (shown in the graphic
+above, near the left-most time). The total insulin delivered since midnight,
+including all basals and boluses **AND priming insulin**, is given in the upper
+right corner of the graph.
 
-Please be patient for a bolus delivery to appear.  There is a lag time from when you press the “deliver” bolus button to when the orange triangle is drawn sometimes.  The insulin has to be delivered and then the pump reservoir needs to be read to confirm delivery, before the triangle will appear and IOB will be added.  Occasionally, the bolus may be temporarily rendered (drawn) as a very high temp basal rate vs. a (triangle) discrete bolus event.  This does NOT mean that the Loop actually enacted a high temp basal rate...only that the bolus is being **drawn** on the chart in the equivalent of a high temp basal rate.
+Please be patient for a bolus delivery to appear. There is a lag time from when
+you press the “deliver” bolus button to when the orange triangle is drawn
+sometimes. The insulin has to be delivered and then the pump reservoir needs to
+be read to confirm delivery, before the triangle will appear and IOB will be
+added. Occasionally, the bolus may be temporarily rendered (drawn) as a very
+high temp basal rate vs. a (triangle) discrete bolus event. This does NOT mean
+that the Loop actually enacted a high temp basal rate...only that the bolus is
+being **drawn** on the chart in the equivalent of a high temp basal rate.
 
 ### Reservoir and Event History
 
@@ -171,11 +246,20 @@ Please be patient for a bolus delivery to appear.  There is a lag time from when
 <img src="../img/insulin_hidden.jpg" width="500">
 </p>
 
-Clicking on either the Active Insulin or Insulin Delivery charts will open your Insulin Delivery history.  The top of the screen will display the current IOB and the total insulin delivered for the day since midnight (or since the time the loop became active if you started Loop after midnight). There are two viewing options; Reservoir or Event History.  
+Clicking on either the Active Insulin or Insulin Delivery charts will open your
+Insulin Delivery history. The top of the screen will display the current IOB and
+the total insulin delivered for the day since midnight (or since the time the
+loop became active if you started Loop after midnight). There are two viewing
+options; Reservoir or Event History.
 
-* Reservoir: Omnipod users will not have a reservoir history displayed, simply because pods do not report or track insulin remaining until their reservoirs get below 50 units remaining. Medtronic users will have reservoir history displayed in 5-minute increments, unless Loop has been having communication issues.
+- Reservoir: Omnipod users will not have a reservoir history displayed, simply
+  because pods do not report or track insulin remaining until their reservoirs
+  get below 50 units remaining. Medtronic users will have reservoir history
+  displayed in 5-minute increments, unless Loop has been having communication
+  issues.
 
-* Event History: Event history is a detailed accounting of all pump/pod actions. Both Medtronic and Omnipod users will have a detailed record of event history.
+- Event History: Event history is a detailed accounting of all pump/pod actions.
+  Both Medtronic and Omnipod users will have a detailed record of event history.
 
 ### Carbohydrate Chart
 
@@ -183,13 +267,20 @@ Clicking on either the Active Insulin or Insulin Delivery charts will open your 
 <img src="../img/carb_graph.jpg" width="400">
 </p>
 
-The Carbohydrate chart displays the carbs used by Loop to predict BG changes.  The active COB is displayed in the upper right corner of the chart.  Clicking on the chart will open the Carb Entries history and you can edit/delete any previous entries through that screen.  Please read the [Carb Entries page](https://loopkit.github.io/loopdocs/operation/features/carbs/) for more information about editing carb entries.
+The Carbohydrate chart displays the carbs used by Loop to predict BG changes.
+The active COB is displayed in the upper right corner of the chart. Clicking on
+the chart will open the Carb Entries history and you can edit/delete any
+previous entries through that screen. Please read the
+[Carb Entries page](https://loopkit.github.io/loopdocs/operation/features/carbs/)
+for more information about editing carb entries.
 
 <p align="center">
 <img src="../img/carb_edit.png" width="300">
 </p>
 
-For more information about the Insulin Counteraction Effects information found in the Carb History, please see [here](https://loopkit.github.io/loopdocs/operation/features/ice/).
+For more information about the Insulin Counteraction Effects information found
+in the Carb History, please see
+[here](https://loopkit.github.io/loopdocs/operation/features/ice/).
 
 ## Tool Bar
 
@@ -197,18 +288,53 @@ For more information about the Insulin Counteraction Effects information found i
 <img src="../img/toolbar.png" width="400">
 </p>
 
-The toolbar is where your inputs to the Loop behavior take place.  The individual components of the toolbar are, left to right:
+The toolbar is where your inputs to the Loop behavior take place. The individual
+components of the toolbar are, left to right:
 
-* **Carb entry tool**- click on this tool to enter carbs into the Loop app.  Loop will not read carb entries from the pump or Nightscout, so you must use the carb entry tool in Loop app in order to have carbs accounted for by the Loop.  Detailed info regarding how to enter, save, and edit carb entries can be found in the [Carb Entries page](https://loopkit.github.io/loopdocs/operation/features/carbs/).
+- **Carb entry tool**- click on this tool to enter carbs into the Loop app. Loop
+  will not read carb entries from the pump or Nightscout, so you must use the
+  carb entry tool in Loop app in order to have carbs accounted for by the Loop.
+  Detailed info regarding how to enter, save, and edit carb entries can be found
+  in the
+  [Carb Entries page](https://loopkit.github.io/loopdocs/operation/features/carbs/).
 
-* **Pre-meal target** - click this tool to set the [Pre-Meal temporary override target](https://loopkit.github.io/loopdocs/setup/loop-settings/configurations/#override-ranges).  This target will remain in effect (1) for 60 minutes, (2) until a carb entry is saved, or (3) until the target is toggled off manually, whichever comes first.  The background coloring of the Pre-Meal target will turn green when active and there will be a dark blue line on the BG chart indicating where the override target is enabled.  For more information about the use of the Pre-Meal target, see the [Bolus Entries page](https://loopkit.github.io/loopdocs/operation/features/bolus/).
+- **Pre-meal target** - click this tool to set the
+  [Pre-Meal temporary override target](https://loopkit.github.io/loopdocs/setup/loop-settings/configurations/#override-ranges).
+  This target will remain in effect (1) for 60 minutes, (2) until a carb entry
+  is saved, or (3) until the target is toggled off manually, whichever comes
+  first. The background coloring of the Pre-Meal target will turn green when
+  active and there will be a dark blue line on the BG chart indicating where the
+  override target is enabled. For more information about the use of the Pre-Meal
+  target, see the
+  [Bolus Entries page](https://loopkit.github.io/loopdocs/operation/features/bolus/).
 
-* **Bolus tool** - click on this tool to bring up the bolus tool.  Normally, this screen will automatically open on its own and function as a bolus wizard when a meal is saved on the carb entry tool screen.  The only time the bolus tool will not automatically open is if the amount of carbs saved is determined to be adequately covered by the insulin on board already.  During rapidly rising BGs, where Loop doesn't have an adequate temp basal rate to cover the pace at which BGs are rising, you may try clicking on the bolus tool to see if Loop is recommending a correction bolus to help control the BG spike.  For more information about the Bolus tool features and use, see the [Bolus Entries page](https://loopkit.github.io/loopdocs/operation/features/bolus/).
+- **Bolus tool** - click on this tool to bring up the bolus tool. Normally, this
+  screen will automatically open on its own and function as a bolus wizard when
+  a meal is saved on the carb entry tool screen. The only time the bolus tool
+  will not automatically open is if the amount of carbs saved is determined to
+  be adequately covered by the insulin on board already. During rapidly rising
+  BGs, where Loop doesn't have an adequate temp basal rate to cover the pace at
+  which BGs are rising, you may try clicking on the bolus tool to see if Loop is
+  recommending a correction bolus to help control the BG spike. For more
+  information about the Bolus tool features and use, see the
+  [Bolus Entries page](https://loopkit.github.io/loopdocs/operation/features/bolus/).
 
-* **Workout Target** - click this tool to set the [Workout temporary override target](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/#override-ranges).  This target will remain in effect for the duration you select.  The standard duration selections available are 1-hour, 2-hour, or indefinitely.  You can add or modify those options, before building the Loop app, by using the [Workout mode customization option](https://loopkit.github.io/loopdocs/build/code_customization/#workout-range-duration).  For more information about using the Workout Mode, see [here](https://loopkit.github.io/loopdocs/operation/features/workout/).
+- **Workout Target** - click this tool to set the
+  [Workout temporary override target](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/#override-ranges).
+  This target will remain in effect for the duration you select. The standard
+  duration selections available are 1-hour, 2-hour, or indefinitely. You can add
+  or modify those options, before building the Loop app, by using the
+  [Workout mode customization option](https://loopkit.github.io/loopdocs/build/code_customization/#workout-range-duration).
+  For more information about using the Workout Mode, see
+  [here](https://loopkit.github.io/loopdocs/operation/features/workout/).
 
-* **Loop Settings** - click on this tool to make changes to any of your [Loop settings](https://loopkit.github.io/loopdocs/operation/overview).
+- **Loop Settings** - click on this tool to make changes to any of your
+  [Loop settings](https://loopkit.github.io/loopdocs/operation/overview).
 
 ## Next Step: RileyLink Menu
 
-You are almost there! One more Loop menu that you need to know about is your RileyLink. You can access your RileyLink menu by tapping on your pump/pod image in Loop settings. Click [here](https://loopkit.github.io/loopdocs/operation/loop-settings/rileylink/) to read more about your RileyLink menu.
+You are almost there! One more Loop menu that you need to know about is your
+RileyLink. You can access your RileyLink menu by tapping on your pump/pod image
+in Loop settings. Click
+[here](https://loopkit.github.io/loopdocs/operation/loop-settings/rileylink/) to
+read more about your RileyLink menu.

--- a/docs/operation/loop-settings/mdt-pump.md
+++ b/docs/operation/loop-settings/mdt-pump.md
@@ -1,23 +1,51 @@
 # Medtronic Pump Users
 
-Your Loop won’t have much showing initially until we get some basic settings input. The beginning step will be to add a pump to your Loop. If you are using a Medtronic pump, you can follow along for the rest of this page. If, however, you are using an Omnipod pump, please head over to [this page](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/) instead.
+Your Loop won’t have much showing initially until we get some basic settings
+input. The beginning step will be to add a pump to your Loop. If you are using a
+Medtronic pump, you can follow along for the rest of this page. If, however, you
+are using an Omnipod pump, please head over to
+[this page](https://loopkit.github.io/loopdocs/operation/loop-settings/omnipod-pump/)
+instead.
 
 ## Prepare Medtronic Pump
 
-!!!info ""
-    Before you begin the rest of the setup process, there are several steps on your Medtronic pump that you will need to complete prior to moving on with Loop setup. **DO NOT SKIP THESE STEPS OR YOUR LOOP WILL NOT WORK.**
+!!!info "" Before you begin the rest of the setup process, there are several
+steps on your Medtronic pump that you will need to complete prior to moving on
+with Loop setup. **DO NOT SKIP THESE STEPS OR YOUR LOOP WILL NOT WORK.**
 
-1. Turn off Patterns under the basal menu settings. This will force Loop to use your "Standard" basal rate schedule.</br></br>
-2. Make sure your standard basal rate schedule is up-to-date and accurate. Loop will automatically import your pump's existing standard basal rate schedule when you add your pump in the subsequent parts of this page. **If you change basal rates later...make sure to make those changes in the Loop app and use Loop to save the changes back to the pump.  If you make changes directly in the pump, Loop will not automatically know about those changes and you will cause a mismatch.**</br></br>
-3. Set your pump's `Temp Basal Type` to `Insulin Rate (U/hr)`. Do NOT use percentage. Your Loop will not run unless your temp basal type is set to units/hour.</br></br>
-4. Make sure your maximum basal rate and maximum bolus (those are particular settings in the pump) are reasonably set for your particular needs. For new Loop users, a maximum basal rate equal to approximately 2-4 times your highest scheduled basal rate is a good starting point as you learn Loop and dial in your other settings. You can adjust as your comfort and use of Loop develop.</br></br>
-5. Set Remote Devices to `ON` and enter any random ID (000000 will work). This setting is found in the pump's Utilities menu (for x23 continue to Connect Devices, Remotes) and turn `ON` the Remote Options.</br></br>
-6. Cancel any currently running extended or dual wave boluses.  Loop cannot loop with those running.</br>
-7. Make sure the other settings in your pump, such as bolus wizard settings, are up-to-date so that if you stop using Loop, those settings will be accurate for non-Loop traditional pump use.
+1. Turn off Patterns under the basal menu settings. This will force Loop to use
+   your "Standard" basal rate schedule.</br></br>
+2. Make sure your standard basal rate schedule is up-to-date and accurate. Loop
+   will automatically import your pump's existing standard basal rate schedule
+   when you add your pump in the subsequent parts of this page. **If you change
+   basal rates later...make sure to make those changes in the Loop app and use
+   Loop to save the changes back to the pump. If you make changes directly in
+   the pump, Loop will not automatically know about those changes and you will
+   cause a mismatch.**</br></br>
+3. Set your pump's `Temp Basal Type` to `Insulin Rate (U/hr)`. Do NOT use
+   percentage. Your Loop will not run unless your temp basal type is set to
+   units/hour.</br></br>
+4. Make sure your maximum basal rate and maximum bolus (those are particular
+   settings in the pump) are reasonably set for your particular needs. For new
+   Loop users, a maximum basal rate equal to approximately 2-4 times your
+   highest scheduled basal rate is a good starting point as you learn Loop and
+   dial in your other settings. You can adjust as your comfort and use of Loop
+   develop.</br></br>
+5. Set Remote Devices to `ON` and enter any random ID (000000 will work). This
+   setting is found in the pump's Utilities menu (for x23 continue to Connect
+   Devices, Remotes) and turn `ON` the Remote Options.</br></br>
+6. Cancel any currently running extended or dual wave boluses. Loop cannot loop
+   with those running.</br>
+7. Make sure the other settings in your pump, such as bolus wizard settings, are
+   up-to-date so that if you stop using Loop, those settings will be accurate
+   for non-Loop traditional pump use.
 
 ## Select Pump Type
 
-Let’s start by clicking on the Loop Settings button in the tool bar at the bottom of your Loop app. It looks like a little sprocket. On the settings screen that opens, click on `Add Pump` and select the **Medtronic pump** option that appears.
+Let’s start by clicking on the Loop Settings button in the tool bar at the
+bottom of your Loop app. It looks like a little sprocket. On the settings screen
+that opens, click on `Add Pump` and select the **Medtronic pump** option that
+appears.
 
 <p align="center">
 <img src="../img/loop_settings_add_pump.png" width="450">
@@ -25,9 +53,13 @@ Let’s start by clicking on the Loop Settings button in the tool bar at the bot
 
 ## Pump Pairing
 
-You now need to follow a few simple screen prompts to add your Medtronic pump to Loop:
+You now need to follow a few simple screen prompts to add your Medtronic pump to
+Loop:
 
-1. Make sure your RileyLink is turned on and nearby, then you will see a RileyLink listed in this area of the settings.  Actually, you will see a list of any RileyLinks that are in the nearby area. Slide on the toggle for your RileyLink.</br></br>
+1. Make sure your RileyLink is turned on and nearby, then you will see a
+   RileyLink listed in this area of the settings. Actually, you will see a list
+   of any RileyLinks that are in the nearby area. Slide on the toggle for your
+   RileyLink.</br></br>
 2. Add your pump's region, color, and serial number.</br></br>
 3. Click the `Continue` button to finish the addition of your pump.</br></br>
 
@@ -36,21 +68,27 @@ You now need to follow a few simple screen prompts to add your Medtronic pump to
 </p>
 
 !!! info "For x23 and x54 Medtronic pump users only"
-    <table>
-    <th><p align="inline"><img src="../img/pump_broadcasts.png" width="550"></p></th>
-    <td>For x23 and x54 Medtronic pump users, there is a packet of information special to those pumps called MySentry messages. If you have never setup this part of the pump previously, you may see a screen, called "Pump Broadcasts", at this point in the setup process.</br></br>Follow the directions on the screen. They will require you to take some manual steps on your pump to "pair" it with your Loop app.</br></br>Basically, you will need to go to your pump's main menu, scroll down to Utilities, then Connect Devices, then Other Devices, turn that setting On, and then select Find Device. Once you do that, click on the `Continue` button in Loop app and the pairing will take place. This will allow those MySentry packets of information to flow to Loop app.</br></br>This step does not apply for x22 or x15 pump users, since those pumps do not have MySentry capabilities.</td>
-    </table>
-    
-    
+
+<table>
+<th><p align="inline"><img src="../img/pump_broadcasts.png" width="550"></p></th>
+<td>For x23 and x54 Medtronic pump users, there is a packet of information special to those pumps called MySentry messages. If you have never setup this part of the pump previously, you may see a screen, called "Pump Broadcasts", at this point in the setup process.</br></br>Follow the directions on the screen. They will require you to take some manual steps on your pump to "pair" it with your Loop app.</br></br>Basically, you will need to go to your pump's main menu, scroll down to Utilities, then Connect Devices, then Other Devices, turn that setting On, and then select Find Device. Once you do that, click on the `Continue` button in Loop app and the pairing will take place. This will allow those MySentry packets of information to flow to Loop app.</br></br>This step does not apply for x22 or x15 pump users, since those pumps do not have MySentry capabilities.</td>
+</table>
+  
+  
 Now that your pump is paired with Loop, you will be finishing these steps:
 
-1. Change your pump time using the Loop app (and read all the info on that screen)</br></br>
-2. Import your pump's basal rate schedule, maximum basal rate, and maximum bolus (maximums are collectively called "delivery limits" in Loop)</br></br>
+1. Change your pump time using the Loop app (and read all the info on that
+   screen)</br></br>
+2. Import your pump's basal rate schedule, maximum basal rate, and maximum bolus
+   (maximums are collectively called "delivery limits" in Loop)</br></br>
 3. Select your pump's battery type (lithium or alakine)</br></br>
 4. Leave the Preferred Data Souce on Event History </br></br>
 
-**Event History must be selected for Nightscout to display temp basals, carbs, and boluses from Loop.**  Event History must also be selected in order for prime events to be detected and NOT contribute to iob during site changes. Please just leave the Preferred Data Source on Event History.</br></br>
-    
+**Event History must be selected for Nightscout to display temp basals, carbs,
+and boluses from Loop.** Event History must also be selected in order for prime
+events to be detected and NOT contribute to iob during site changes. Please just
+leave the Preferred Data Source on Event History.</br></br>
+
 <p align="center">
 <img src="../img/add_pump2.png" width="750">
 </p>
@@ -58,4 +96,3 @@ Now that your pump is paired with Loop, you will be finishing these steps:
 ## Next Step: Add CGM
  
  Congrats! You've added your Medtronic pump to your Loop app. Now, click on the settings button in the upper left corner to take you back to the Loop's settings menu. Your next step is to [Add CGM](https://loopkit.github.io/loopdocs/operation/loop-settings/cgm/) to your Loop app. After all, without CGM data, your Loop won't loop.
- 

--- a/docs/operation/loop-settings/omnipod-pump.md
+++ b/docs/operation/loop-settings/omnipod-pump.md
@@ -1,10 +1,17 @@
 # Omnipod Users
 
-Your Loop won’t have much showing initially until we get some basic settings input. The beginning step will be to add a pump to your Loop. If you are using an Omnipod pump, you can follow along for the rest of this page. If, however, you are using a Medtronic pump, please head over to [this page](https://loopkit.github.io/loopdocs/operation/loop-settings/mdt-pump/) instead.
+Your Loop won’t have much showing initially until we get some basic settings
+input. The beginning step will be to add a pump to your Loop. If you are using
+an Omnipod pump, you can follow along for the rest of this page. If, however,
+you are using a Medtronic pump, please head over to
+[this page](https://loopkit.github.io/loopdocs/operation/loop-settings/mdt-pump/)
+instead.
 
 ## Select Pump Type
 
-Let’s start by clicking on the Loop Settings button in the toolbar at the bottom of your Loop app. It looks like a little sprocket. On the settings screen that opens, click on `Add Pump` and select the **Omnipod** option that appears.
+Let’s start by clicking on the Loop Settings button in the toolbar at the bottom
+of your Loop app. It looks like a little sprocket. On the settings screen that
+opens, click on `Add Pump` and select the **Omnipod** option that appears.
 
 <p align="center">
 <img src="../img/loop_settings_add_pump.png" width="650">
@@ -12,7 +19,11 @@ Let’s start by clicking on the Loop Settings button in the toolbar at the bott
 
 ## Select RileyLink
 
-A list of all RileyLinks in the nearby area will display in the RileyLink Setup screen. Select your RileyLink by sliding the toggle to display green and then press the blue `Continue` button at the bottom of the screen. If your RileyLink does not appear, make sure that its switch is turned on (switch slide up toward the case's keyring) and lipo is charged.
+A list of all RileyLinks in the nearby area will display in the RileyLink Setup
+screen. Select your RileyLink by sliding the toggle to display green and then
+press the blue `Continue` button at the bottom of the screen. If your RileyLink
+does not appear, make sure that its switch is turned on (switch slide up toward
+the case's keyring) and lipo is charged.
 
 <p align="center">
 <img src="../img/pod-rl.png" width="250">
@@ -22,15 +33,23 @@ A list of all RileyLinks in the nearby area will display in the RileyLink Setup 
 
 The next screen will offer two areas where you will need to enter information:
 
-* Delivery Limits: Delivery Limits are both your maximum basal rate and your maximum bolus amount. Your maximum basal rate will limit how aggressive your Loop will be able to set temporary basals to treat high blood glucose. Typically, new users should set this value conservatively around 3 times your highest scheduled basal rate until your comfort and experience with Loop develops.
+- Delivery Limits: Delivery Limits are both your maximum basal rate and your
+  maximum bolus amount. Your maximum basal rate will limit how aggressive your
+  Loop will be able to set temporary basals to treat high blood glucose.
+  Typically, new users should set this value conservatively around 3 times your
+  highest scheduled basal rate until your comfort and experience with Loop
+  develops.
 
-* Basal Rates: Enter your scheduled basal rates, beginning at midnight. Consistent with PO use, the scheduled basal rates have a maximum of 24 entries, no 0 u/hr entries allows, and rate increments of 0.05 u/hr.
+- Basal Rates: Enter your scheduled basal rates, beginning at midnight.
+  Consistent with PO use, the scheduled basal rates have a maximum of 24
+  entries, no 0 u/hr entries allows, and rate increments of 0.05 u/hr.
 
 <p align="center">
 <img src="../img/pod-settings-screen.png" width="650">
 </p></br>
 
-When you finish entering these values, press the blue `Continue` button on the bottom of the POD Settings screen to continue with the next steps of POD setup.
+When you finish entering these values, press the blue `Continue` button on the
+bottom of the POD Settings screen to continue with the next steps of POD setup.
 
 ## Pair POD
 
@@ -38,7 +57,8 @@ When you finish entering these values, press the blue `Continue` button on the b
 2. Fill the POD with insulin until it beeps (minimum fill is 80 units)
 3. Click the `Pair` button
 4. Wait while the progress bar for priming completes
-5. Press the `Continue` button when the blue checkmark confirms priming is complete
+5. Press the `Continue` button when the blue checkmark confirms priming is
+   complete
 
 <p align="center">
 <img src="../img/pod-setup-01-pair.png" width="650">
@@ -48,9 +68,13 @@ When you finish entering these values, press the blue `Continue` button on the b
 
 1. Prepare your insertion site
 2. Remove the POD's needle cap and adhesive backing
-3. If the cannula is safely tucked away, apply the POD to your desired infusion site. If cannula is sticking out, press `cancel` in the upper right corner of the screen and try a new POD.
+3. If the cannula is safely tucked away, apply the POD to your desired infusion
+   site. If cannula is sticking out, press `cancel` in the upper right corner of
+   the screen and try a new POD.
 4. Press the `Insert Cannula` button.
-5. Listen to the clicks filling the cannula, wait for insertion and the progress bar to complete. The number of clicks to insertion is not consistent. The cannula will deploy before the progress bar is completed.
+5. Listen to the clicks filling the cannula, wait for insertion and the progress
+   bar to complete. The number of clicks to insertion is not consistent. The
+   cannula will deploy before the progress bar is completed.
 6. Confirm cannula has deployed by looking through the peep-hole on the POD.
 7. Press the `Continue` button
 
@@ -60,7 +84,11 @@ When you finish entering these values, press the blue `Continue` button on the b
 
 ## Expiration Reminder
 
-Finish the setup with using the default expiration reminder time (2 hours before a full 3-days usage) or set the expiration notification to a more convenient time to your liking which will show up in your locked screen and vibrates at that time. Setup is complete and your POD is ready for use when you press the final button.
+Finish the setup with using the default expiration reminder time (2 hours before
+a full 3-days usage) or set the expiration notification to a more convenient
+time to your liking which will show up in your locked screen and vibrates at
+that time. Setup is complete and your POD is ready for use when you press the
+final button.
 
 <p align="center">
 <img src="../img/pod-setup-03-complete.png" width="650">
@@ -68,90 +96,129 @@ Finish the setup with using the default expiration reminder time (2 hours before
 
 ## POD Settings
 
-After the POD setup is completed, you will be on the POD Settings screen. This screen will provide a variety of important information about your POD. You can always come back to this screen later by tapping on the Omnipod image in your Loop settings.
+After the POD setup is completed, you will be on the POD Settings screen. This
+screen will provide a variety of important information about your POD. You can
+always come back to this screen later by tapping on the Omnipod image in your
+Loop settings.
 
 <p align="center">
 <img src="../img/long-pod-settings.jpeg" width="250">
 </p></br>
 
-####  Device Information
-The first section has information regarding how long the POD has been active, expiration date and time, POD identifying information (if you have to call in for a POD failure).
+#### Device Information
+
+The first section has information regarding how long the POD has been active,
+expiration date and time, POD identifying information (if you have to call in
+for a POD failure).
 
 #### POD commands
-There are two commands that you can issue through Loop to the POD. 
 
-* Suspend Delivery: This command will suspend all insulin delivery; basals, temp basals, and boluses in progress. When you press suspend delivery, all insulin delivery will stop indefinitely. 
+There are two commands that you can issue through Loop to the POD.
+
+- Suspend Delivery: This command will suspend all insulin delivery; basals, temp
+  basals, and boluses in progress. When you press suspend delivery, all insulin
+  delivery will stop indefinitely.
 
 <p align="center">
 <img src="../img/pod-settings-resume.png" width="250">
-</p> 
+</p>
 
-A banner notice will appear on the Loop's main screen when insulin delivery is suspended. 
+A banner notice will appear on the Loop's main screen when insulin delivery is
+suspended.
 
 <p align="center">
 <img src="../img/pod-hud-suspended.png" width="250">
-</p> 
+</p>
 
-You will need to press `Tap to Resume` in the banner or the `Resume Delivery` button in the POD settings to resume your scheduled basal rate and let Loop get back to action. Bolus deliveries will not be resumed, if they were interrupted.
+You will need to press `Tap to Resume` in the banner or the `Resume Delivery`
+button in the POD settings to resume your scheduled basal rate and let Loop get
+back to action. Bolus deliveries will not be resumed, if they were interrupted.
 
-
-* Replace POD: This command should be used to deactivate a POD prior to replacing it.
+- Replace POD: This command should be used to deactivate a POD prior to
+  replacing it.
 
 <p align="center">
 <img src="../img/pod-settings-replace-pod.png" width="250">
-</p> 
+</p>
 
 #### Configuration
-* Expiration Reminder: With the Expiration Reminder you can set a convenient time to get a notification to replace your POD. Using the standard setting, Loop sets the default to a full 3 days. You can set the reminder to any day and time up until 80 hours. This changes the PDM default which sets the alert always to 2 hours before a full 3-day (72 hours) run. This assumes you will not have run out of insulin before that time. In the event your POD runs out of insulin, then you will get a "POD empty" notification.
+
+- Expiration Reminder: With the Expiration Reminder you can set a convenient
+  time to get a notification to replace your POD. Using the standard setting,
+  Loop sets the default to a full 3 days. You can set the reminder to any day
+  and time up until 80 hours. This changes the PDM default which sets the alert
+  always to 2 hours before a full 3-day (72 hours) run. This assumes you will
+  not have run out of insulin before that time. In the event your POD runs out
+  of insulin, then you will get a "POD empty" notification.
 
 <p align="center">
 <img src="../img/pod-settings-screen-expiration-reminder.png" width="250">
 </p></br>
 
-
-* Change Time Zone: If you are traveling for short periods of time, you do not have to worry about changing the time on your POD. However, if you are going to be away from home for longer periods of time, you will want to update your POD's basal schedule to match local time by selecting the `Change Time Zone` command when convenient. Using this command will move your basal schedule on your current POD to the new time. If you start a new POD session the new time zone will be used. Please wait until you see `Succeeded` appear on the page to ensure the command has successfully been received by the POD.
+- Change Time Zone: If you are traveling for short periods of time, you do not
+  have to worry about changing the time on your POD. However, if you are going
+  to be away from home for longer periods of time, you will want to update your
+  POD's basal schedule to match local time by selecting the `Change Time Zone`
+  command when convenient. Using this command will move your basal schedule on
+  your current POD to the new time. If you start a new POD session the new time
+  zone will be used. Please wait until you see `Succeeded` appear on the page to
+  ensure the command has successfully been received by the POD.
 
 <p align="center">
 <img src="../img/pod-change-timezone.png" width="250">
-</p> 
+</p>
 
-* Test Command: This command is used only by the developers to test Omnipod commands in Loop. It currently issues a "get status" command and can be used to update your screen details if needed or force a fault error to generate in the issue report after getting a screaming POD.
+- Test Command: This command is used only by the developers to test Omnipod
+  commands in Loop. It currently issues a "get status" command and can be used
+  to update your screen details if needed or force a fault error to generate in
+  the issue report after getting a screaming POD.
 
 #### Status
 
-This section provides information about your POD's status. 
+This section provides information about your POD's status.
 
-* Bolus Delivery: This line will let you know the % progress of any ongoing bolus. 
+- Bolus Delivery: This line will let you know the % progress of any ongoing
+  bolus.
 
 <p align="center">
 <img src="../img/pod-settings-bolus-status.png" width="250">
-</p> 
+</p>
 
-* Basal Delivery: This line will let you know what is active: The normal basal _schedule_,the _U/hour_ of a 30 minute Temp Basal or if the POD is _suspended_.
+- Basal Delivery: This line will let you know what is active: The normal basal
+  _schedule_,the _U/hour_ of a 30 minute Temp Basal or if the POD is
+  _suspended_.
 
 <p align="center">
 <img src="../img/pod-settings-basal-delivery.png" width="250">
-</p> 
+</p>
 
-* Alarms: If your POD is screaming or beeping an alarm, this line will display information about the alarm. By clicking on this line, you can clear or "snooze" the alarm status.
-
+- Alarms: If your POD is screaming or beeping an alarm, this line will display
+  information about the alarm. By clicking on this line, you can clear or
+  "snooze" the alarm status.
 
 <p align="center">
 <img src="../img/pod-settings-alarms.png" width="250">
-</p> 
+</p>
 
-* Reservoir: Pods do not report the volume of insulin remaining in the reservoir until there are less than 50 units remaining. So, typically you will see "50+ U" in this line for quite a while with a new POD.
+- Reservoir: Pods do not report the volume of insulin remaining in the reservoir
+  until there are less than 50 units remaining. So, typically you will see "50+
+  U" in this line for quite a while with a new POD.
 
 <p align="center">
 <img src="../img/pod-settings-reservoir.png" width="250">
-</p> 
+</p>
 
-* Insulin Delivered: This line is the total amount of insulin, both basal and bolus, delivered by the POD since it was activated.
+- Insulin Delivered: This line is the total amount of insulin, both basal and
+  bolus, delivered by the POD since it was activated.
 
 <p align="center">
 <img src="../img/pod-settings-insulin-delivered.png" width="250">
-</p> 
+</p>
 
 ## Next Step: Add CGM
 
-Congrats! You've added your POD to your Loop app. Now, click on the `Done` button in the upper right corner of your Pump Settings screen to take you back to the Loop's settings. Your next step is to [Add CGM](https://loopkit.github.io/loopdocs/operation/loop-settings/cgm/) to your Loop app. After all, without CGM data, your Loop won't loop.
+Congrats! You've added your POD to your Loop app. Now, click on the `Done`
+button in the upper right corner of your Pump Settings screen to take you back
+to the Loop's settings. Your next step is to
+[Add CGM](https://loopkit.github.io/loopdocs/operation/loop-settings/cgm/) to
+your Loop app. After all, without CGM data, your Loop won't loop.

--- a/docs/operation/loop-settings/rileylink.md
+++ b/docs/operation/loop-settings/rileylink.md
@@ -1,10 +1,24 @@
 # RileyLink Menu
 
-The RileyLink menu is accessed by clicking on the image of your connected pump in Loop settings. From that pump screen, scroll to the bottom and you will see the names of your connected RileyLink(s). (Note: The device searching indicator near the RileyLink's toggle will always be spinning, even after a RileyLink is successfully connected. That is normal behavior.)
+The RileyLink menu is accessed by clicking on the image of your connected pump
+in Loop settings. From that pump screen, scroll to the bottom and you will see
+the names of your connected RileyLink(s). (Note: The device searching indicator
+near the RileyLink's toggle will always be spinning, even after a RileyLink is
+successfully connected. That is normal behavior.)
 
-Helpful tip: If you are ever going to be near other Loop users, you may want to consider renaming your RileyLink to a new name so that you can pick it out of a crowd.  Click on the RileyLink line, and the RileyLink's menu will be displayed. At the top of this menu is a line for the device name. Click on the that line and you will be able to change the name of your RileyLink. The new name may need to sit for a few seconds before exiting back out of the naming screen for it to save itself. RileyLink must be connected and on to change the name.
+Helpful tip: If you are ever going to be near other Loop users, you may want to
+consider renaming your RileyLink to a new name so that you can pick it out of a
+crowd. Click on the RileyLink line, and the RileyLink's menu will be displayed.
+At the top of this menu is a line for the device name. Click on the that line
+and you will be able to change the name of your RileyLink. The new name may need
+to sit for a few seconds before exiting back out of the naming screen for it to
+save itself. RileyLink must be connected and on to change the name.
 
-Depending on which pump you have connected to your Loop app, your RL menu will look different. On the left below is the typical RL menu when using Medtronic pump, and on the right is with an Omnipod. As you can see, both have in common a section called "Device", but after that only the Medtronic pumps will have additional commands in the RileyLink menu.
+Depending on which pump you have connected to your Loop app, your RL menu will
+look different. On the left below is the typical RL menu when using Medtronic
+pump, and on the right is with an Omnipod. As you can see, both have in common a
+section called "Device", but after that only the Medtronic pumps will have
+additional commands in the RileyLink menu.
 
 <p align="center">
 <img src="../img/rl-comp.png" width="450">
@@ -12,57 +26,128 @@ Depending on which pump you have connected to your Loop app, your RL menu will l
 
 ## Device
 
-The settings under the Device section are mostly for your information only. The two most important lines are the Connection Status and Signal Strength.
+The settings under the Device section are mostly for your information only. The
+two most important lines are the Connection Status and Signal Strength.
 
-* The Connections Status should say `connected` if the RileyLink is connected to the iPhone's Bluetooth. If the status says `connecting` or `disconnected` then you should toggle the iPhone's BT and/or RileyLink's power switch off/on to help reconnect.
+- The Connections Status should say `connected` if the RileyLink is connected to
+  the iPhone's Bluetooth. If the status says `connecting` or `disconnected` then
+  you should toggle the iPhone's BT and/or RileyLink's power switch off/on to
+  help reconnect.
 
-* The Signal Strength is the strength of the Bluetooth signal between the iPhone and RileyLink.  It is **not** the signal strength of the radio communications with the pump/pod.  The lower the number, the stronger the connection. As you move the RL and iPhone closer/farther apart, you will be able to see the signal strength change. In a pinch, this can be used to help locate a lost RileyLink in the house.
+- The Signal Strength is the strength of the Bluetooth signal between the iPhone
+  and RileyLink. It is **not** the signal strength of the radio communications
+  with the pump/pod. The lower the number, the stronger the connection. As you
+  move the RL and iPhone closer/farther apart, you will be able to see the
+  signal strength change. In a pinch, this can be used to help locate a lost
+  RileyLink in the house.
 
 <p align="center">
 <img src="../img/RL_bt.jpg" width="350">
 </p>
 
 ## Pump
-The Pump ID and Pump Model will be automatically filled in from your pump. 
+
+The Pump ID and Pump Model will be automatically filled in from your pump.
 
 ## Commands
 
-There are several commands that the RileyLink can issue to a Medtronic pump. Most are simply for gathering information from the pump.
+There are several commands that the RileyLink can issue to a Medtronic pump.
+Most are simply for gathering information from the pump.
 
 ### Tune Radio Frequency
 
-The pump and RileyLink communicate via radio frequency. In order to have the best possible communications, RileyLink will test a range of frequencies in order to see which provides the strongest response with the pump. In the event that pump comms fail for over 14 minutes, Loop will automatically retune the RileyLink to see if perhaps the strongest frequency has changed since it was last tuned.
+The pump and RileyLink communicate via radio frequency. In order to have the
+best possible communications, RileyLink will test a range of frequencies in
+order to see which provides the strongest response with the pump. In the event
+that pump comms fail for over 14 minutes, Loop will automatically retune the
+RileyLink to see if perhaps the strongest frequency has changed since it was
+last tuned.
 
-When you first setup your Loop app, RileyLink will automatically perform a **Tune Radio Frequency** to get pump comms started. You can manually tune your radio frequency at any time by clicking on the command. It may take about a minute, but soon you will see a list of frequencies with the tuning strength results beside each frequency. The signal with the lowest value is the strongest and RileyLink will use that frequency. Exit out of that screen and the command line will now show the frequency (916.xx MHz for North American pumps) and the timestamp of the tune.
+When you first setup your Loop app, RileyLink will automatically perform a
+**Tune Radio Frequency** to get pump comms started. You can manually tune your
+radio frequency at any time by clicking on the command. It may take about a
+minute, but soon you will see a list of frequencies with the tuning strength
+results beside each frequency. The signal with the lowest value is the strongest
+and RileyLink will use that frequency. Exit out of that screen and the command
+line will now show the frequency (916.xx MHz for North American pumps) and the
+timestamp of the tune.
 
-!!!info ""
-    **A common troubleshooting recommendation is to tune your RL when you have poor pump communications. Just keep in mind that the Loop code has a function that it will automatically retune in the event of poor pump communications within 14 minutes. Loop does this automatically.  Manually retuning is only useful for impatience purposes. If Loop has failed longer than 20 minutes, it will have already likely tried a retune...but knock yourself out if you want to try it again manually.**
+!!!info "" **A common troubleshooting recommendation is to tune your RL when you
+have poor pump communications. Just keep in mind that the Loop code has a
+function that it will automatically retune in the event of poor pump
+communications within 14 minutes. Loop does this automatically. Manually
+retuning is only useful for impatience purposes. If Loop has failed longer than
+20 minutes, it will have already likely tried a retune...but knock yourself out
+if you want to try it again manually.**
 
 ### Change Time
-Loop automatically prompts you to set your pump time using the Loop app as part of initial Loop setup.  It is important that Loop and your pump share a common time setting, otherwise Looping will fail.  If you are traveling through timezones or dealing with daylight savings time, please read up on [how to safely change your pump time](/troubleshooting/time-change.md#traveling-across-time-zones-and-daylight-savings).
 
-!!!info ""
-    **Always use the RileyLink's <font color="orange">Change Time</font> command to change pump time.  If you fail to set the pump time by using the RileyLink, Loop will not function properly.  Do not use the pump menus to change your pump's time when Looping.**
+Loop automatically prompts you to set your pump time using the Loop app as part
+of initial Loop setup. It is important that Loop and your pump share a common
+time setting, otherwise Looping will fail. If you are traveling through
+timezones or dealing with daylight savings time, please read up on
+[how to safely change your pump time](/troubleshooting/time-change.md#traveling-across-time-zones-and-daylight-savings).
+
+!!!info "" **Always use the RileyLink's <font color="orange">Change Time</font>
+command to change pump time. If you fail to set the pump time by using the
+RileyLink, Loop will not function properly. Do not use the pump menus to change
+your pump's time when Looping.**
 
 ### Other commands
-MySentry Pair, Fetch Recent History, Fetch Enlite Glucose, Get Pump Model, Send Button Press, Read Pump Status, and Read Basal Schedule are all ways of asking the pump for information you might be interested in. They are not part of setting up the Loop and will not affect Loop operations. Enable Diagnostic LEDs, Discover Commands, and RileyLink Statistics are commands that are sometimes used by developers to aid in app troubleshooting and debugging. They don't impact Loop operations.
 
-**MySentry Pair** is for x23 and x54 pumps only, and you will have completed this pairing command as part of the original `Add Pump` process. The MySentry pairing process adds a specific ID to your pump in the pump's Connect Devices, Other Devices menu. This pairing allows Loop to get information from x23 and x54 in an efficient manner. If that is not done, Loop will only be green every other loop. If you ever want to re-pair MySentry, you can follow the directions as shown in the RileyLink command screen. You do not have to worry about this command if you are using an x15 or x22 model pump, as they do not have MySentry.
+MySentry Pair, Fetch Recent History, Fetch Enlite Glucose, Get Pump Model, Send
+Button Press, Read Pump Status, and Read Basal Schedule are all ways of asking
+the pump for information you might be interested in. They are not part of
+setting up the Loop and will not affect Loop operations. Enable Diagnostic LEDs,
+Discover Commands, and RileyLink Statistics are commands that are sometimes used
+by developers to aid in app troubleshooting and debugging. They don't impact
+Loop operations.
 
-**Fetch Recent History** polls the pump for recent pump events such as boluses, temp basals, primes, rewinds, etc.  The amount of information transmitted for a Fetch Recent History is usually quite large and, as a result, may be more prone to an early failure before it succeeds. If the first Fetch Recent History fails, sometimes it is helpful to use the Send Button Press command to sort of "wake up" the pump in preparation for communications.
+**MySentry Pair** is for x23 and x54 pumps only, and you will have completed
+this pairing command as part of the original `Add Pump` process. The MySentry
+pairing process adds a specific ID to your pump in the pump's Connect Devices,
+Other Devices menu. This pairing allows Loop to get information from x23 and x54
+in an efficient manner. If that is not done, Loop will only be green every other
+loop. If you ever want to re-pair MySentry, you can follow the directions as
+shown in the RileyLink command screen. You do not have to worry about this
+command if you are using an x15 or x22 model pump, as they do not have MySentry.
 
-**Fetch Enlite Glucose** is only useful for Medtronic CGM users. The Fetch Enlite Glucose command will pull the recent glucose values saved in the pump history. Dexcom users do not store any glucose data in the pump.
+**Fetch Recent History** polls the pump for recent pump events such as boluses,
+temp basals, primes, rewinds, etc. The amount of information transmitted for a
+Fetch Recent History is usually quite large and, as a result, may be more prone
+to an early failure before it succeeds. If the first Fetch Recent History fails,
+sometimes it is helpful to use the Send Button Press command to sort of "wake
+up" the pump in preparation for communications.
+
+**Fetch Enlite Glucose** is only useful for Medtronic CGM users. The Fetch
+Enlite Glucose command will pull the recent glucose values saved in the pump
+history. Dexcom users do not store any glucose data in the pump.
 
 **Get Pump Model** simply returns the pump's model.
 
-**Send Button Press** can be useful to see if the communication between the RileyLink and pump is working. If successful, the screen on the pump will light up and Loop will confirm the button press with a `success` message. If pump comms are failing, sending a successful button press can help "wake up" a pump that perhaps has not been communicating well.
+**Send Button Press** can be useful to see if the communication between the
+RileyLink and pump is working. If successful, the screen on the pump will light
+up and Loop will confirm the button press with a `success` message. If pump
+comms are failing, sending a successful button press can help "wake up" a pump
+that perhaps has not been communicating well.
 
-**Read Pump Status** is also nice quick pump read for reservoir volume, pump battery voltage, and pump status (bolusing or suspending). For x23 and x54 pump users, this command will provide the exact pump battery voltage instead of the 25/50/75/100% levels that are reported otherwise.
+**Read Pump Status** is also nice quick pump read for reservoir volume, pump
+battery voltage, and pump status (bolusing or suspending). For x23 and x54 pump
+users, this command will provide the exact pump battery voltage instead of the
+25/50/75/100% levels that are reported otherwise.
 
-**Read Basal Schedule** will pull the active basal pattern from the pump so you can review what the current settings are without using pump menu.
+**Read Basal Schedule** will pull the active basal pattern from the pump so you
+can review what the current settings are without using pump menu.
 
-**Enable Diagnostic LEDs** will turn on more LED flashes on the RileyLink while it is operating. You will see more blue flashing lights as the RileyLink communicates with the pump. If you tried turning on this feature and decide later that you just don't want to see so many flashing lights, simply reboot the RileyLink by turning the power switch off/on.  This will reset the LEDs.
+**Enable Diagnostic LEDs** will turn on more LED flashes on the RileyLink while
+it is operating. You will see more blue flashing lights as the RileyLink
+communicates with the pump. If you tried turning on this feature and decide
+later that you just don't want to see so many flashing lights, simply reboot the
+RileyLink by turning the power switch off/on. This will reset the LEDs.
 
 **Discover Commands** just ignore this menu item.
 
-**RileyLink Statistics** tracks how long your RileyLink has stayed successfully operating and gives the developers some useful information about the stability of the RL operations. It really doesn't provide much to the average Loop user, however.
+**RileyLink Statistics** tracks how long your RileyLink has stayed successfully
+operating and gives the developers some useful information about the stability
+of the RL operations. It really doesn't provide much to the average Loop user,
+however.

--- a/docs/operation/loop-settings/services.md
+++ b/docs/operation/loop-settings/services.md
@@ -1,33 +1,57 @@
 # Loop Services
 
-At the bottom of your Loop settings screen is a section called "Services". <u>The services listed in this section are all **OPTIONAL**.  You can choose to leave them empty and your Loop will still work.</u>
+At the bottom of your Loop settings screen is a section called "Services".
+<u>The services listed in this section are all **OPTIONAL**. You can choose to
+leave them empty and your Loop will still work.</u>
 
 <p align="center">
 <img src="../img/services.jpeg" width="350">
-</p> 
+</p>
 
 ## Nightscout
-If you have an existing Nightscout site, add the Site URL and API Secret to have your Loop data transmitted to your Nightscout site. If you can’t remember your API Secret, it can be found under Settings, Reveal Config Vars for Heroku sites (or Application Settings, Connection Strings for Azure sites). 
+
+If you have an existing Nightscout site, add the Site URL and API Secret to have
+your Loop data transmitted to your Nightscout site. If you can’t remember your
+API Secret, it can be found under Settings, Reveal Config Vars for Heroku sites
+(or Application Settings, Connection Strings for Azure sites).
 
 The two most common errors in filling out this section are:
 
-1. Failure to use `https://`  in the site URL.  If you use `http://` (see how that doesn't have the "s" at the end?), you will get an error message about an App Transport Security policy.  Take a look at the sample URL in the field before you start filling in that line, if you want an example to follow.</br></br>
-2. Having a trailing slash on the end of the URL. If you copy and paste from a web browser, make sure to delete the trailing slash on the URL entry.
+1. Failure to use `https://` in the site URL. If you use `http://` (see how that
+   doesn't have the "s" at the end?), you will get an error message about an App
+   Transport Security policy. Take a look at the sample URL in the field before
+   you start filling in that line, if you want an example to follow.</br></br>
+2. Having a trailing slash on the end of the URL. If you copy and paste from a
+   web browser, make sure to delete the trailing slash on the URL entry.
 
 ## Loggly
-[Loggly](https://loggly.com) is a free logging service. If you sign up for an account, you'll need to go under Source Setup and then Customer Tokens. Copy and paste your customer token into your Loop App settings for Loggly.
+
+[Loggly](https://loggly.com) is a free logging service. If you sign up for an
+account, you'll need to go under Source Setup and then Customer Tokens. Copy and
+paste your customer token into your Loop App settings for Loggly.
 
 <p align="center">
 <img src="../img/loggly.png" width="500">
-</p> 
+</p>
 
 ## Amplitude
-[Amplitude](https://amplitude.com) is a remote event monitoring service and can be used to quickly identify errors and events with Loop. Amplitude stores the events and allows you to view those events as points in time. To retrieve the details of the events you will need to look at corresponding mLab data entries to get a complete picture of the issues. If you sign up for a free account with Amplitude, you will be given an API Key that you can enter here to have Loop integration setup.
+
+[Amplitude](https://amplitude.com) is a remote event monitoring service and can
+be used to quickly identify errors and events with Loop. Amplitude stores the
+events and allows you to view those events as points in time. To retrieve the
+details of the events you will need to look at corresponding mLab data entries
+to get a complete picture of the issues. If you sign up for a free account with
+Amplitude, you will be given an API Key that you can enter here to have Loop
+integration setup.
 
 <p align="center">
 <img src="../img/amplitude.png" width="500">
-</p> 
+</p>
 
 ## Next Step: Loop Displays
 
-Great job, almost finished! Now that you have completed your services, let's move onto understanding your [Loop displays](https://loopkit.github.io/loopdocs/operation/loop-settings/displays). Understanding the Loop displays can be a valuable tool for understanding your Loop's actions, and also for troubleshooting, if you are having issues.
+Great job, almost finished! Now that you have completed your services, let's
+move onto understanding your
+[Loop displays](https://loopkit.github.io/loopdocs/operation/loop-settings/displays).
+Understanding the Loop displays can be a valuable tool for understanding your
+Loop's actions, and also for troubleshooting, if you are having issues.

--- a/docs/operation/loop/close-loop.md
+++ b/docs/operation/loop/close-loop.md
@@ -1,28 +1,57 @@
 # Close-Loop
 
-When you feel like you have learned what you need from open-loop, you should be ready to switch to close-loop.  There are several ways you can help make that transition as smooth as possible.  
+When you feel like you have learned what you need from open-loop, you should be
+ready to switch to close-loop. There are several ways you can help make that
+transition as smooth as possible.
 
 ## Timing
 
-Many people choose to transition to close-loop in a step-wise fashion.  Starting close-loop on weekends is an easier starting point so that you can minimize distractions (let's face it...you'll probably be staring at the Loop a lot for those first few days). Typically, people have an easier time transitioning to close-loop for parts of their day that don't involve food...so nighttimes tend to be easier than daytimes to start.
+Many people choose to transition to close-loop in a step-wise fashion. Starting
+close-loop on weekends is an easier starting point so that you can minimize
+distractions (let's face it...you'll probably be staring at the Loop a lot for
+those first few days). Typically, people have an easier time transitioning to
+close-loop for parts of their day that don't involve food...so nighttimes tend
+to be easier than daytimes to start.
 
 ## Maximum Basal Rate
 
-When you are first beginning to close-loop, it is important to be conservative (low) in setting your maximum basal rate.  If your settings are incorrect in other areas (basal rates, carb absorption time, carb ratio, etc), Loop may enact incorrectly aggressive high temp basals.  Gradually increase your maximum basal rate as your comfort and confidence in Loop increase.  Typically, experienced closed loop users set their max basal rate no more than 3-4 times their average basal rate.  
+When you are first beginning to close-loop, it is important to be conservative
+(low) in setting your maximum basal rate. If your settings are incorrect in
+other areas (basal rates, carb absorption time, carb ratio, etc), Loop may enact
+incorrectly aggressive high temp basals. Gradually increase your maximum basal
+rate as your comfort and confidence in Loop increase. Typically, experienced
+closed loop users set their max basal rate no more than 3-4 times their average
+basal rate.
 
 ## BG targets
 
-If your basals, ISF, or carb ratios aren't set correctly, Loop may overshoot and leave you lower than expected (or with more IOB than you are comfortable with).  Setting your low BG target slightly higher can help prevent unexpected lows or high IOB as you adjust your settings.
+If your basals, ISF, or carb ratios aren't set correctly, Loop may overshoot and
+leave you lower than expected (or with more IOB than you are comfortable with).
+Setting your low BG target slightly higher can help prevent unexpected lows or
+high IOB as you adjust your settings.
 
 ## Watch the IOB
 
-Watch whether Loop accumulates positive or negative IOB while holding your BG steady when no food is present.  If you find that you are "carrying" positive or negative IOB consistently, you should review your settings to see if perhaps your basal or ISF needs adjusting.
+Watch whether Loop accumulates positive or negative IOB while holding your BG
+steady when no food is present. If you find that you are "carrying" positive or
+negative IOB consistently, you should review your settings to see if perhaps
+your basal or ISF needs adjusting.
 
 ## Meals
 
-Meals will likely be the hardest part of transitioning to close-loop.  Starting with foods that you have a high comfort level with is a great idea.  If you have favorite meals that you know well (how high BGs usually go, how much to bolus, how to pre-bolus, etc), these would be a good starting point.  Watching when the Loop high temps or suspends basals (early vs late in the meal) will really help you adjust to find your typical carb absorption times.  As a general idea, **assuming other settings are accurate**:
+Meals will likely be the hardest part of transitioning to close-loop. Starting
+with foods that you have a high comfort level with is a great idea. If you have
+favorite meals that you know well (how high BGs usually go, how much to bolus,
+how to pre-bolus, etc), these would be a good starting point. Watching when the
+Loop high temps or suspends basals (early vs late in the meal) will really help
+you adjust to find your typical carb absorption times. As a general idea,
+**assuming other settings are accurate**:
 
-* early high temps in a meal that leave you low after, you may need to shorten carb absorption time
-* early suspensions in a meal that leave you high after, you may need to lengthen carb absorption time
+- early high temps in a meal that leave you low after, you may need to shorten
+  carb absorption time
+- early suspensions in a meal that leave you high after, you may need to
+  lengthen carb absorption time
 
-This is definitely an area where YDMV (your diabetes may vary), so don't expect or accept that what works for others will work for you.  Test, observe, and adjust as needed.
+This is definitely an area where YDMV (your diabetes may vary), so don't expect
+or accept that what works for others will work for you. Test, observe, and
+adjust as needed.

--- a/docs/operation/loop/looptips.md
+++ b/docs/operation/loop/looptips.md
@@ -1,20 +1,24 @@
 # Loop Tips
 
-These docs are a great resource for the technical aspects of building your Loop app.  However, they don't really cover in detail a lot of the frequently asked questions about *USING* Loop. 
+These docs are a great resource for the technical aspects of building your Loop
+app. However, they don't really cover in detail a lot of the frequently asked
+questions about _USING_ Loop.
 
 Things such as:
 
-* How to enter low treatments while using Loop?</br></br>
-* What to discuss with your Endo?</br></br>
-* What data reports might be useful?</br></br>
-* How to deal with failed sites?</br></br>
-* What about pizza boluses?</br></br>
-* What do I do when I shower or swim?</br></br>
+- How to enter low treatments while using Loop?</br></br>
+- What to discuss with your Endo?</br></br>
+- What data reports might be useful?</br></br>
+- How to deal with failed sites?</br></br>
+- What about pizza boluses?</br></br>
+- What do I do when I shower or swim?</br></br>
 
-All of those usability questions and more are addressed over in the companion site called [Looptips](https://looptips.org).  
+All of those usability questions and more are addressed over in the companion
+site called [Looptips](https://looptips.org).
 
-Please head over to Looptips in order to read some really helpful tips to make your Looping easier.
+Please head over to Looptips in order to read some really helpful tips to make
+your Looping easier.
 
 <p align="center">
 <img src="../img/looptips.png" width="550">
-</p> 
+</p>

--- a/docs/operation/loop/open-loop.md
+++ b/docs/operation/loop/open-loop.md
@@ -1,29 +1,83 @@
 # Open-Loop
 
-Open-loop is a great place to start with Loop. When you are operating in open-loop mode, Loop is offering recommendations for temp basals and will display them on the main screen.  The recommendations will not be enacted unless you specifically choose to enact the temp basal.  Usually in open-loop mode, you aren't really enacting the recommended basals but instead watching how the recommendations come in and figuring out WHY they are being recommended.
+Open-loop is a great place to start with Loop. When you are operating in
+open-loop mode, Loop is offering recommendations for temp basals and will
+display them on the main screen. The recommendations will not be enacted unless
+you specifically choose to enact the temp basal. Usually in open-loop mode, you
+aren't really enacting the recommended basals but instead watching how the
+recommendations come in and figuring out WHY they are being recommended.
 
-It is understandable to want to jump straight away into close-loop mode, but a lot can be learned by watching Loop operate in open mode.  Becoming familiar with the algorithm can be easier by watching it in action rather than only reading about it in docs.
+It is understandable to want to jump straight away into close-loop mode, but a
+lot can be learned by watching Loop operate in open mode. Becoming familiar with
+the algorithm can be easier by watching it in action rather than only reading
+about it in docs.
 
 ## Testing
 
-A great benefit of open-loop mode is that you can establish a baseline of BG trends without the influence of temp basals from Loop.  This is particularly helpful if you haven't used Medtronic sites/pumps prior to Loop.  You may find that your basal rates change significantly coming from other brands of pumps.  Taking the time to establish a good Medtronic pump basal profile will set you up for a smoother transition to close-loop mode.  Test your ISF during open-loop time too, as ISF is an important component for every Loop calculation for temp basals.  Every 5 minutes, Loop uses your ISF...so it's worth testing it ahead of close-loop mode.
+A great benefit of open-loop mode is that you can establish a baseline of BG
+trends without the influence of temp basals from Loop. This is particularly
+helpful if you haven't used Medtronic sites/pumps prior to Loop. You may find
+that your basal rates change significantly coming from other brands of pumps.
+Taking the time to establish a good Medtronic pump basal profile will set you up
+for a smoother transition to close-loop mode. Test your ISF during open-loop
+time too, as ISF is an important component for every Loop calculation for temp
+basals. Every 5 minutes, Loop uses your ISF...so it's worth testing it ahead of
+close-loop mode.
 
 ## Eventual BG
 
-One of the best things you can do is to train yourself to watch the eventual BG rather than the current BG for helping understand Loop recommendations for temp basals.  So many of us have become accustomed to dealing with current BGs and perhaps IOB at the same time...but Loop is also looking at BG momentum, carbs on board, retrospective trends.  Loop is utilizing all of those variables to predict an eventual BG.  Its current decisions are based on that eventual BG.  Training yourself to watch that eventual BG will help you understand the temp basals being offered at any given time.
+One of the best things you can do is to train yourself to watch the eventual BG
+rather than the current BG for helping understand Loop recommendations for temp
+basals. So many of us have become accustomed to dealing with current BGs and
+perhaps IOB at the same time...but Loop is also looking at BG momentum, carbs on
+board, retrospective trends. Loop is utilizing all of those variables to predict
+an eventual BG. Its current decisions are based on that eventual BG. Training
+yourself to watch that eventual BG will help you understand the temp basals
+being offered at any given time.
 
 ## Carb Absorption
 
-Probably the next most difficult transition involves using carb absorption as a component to every meal bolus.  Understand that the default carb absorption times in Loop may not work for your particular body.  Similar to how you perhaps had used extended boluses for meals that impacted BGs longer than the duration of your insulin...that same idea applies to estimate your carb absorption times.  Watch your meals and try to estimate how long they are impacting your BG for various types of food.  Watch the times when Loop would've wanted to suspend or high temp basal...ask yourself why it would be doing that.  Especially ask yourself if that is the same decision as you would've made at that time in a meal normally.  Would you be worried that you might go low later if you see Loop offering high temp basal early after a meal?  Would you be worried about going high later if Loop wants to suspend basals instead?  If you put some effort into this effort before closing the loop, it will pay off with a smoother transition to closed loop.
+Probably the next most difficult transition involves using carb absorption as a
+component to every meal bolus. Understand that the default carb absorption times
+in Loop may not work for your particular body. Similar to how you perhaps had
+used extended boluses for meals that impacted BGs longer than the duration of
+your insulin...that same idea applies to estimate your carb absorption times.
+Watch your meals and try to estimate how long they are impacting your BG for
+various types of food. Watch the times when Loop would've wanted to suspend or
+high temp basal...ask yourself why it would be doing that. Especially ask
+yourself if that is the same decision as you would've made at that time in a
+meal normally. Would you be worried that you might go low later if you see Loop
+offering high temp basal early after a meal? Would you be worried about going
+high later if Loop wants to suspend basals instead? If you put some effort into
+this effort before closing the loop, it will pay off with a smoother transition
+to closed loop.
 
 ## Troubleshooting
 
-Get used to carrying the RileyLink around.  Find how far your connectivity stretches before you have pump communication problems.  Get used to troubleshooting yellow and red loops, finding out the pattern/cause of any potential loop issues.  You'll be less frustrated starting on closed loop if you aren't dealing with learning new electronics at the same time as you are learning carb absorption times in a closed loop.  Learn how to retune your RL. 
+Get used to carrying the RileyLink around. Find how far your connectivity
+stretches before you have pump communication problems. Get used to
+troubleshooting yellow and red loops, finding out the pattern/cause of any
+potential loop issues. You'll be less frustrated starting on closed loop if you
+aren't dealing with learning new electronics at the same time as you are
+learning carb absorption times in a closed loop. Learn how to retune your RL.
 
 ## Bolus
 
-Bolus meals from the Loop, rather than the pump.  Become familiar with entering carbs into the Loop, as well as editing them.  Watch how long it takes for Loop app to display the bolus after you enact it (hint: there's a delay until the bolus finishes delivery and the pump gets read).  Familiarize yourself with the "Bolus May Have Failed" notifications and how to handle them.  Double-check the pump and watch to see if the bolus indeed didn't enact before trying to give the bolus again.  
+Bolus meals from the Loop, rather than the pump. Become familiar with entering
+carbs into the Loop, as well as editing them. Watch how long it takes for Loop
+app to display the bolus after you enact it (hint: there's a delay until the
+bolus finishes delivery and the pump gets read). Familiarize yourself with the
+"Bolus May Have Failed" notifications and how to handle them. Double-check the
+pump and watch to see if the bolus indeed didn't enact before trying to give the
+bolus again.
 
 ## Caregiver training
 
-If you are the parent of a t1d kid using Loop, make sure you take the time to educate caregivers around your family and school for how to use Loop.  Perhaps you want to draft individualized quick info sheets for those caregivers to use with Loop.  If your child needs a site change at school, school staff or your child need to know how to delete reservoir history or change to open-loop for the duration of DIA.  Try to watch Nightscout while you get to know Loop so that you can become better at remote troubleshooting of any problems that you might encounter.
+If you are the parent of a t1d kid using Loop, make sure you take the time to
+educate caregivers around your family and school for how to use Loop. Perhaps
+you want to draft individualized quick info sheets for those caregivers to use
+with Loop. If your child needs a site change at school, school staff or your
+child need to know how to delete reservoir history or change to open-loop for
+the duration of DIA. Try to watch Nightscout while you get to know Loop so that
+you can become better at remote troubleshooting of any problems that you might
+encounter.

--- a/docs/operation/overview.md
+++ b/docs/operation/overview.md
@@ -1,10 +1,18 @@
 # How to set up your Loop app
 
-This section of LoopDocs, under the general menu tab "Set up App", goes through all the important information about the process to properly set up all your needed information. You will need to work through the steps listed in the headings under this page one by one. Please follow along with each page's information to make sure that you don't miss any valuable information about your Loop's settings and function. 
+This section of LoopDocs, under the general menu tab "Set up App", goes through
+all the important information about the process to properly set up all your
+needed information. You will need to work through the steps listed in the
+headings under this page one by one. Please follow along with each page's
+information to make sure that you don't miss any valuable information about your
+Loop's settings and function.
 
 ## Add Pump
 
-The first step to setting up your Loop app is to tell Loop which pump you're using. There are separate pages for setting up a Medtronic (MDT) pump or an Omnipod Eros pump (aka "pods"). Click on one of the pages to go straight to that page's guide.
+The first step to setting up your Loop app is to tell Loop which pump you're
+using. There are separate pages for setting up a Medtronic (MDT) pump or an
+Omnipod Eros pump (aka "pods"). Click on one of the pages to go straight to that
+page's guide.
 
 </br>
 <p align="center">
@@ -18,7 +26,11 @@ The first step to setting up your Loop app is to tell Loop which pump you're usi
 
 ## Add CGM
 
-You will need to add a CGM source for your Loop app. If you are wondering which CGMs are supported natively by Loop, check [here](https://loopkit.github.io/loopdocs/setup/requirements/cgm/). The guide for adding the CGM source is [here](https://loopkit.github.io/loopdocs/operation/loop-settings/cgm/)
+You will need to add a CGM source for your Loop app. If you are wondering which
+CGMs are supported natively by Loop, check
+[here](https://loopkit.github.io/loopdocs/setup/requirements/cgm/). The guide
+for adding the CGM source is
+[here](https://loopkit.github.io/loopdocs/operation/loop-settings/cgm/)
 
 <p align="center">
 <img src="../img/add-cgm-main.jpeg" width="250">
@@ -26,7 +38,14 @@ You will need to add a CGM source for your Loop app. If you are wondering which 
 
 ## Configurations
 
-There is a particular section of Loop's settings area called "Configurations". Within this section, you will be entering many settings that you are already familiar with such as basal rates, carb ratios, and insulin sensitivity factor (aka correction factor). There are also several new terms that you may be unfamiliar with like insulin model selection, suspend threshold, and override ranges. Make sure you walk through the setup guide [here](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/) for the configurations.
+There is a particular section of Loop's settings area called "Configurations".
+Within this section, you will be entering many settings that you are already
+familiar with such as basal rates, carb ratios, and insulin sensitivity factor
+(aka correction factor). There are also several new terms that you may be
+unfamiliar with like insulin model selection, suspend threshold, and override
+ranges. Make sure you walk through the setup guide
+[here](https://loopkit.github.io/loopdocs/operation/loop-settings/configurations/)
+for the configurations.
 
 <p align="center">
 <img src="../img/overview.jpg" width="250">
@@ -34,7 +53,13 @@ There is a particular section of Loop's settings area called "Configurations". W
 
 ## Services (optional)
 
-The last section of entries to your Loop app, [Services](https://loopkit.github.io/loopdocs/operation/loop-settings/services) involve optional services that you can choose to send Loop data to. The most popular of those services is likely your Nightscout site; but there are also logging sites that can store information about your Loop errors and messages. All of these services are optional; not using these services will not affect your ability to Loop.
+The last section of entries to your Loop app,
+[Services](https://loopkit.github.io/loopdocs/operation/loop-settings/services)
+involve optional services that you can choose to send Loop data to. The most
+popular of those services is likely your Nightscout site; but there are also
+logging sites that can store information about your Loop errors and messages.
+All of these services are optional; not using these services will not affect
+your ability to Loop.
 
 <p align="center">
 <img src="../img/overview-services.jpg" width="250">
@@ -42,10 +67,14 @@ The last section of entries to your Loop app, [Services](https://loopkit.github.
 
 ## Loop Displays
 
-After you are done setting up all your information, you will also need to familiarize yourself with the Loop's various information displays. [This page](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/) will help you recognize what all the icons, graphs, and data mean.
+After you are done setting up all your information, you will also need to
+familiarize yourself with the Loop's various information displays.
+[This page](https://loopkit.github.io/loopdocs/operation/loop-settings/displays/)
+will help you recognize what all the icons, graphs, and data mean.
 
 ## RileyLink menu
 
-The RileyLink itself has some menu displays and commands which provide useful information for your Loop. Check out [this page](https://loopkit.github.io/loopdocs/operation/loop-settings/rileylink) to read up about the various options available.
-
-
+The RileyLink itself has some menu displays and commands which provide useful
+information for your Loop. Check out
+[this page](https://loopkit.github.io/loopdocs/operation/loop-settings/rileylink)
+to read up about the various options available.

--- a/docs/troubleshooting/green-loop.md
+++ b/docs/troubleshooting/green-loop.md
@@ -1,37 +1,48 @@
 # Turning Your Grey Loop to Green
 
-When you are initially starting the Loop app, the Loop will be colored grey.  Wait about 15-20 minutes for the Loop to turn from grey to green.  There's a bit of time for Loop to pull all of those first pieces of data together, especially reading your pump history for the first time.  If the Loop remains grey after 15-20 min, there are several possible causes for this.  If you find yourself with a grey loop that just won't turn green, check these most frequently missed items on new setups:
+When you are initially starting the Loop app, the Loop will be colored grey.
+Wait about 15-20 minutes for the Loop to turn from grey to green. There's a bit
+of time for Loop to pull all of those first pieces of data together, especially
+reading your pump history for the first time. If the Loop remains grey after
+15-20 min, there are several possible causes for this. If you find yourself with
+a grey loop that just won't turn green, check these most frequently missed items
+on new setups:
 
 ## Pump
 
-* Max basal rate in Loop app is no greater than the max basal rate in pump settings
-* Temp basal type in the pump's basal menu is set to "Insulin Rate (U/hr)" and not "Percent of Basal"
+- Max basal rate in Loop app is no greater than the max basal rate in pump
+  settings
+- Temp basal type in the pump's basal menu is set to "Insulin Rate (U/hr)" and
+  not "Percent of Basal"
 
 ## CGM
 
-* Dexcom app installed on the looping iPhone and open
-* CGM getting current values without interruption
-* Loop app has a CGM value displayed in the top bar of the main display
+- Dexcom app installed on the looping iPhone and open
+- CGM getting current values without interruption
+- Loop app has a CGM value displayed in the top bar of the main display
 
 ## RileyLink
 
-* RL is charged (it does not ship completely charged)
-* RL battery needs to be securely plugged in, [check those connections](https://loopkit.github.io/loopdocs/setup/requirements/rileylink/#assembling-rl)
+- RL is charged (it does not ship completely charged)
+- RL battery needs to be securely plugged in,
+  [check those connections](https://loopkit.github.io/loopdocs/setup/requirements/rileylink/#assembling-rl)
 
 ## Loop Settings
 
-* Correct CGM system has been selected in Loop settings
-* Insulin curve has been selected
-* Suspend Threshold has been entered
+- Correct CGM system has been selected in Loop settings
+- Insulin curve has been selected
+- Suspend Threshold has been entered
 
-!!! info ""
-    The most common delay in getting a grey loop to turn green is probably the lack of CGM data.  If you have waited 15-20 minutes and no CGM data has appeared, try closing both the Loop and Dexcom apps (double-tap home button and up-swipe to close apps).  Toggle your BT on iPhone off/on.  Reopen the Loop app, then reopen Dexcom app.
+!!! info "" The most common delay in getting a grey loop to turn green is
+probably the lack of CGM data. If you have waited 15-20 minutes and no CGM data
+has appeared, try closing both the Loop and Dexcom apps (double-tap home button
+and up-swipe to close apps). Toggle your BT on iPhone off/on. Reopen the Loop
+app, then reopen Dexcom app.
 
+If all else fails after verifying the settings listed in the sections above, you
+can:
 
-If all else fails after verifying the settings listed in the sections above, you can:
-
-* Close and restart the Loop and Dexcom apps
-* Toggle BT off/on
-* Turn RileyLink off/on
-* Replace pump battery
-
+- Close and restart the Loop and Dexcom apps
+- Toggle BT off/on
+- Turn RileyLink off/on
+- Replace pump battery

--- a/docs/troubleshooting/loop-crashing.md
+++ b/docs/troubleshooting/loop-crashing.md
@@ -1,32 +1,52 @@
 # Loop Crashes Upon Opening
 
-If your Loop app crashes immediately upon opening, you have a problem that needs to be fixed. What do I mean by "crashes"? That your Loop app immediately turns to a white screen and shuts itself down, landing you back at your iPhone's main screen. No amount of tapping will let you keep your Loop app open.
+If your Loop app crashes immediately upon opening, you have a problem that needs
+to be fixed. What do I mean by "crashes"? That your Loop app immediately turns
+to a white screen and shuts itself down, landing you back at your iPhone's main
+screen. No amount of tapping will let you keep your Loop app open.
 
-There are only two potential causes of this: 
+There are only two potential causes of this:
 
 1. App expired, or
 2. A correction range was saved backward.
 
-## Expired app 
+## Expired app
 
-Your Loop app has an expiration date. The expiration date will depend on the type of developer account that signed the app.
+Your Loop app has an expiration date. The expiration date will depend on the
+type of developer account that signed the app.
 
-* If you build with a free account, your app will expire after 7 days.
-* If you build with a paid account, your app will expire after 12 months.
+- If you build with a free account, your app will expire after 7 days.
+- If you build with a paid account, your app will expire after 12 months.
 
-Many people *accidentally* build with their old free account even after buying a paid account. How can you tell which you're signing with? The free signing team has the `(Personal Team)` listed after your name in the signing team.
+Many people _accidentally_ build with their old free account even after buying a
+paid account. How can you tell which you're signing with? The free signing team
+has the `(Personal Team)` listed after your name in the signing team.
 
-If your app expires, you simply need to plug your phone back into the computer and press the play button on your project again. This will rebuild. If you want to change to a paid signing team before rebuilding, please make sure to double-check which signing team is selected before building again. 
+If your app expires, you simply need to plug your phone back into the computer
+and press the play button on your project again. This will rebuild. If you want
+to change to a paid signing team before rebuilding, please make sure to
+double-check which signing team is selected before building again.
 
 ## Incorrectly entered correction range
 
-!!!info "Important To Know"
-    Correction ranges in Loop are to be entered in minimum-maximum...in other words, LOW-HIGH. If you enter the range backward, your app will crash as soon as Loop tries to use that backward target range...that could be immediately or at a time in the future, depending on when the backwards entry is in your schedule.
-    
-    * An example of a properly entered correction range: 100-120 mg/dL
-    * An example of an improperly entered correction range: 120-100 mg/dL
-    
-If your app crashes because of an improperly set correction range, you will need to entirely delete your Loop app in order to fix the problem. Unfortunately, simply rebuilding Loop app will not be sufficient because settings are saved from just rebuilding on top of an existing Loop app. And, these bad settings need to be deleted, not saved. So...if you are podding...you'll also need to start a new pod after rebuilding. Make sure to move your existing pod far away from the room when starting a new pod as that old pod may interfere with pairing a new one, since the old one was not properly deactivated before removing.
+!!!info "Important To Know" Correction ranges in Loop are to be entered in
+minimum-maximum...in other words, LOW-HIGH. If you enter the range backward,
+your app will crash as soon as Loop tries to use that backward target
+range...that could be immediately or at a time in the future, depending on when
+the backwards entry is in your schedule.
 
-Because of the obvious hassle to fix an incorrect entry, please be careful when entering in the correction range. Follow the greyed out text suggestions in the Loop user interface that say `min-max`.
+_ An example of a properly entered correction range: 100-120 mg/dL _ An example
+of an improperly entered correction range: 120-100 mg/dL
 
+If your app crashes because of an improperly set correction range, you will need
+to entirely delete your Loop app in order to fix the problem. Unfortunately,
+simply rebuilding Loop app will not be sufficient because settings are saved
+from just rebuilding on top of an existing Loop app. And, these bad settings
+need to be deleted, not saved. So...if you are podding...you'll also need to
+start a new pod after rebuilding. Make sure to move your existing pod far away
+from the room when starting a new pod as that old pod may interfere with pairing
+a new one, since the old one was not properly deactivated before removing.
+
+Because of the obvious hassle to fix an incorrect entry, please be careful when
+entering in the correction range. Follow the greyed out text suggestions in the
+Loop user interface that say `min-max`.

--- a/docs/troubleshooting/omnipod-faults.md
+++ b/docs/troubleshooting/omnipod-faults.md
@@ -1,42 +1,63 @@
 # Omnipod Faults
 
 Pod faults are shown in the HUD:
+
 <p align="center">
 <img src="../img/pod-hud-fault.png" width="250">
 </p></br>
 
-Loop will put a higher battery load on a pod than the PDM due to its regular and repeated communications. A pod with lower battery level appears to be more likely to fault for conditions like static electricity and occlusions/pump issues that Loop is not directly causing, like internal fault codes 052, 061, 064 and 066. Pods always perform safety checks and if a potential problem is found, the pod will end itself by screaming and stop with the insulin delivery.
+Loop will put a higher battery load on a pod than the PDM due to its regular and
+repeated communications. A pod with lower battery level appears to be more
+likely to fault for conditions like static electricity and occlusions/pump
+issues that Loop is not directly causing, like internal fault codes 052, 061,
+064 and 066. Pods always perform safety checks and if a potential problem is
+found, the pod will end itself by screaming and stop with the insulin delivery.
 
-!!! note
-    During extensive tests after getting all commands working properly, many failures due to one specific safety check were still encountered. This check needed to recover its counter within 30 minutes after a temp basal returning to a normal basal schedule, or else the pod would scream. Eventually, this was resolved by disabling _only_ this particular check. Therefore the 096-106 faults are always ignored in the current configuration of Loop.
-
-
+!!! note During extensive tests after getting all commands working properly,
+many failures due to one specific safety check were still encountered. This
+check needed to recover its counter within 30 minutes after a temp basal
+returning to a normal basal schedule, or else the pod would scream. Eventually,
+this was resolved by disabling _only_ this particular check. Therefore the
+096-106 faults are always ignored in the current configuration of Loop.
 
 ## Known internal pod fault codes
-The currently known pod faults are listed here on the openomni wiki page: [Pod Fault codes](https://github.com/openaps/openomni/wiki/Fault-event-codes)
+
+The currently known pod faults are listed here on the openomni wiki page:
+[Pod Fault codes](https://github.com/openaps/openomni/wiki/Fault-event-codes)
 
 ## Ways to reduce the possibility of a fault
 
-None of the ways listed here are certain to reduce the possibility of a screaming pod, but they could be worth considering if the hypothesis of a low battery is indeed the cause of some late-in-life pods.
+None of the ways listed here are certain to reduce the possibility of a
+screaming pod, but they could be worth considering if the hypothesis of a low
+battery is indeed the cause of some late-in-life pods.
 
-* Keep the Loop app up to date; newer versions might include improvements to reduce pod battery load
-* Do not use the "neutral temp basal" code customization
-* Use a 433 Mhz RileyLink
+- Keep the Loop app up to date; newer versions might include improvements to
+  reduce pod battery load
+- Do not use the "neutral temp basal" code customization
+- Use a 433 Mhz RileyLink
 
 ## Not "replacement pod" situations
 
-Normal pod use can still give these two internal pod faults, which are not eligible for a replacement pod:
-* 028, Pod expired
-* 024, Empty reservoir
+Normal pod use can still give these two internal pod faults, which are not
+eligible for a replacement pod:
+
+- 028, Pod expired
+- 024, Empty reservoir
 
 ## Replacement pod situations
-You can always call Insulet tech support if a pod has a clear failure on the pod, such as:
 
-* A cannula was sticking out when the end cap was removed.
-* Visual inspection of the pod's cannula window indicating the cannula insertion was not successful.
-* Leaking or kinked cannula was causing insulin delivery issues.
-* The adhesive was not working properly when trying to place it on your body.
+You can always call Insulet tech support if a pod has a clear failure on the
+pod, such as:
 
-If the pod fails during use with Loop, a replacement might still be possible. However, the software which communicates with the pod isn't developed or supported by Insulet. Generally speaking, calling in failed pods for reasons not listed, above mid-pod life, maybe a bit of a reach for the DIY community. There is a grey area here that we should be careful of and acknowledge that Looping may be a cause in certain faults.
+- A cannula was sticking out when the end cap was removed.
+- Visual inspection of the pod's cannula window indicating the cannula insertion
+  was not successful.
+- Leaking or kinked cannula was causing insulin delivery issues.
+- The adhesive was not working properly when trying to place it on your body.
 
-
+If the pod fails during use with Loop, a replacement might still be possible.
+However, the software which communicates with the pod isn't developed or
+supported by Insulet. Generally speaking, calling in failed pods for reasons not
+listed, above mid-pod life, maybe a bit of a reach for the DIY community. There
+is a grey area here that we should be careful of and acknowledge that Looping
+may be a cause in certain faults.

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -1,37 +1,77 @@
 # Troubleshooting
 
-After you have been using Loop for a while, there's a potential that you will run across a behavior or issue that you wonder if it is normal or intended.  When that happens, there are a few things that we'd recommend doing to resolve the issue.
+After you have been using Loop for a while, there's a potential that you will
+run across a behavior or issue that you wonder if it is normal or intended. When
+that happens, there are a few things that we'd recommend doing to resolve the
+issue.
 
-## Issues with 
-
-
+## Issues with
 
 ## Gather information
 
 ### Check the Docs
-The Loop docs are updated regularly.  If you built your Loop app awhile ago, chances are good that more information has been updated and changed since you first read them.  Please can the topics and look for a section that may be applicable.  For example, if your Nightscout isn't working, try looking at the docs there.  A good read of ALL the pages at the beginning of using Loop is encouraged.  Many FAQs from new Loop users are covered in the docs.
+
+The Loop docs are updated regularly. If you built your Loop app awhile ago,
+chances are good that more information has been updated and changed since you
+first read them. Please can the topics and look for a section that may be
+applicable. For example, if your Nightscout isn't working, try looking at the
+docs there. A good read of ALL the pages at the beginning of using Loop is
+encouraged. Many FAQs from new Loop users are covered in the docs.
 
 ### Screenshots
-**Take a screenshot of your Loop main display screen**, or other screens (such as Tuning results of RileyLink) that may help troubleshooters better understand your issue.  A lot of times a picture is worth a thousand words.  Being able to see recent Loop basal adjustments, predicted BG curve, and carb entries really help fill in the full story of the current Loop status.  If you didn't manage to get a screenshot when the issue was happening, you can also go to Nightscout and scroll back over the previous 48 hours to obtain much of the same information.  Try to capture a Nightscout screen from the time period in question.
+
+**Take a screenshot of your Loop main display screen**, or other screens (such
+as Tuning results of RileyLink) that may help troubleshooters better understand
+your issue. A lot of times a picture is worth a thousand words. Being able to
+see recent Loop basal adjustments, predicted BG curve, and carb entries really
+help fill in the full story of the current Loop status. If you didn't manage to
+get a screenshot when the issue was happening, you can also go to Nightscout and
+scroll back over the previous 48 hours to obtain much of the same information.
+Try to capture a Nightscout screen from the time period in question.
 
 ### Issue Report
-Under the Loop app settings, there is a selection called `Issue Report`.  Within the Issue Report are important information about your Loop's actions and status that can be very useful for troubleshooters...particularly with unexplained behaviors.  The upper right corner of the Issue Report includes a button so that you can email the Issue Report to yourself (or others).  If you are seeing something unusual in your Loop, capture an Issue Report while it is happening and save it.  A troubleshooter may want to see that information.
+
+Under the Loop app settings, there is a selection called `Issue Report`. Within
+the Issue Report are important information about your Loop's actions and status
+that can be very useful for troubleshooters...particularly with unexplained
+behaviors. The upper right corner of the Issue Report includes a button so that
+you can email the Issue Report to yourself (or others). If you are seeing
+something unusual in your Loop, capture an Issue Report while it is happening
+and save it. A troubleshooter may want to see that information.
 
 ## Check Resources
 
 ### GitHub Issues
 
-Check the current list of [GitHub Loop Issues](https://github.com/LoopKit/Loop/issues) for known issues.  Many times other users have noticed the same issue previously and opened an Issue so that more information can be added to help develop a solution.  If you see your same issue has already been reported, please add to the open issue instead of creating a new one.
+Check the current list of
+[GitHub Loop Issues](https://github.com/LoopKit/Loop/issues) for known issues.
+Many times other users have noticed the same issue previously and opened an
+Issue so that more information can be added to help develop a solution. If you
+see your same issue has already been reported, please add to the open issue
+instead of creating a new one.
 
 <p align="center">
 <img src="../img/loop-issues.png" width="800">
 </p>
 
 ### Zulipchat and Facebook
-Search in [Zulipchat]( https://loop.zulipchat.com) or [Facebook](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf).  Quite possibly someone else has already posted about the same issue and perhaps a resolution has already been provided.  
+
+Search in [Zulipchat](https://loop.zulipchat.com) or
+[Facebook](https://www.facebook.com/groups/TheLoopedGroup/?fref=nf). Quite
+possibly someone else has already posted about the same issue and perhaps a
+resolution has already been provided.
 
 ## Ask for Help
-If you can't find any information in the Loop docs, GitHub Issues, Zulipchat, or Facebook...PLEASE post and ask for help.  GitHub Issues list is an EXCELLENT place to post issues of unexpected Loop behavior (that you believe are errant or need improvement).  However, if you are just seeking clarifications on Loop, but don't necessarily expect that there's a problem with the underlying code, then Facebook and Gitter would be a good place.  For example, Zulipchat and Facebook are great for asking about bolus strategies or exercise target use...those aren't really code issues.
 
-When you post, provide a description along with any screenshots of the issue you are having.  You don't necessarily have to tag any particular person, the community is fairly active in replying to messages.
+If you can't find any information in the Loop docs, GitHub Issues, Zulipchat, or
+Facebook...PLEASE post and ask for help. GitHub Issues list is an EXCELLENT
+place to post issues of unexpected Loop behavior (that you believe are errant or
+need improvement). However, if you are just seeking clarifications on Loop, but
+don't necessarily expect that there's a problem with the underlying code, then
+Facebook and Gitter would be a good place. For example, Zulipchat and Facebook
+are great for asking about bolus strategies or exercise target use...those
+aren't really code issues.
 
+When you post, provide a description along with any screenshots of the issue you
+are having. You don't necessarily have to tag any particular person, the
+community is fairly active in replying to messages.

--- a/docs/troubleshooting/pod-pairing.md
+++ b/docs/troubleshooting/pod-pairing.md
@@ -1,28 +1,56 @@
 # Pod Pairing Failure
 
-At the end of a pod life, you will deactivate your pod and then start the procedure for starting a new pod. You'll fill the new pod and it will start sending out periodic beeps while looking to establish a new pairing with your Loop. If during the pod pairing, you encounter troubles in Loop, here are some steps to take:
+At the end of a pod life, you will deactivate your pod and then start the
+procedure for starting a new pod. You'll fill the new pod and it will start
+sending out periodic beeps while looking to establish a new pairing with your
+Loop. If during the pod pairing, you encounter troubles in Loop, here are some
+steps to take:
 
 ### Check RileyLink
+
 First, let's make sure everything is ok as far as the RileyLink goes:
 
 1. RileyLink is charged and nearby, and
-2. RileyLink has a green LED light lit (indicating a Bluetooth connection with your iPhone), and
-3. Try toggling the RileyLink off/on at its physical switch if the green light is not on.
+2. RileyLink has a green LED light lit (indicating a Bluetooth connection with
+   your iPhone), and
+3. Try toggling the RileyLink off/on at its physical switch if the green light
+   is not on.
 
 ### Deactivate and Pair Fresh
 
-Assuming the RileyLink is ok, the most common cause of a pod failure is that Loop kind of incorrectly "halfway" pairs. Imagine if you will that the pod is calling out "I'm here...over here. My name is Cassandra." And the Loop says "Oh...I hear you! Hi Cassie! Let's get together!!" Except the pod is actually Cassandra, not Cassie. So the pod will not pair. And worse...when you try to get another pod, Jane, who replaces Cassandra...that won't work either. Now there's Cassandra and Jane both screaming out for someone to pair with and your Loop app is still looking for Cassie. Two pods down and no closer to a pairing. (Obviously, I'm simplifying the description for ease of explanation.)
+Assuming the RileyLink is ok, the most common cause of a pod failure is that
+Loop kind of incorrectly "halfway" pairs. Imagine if you will that the pod is
+calling out "I'm here...over here. My name is Cassandra." And the Loop says
+"Oh...I hear you! Hi Cassie! Let's get together!!" Except the pod is actually
+Cassandra, not Cassie. So the pod will not pair. And worse...when you try to get
+another pod, Jane, who replaces Cassandra...that won't work either. Now there's
+Cassandra and Jane both screaming out for someone to pair with and your Loop app
+is still looking for Cassie. Two pods down and no closer to a pairing.
+(Obviously, I'm simplifying the description for ease of explanation.)
 
-So...here's how to fix that issue. We need to get the Loop to stop looking for Cassie without insulting Cassandra. What we are going to do is leave Cassandra and Jane (and any other pods you've tried as well) out of the room, far away.
+So...here's how to fix that issue. We need to get the Loop to stop looking for
+Cassie without insulting Cassandra. What we are going to do is leave Cassandra
+and Jane (and any other pods you've tried as well) out of the room, far away.
 
-1. Take your RileyLink and iPhone and walk far away from all the beeping pods (Cassandras and Janes) looking to pair. How far away? Far enough away that there's no chance the beeping pods will hear the Loop app. We do not want the beeping pods to connect to the RileyLink or hear the commands we are about to do. (If you want, you could put the pods in a faraday bag or your microwave to shield them similar to what you might already do for Dexcom restarts.)
+1. Take your RileyLink and iPhone and walk far away from all the beeping pods
+   (Cassandras and Janes) looking to pair. How far away? Far enough away that
+   there's no chance the beeping pods will hear the Loop app. We do not want the
+   beeping pods to connect to the RileyLink or hear the commands we are about to
+   do. (If you want, you could put the pods in a faraday bag or your microwave
+   to shield them similar to what you might already do for Dexcom restarts.)
 
-2. While you are out-of-range from the beeping pods, click on the `cancel` button in the upper right corner of the pairing screen you've been stuck on.
+2. While you are out-of-range from the beeping pods, click on the `cancel`
+   button in the upper right corner of the pairing screen you've been stuck on.
 
 <p align="center">
 <img src="../img/pod-pair-fail.jpg" width="300">
 </p>
 
-3. On the next screen, click on the button to `Deactivate Pod`. This will make the Loop app forget about the "Cassie" it has been trying to use to pair with, leaving Loop free to make a fresh pairing.
+3. On the next screen, click on the button to `Deactivate Pod`. This will make
+   the Loop app forget about the "Cassie" it has been trying to use to pair
+   with, leaving Loop free to make a fresh pairing.
 
-4. After you finish that deactivation, now come back into range of ONE of your beeping pods....just one of them. Pull that pod close to RileyLink and do the usual steps for pairing in Loop again. This should now give the pod and Loop a chance to get their pairing done properly.
+4. After you finish that deactivation, now come back into range of ONE of your
+   beeping pods....just one of them. Pull that pod close to RileyLink and do the
+   usual steps for pairing in Loop again. This should now give the pod and Loop
+   a chance to get their pairing done properly.

--- a/docs/troubleshooting/priming.md
+++ b/docs/troubleshooting/priming.md
@@ -1,31 +1,59 @@
 # Priming and Site Changes
 
-Loop uses event history and reservoir levels to determine how much insulin has actually been delivered through the pump, and correspondingly the Insulin On Board (IOB).  
+Loop uses event history and reservoir levels to determine how much insulin has
+actually been delivered through the pump, and correspondingly the Insulin On
+Board (IOB).
 
 ## Site Changes
 
-!!!info "Priming Events and IOB"
-    Loop version 1.3.2 and newer will automatically detect prime events and the primed insulin will not be counted to IOB.  **You will need to have your Preferred Data Source set to Event History for the automatic detection of primes to work.**  Reservoir Volumes will not detect prime events.
+!!!info "Priming Events and IOB" Loop version 1.3.2 and newer will automatically
+detect prime events and the primed insulin will not be counted to IOB. **You
+will need to have your Preferred Data Source set to Event History for the
+automatic detection of primes to work.** Reservoir Volumes will not detect prime
+events.
 
-If you are using a version of Loop older than v1.3.2 (or using Preferred Data Source of Reservoir Volume), you will need to be aware of the following regarding prime events at site changes:
+If you are using a version of Loop older than v1.3.2 (or using Preferred Data
+Source of Reservoir Volume), you will need to be aware of the following
+regarding prime events at site changes:
 
-* If you change sites and increase reservoir volume (i.e., start a new reservoir), don't worry. So long as you are putting in a reservoir that has more insulin than the old one, IOB will be accurate in Loop.  When Loop sees a rewind and an increase in reservoir volume, it will not count any tubing primes as IOB.
+- If you change sites and increase reservoir volume (i.e., start a new
+  reservoir), don't worry. So long as you are putting in a reservoir that has
+  more insulin than the old one, IOB will be accurate in Loop. When Loop sees a
+  rewind and an increase in reservoir volume, it will not count any tubing
+  primes as IOB.
 
-* If you change sites but **do NOT increase reservoir volume** (i.e., you keep existing reservoir going), you will need to go into Loop's reservoir history and delete 30 minutes of continuous reservoir history including the prime event.  By deleting 30 minutes of reservoir history, Loop will use Event History to determine insulin deliveries and IOB. If you cannot get the prime to clear from the IOB, operate in Open Loop mode until the insulin action duration time has passed.  Deleting history is done by:
+- If you change sites but **do NOT increase reservoir volume** (i.e., you keep
+  existing reservoir going), you will need to go into Loop's reservoir history
+  and delete 30 minutes of continuous reservoir history including the prime
+  event. By deleting 30 minutes of reservoir history, Loop will use Event
+  History to determine insulin deliveries and IOB. If you cannot get the prime
+  to clear from the IOB, operate in Open Loop mode until the insulin action
+  duration time has passed. Deleting history is done by:
 
-    (1)  clicking on the Insulin Delivery Chart  
+  (1) clicking on the Insulin Delivery Chart
 
-    (2)  selecting the Reservoir history screen  
+  (2) selecting the Reservoir history screen
 
-    (3)  swiping to delete individual reservoir readings  
+  (3) swiping to delete individual reservoir readings
 
-    (4)  delete at least 30 minutes of reservoir readings, including the readings that involved priming events
+  (4) delete at least 30 minutes of reservoir readings, including the readings
+  that involved priming events
 
 ## Prime Menu
 
-!!!Warning
-    When you prime tubing on a Medtronic pump, make sure to complete the priming menu commands.
+!!!Warning When you prime tubing on a Medtronic pump, make sure to complete the
+priming menu commands.
 
-In other words, finish all the prompts so that you get back to the (nearly blank) normal Medtronic pump screen.  If you don't finish the priming menu, the pump will not begin basal insulin delivery, nor does it alarm.  It is equivalent to the pump being suspended...but you won't be able to see any indication of that in Nightscout as a remote monitoring parent other than Loop's temp basals not being set.  Loop will not detect the prime screen issue and will keep sending temp basal messages...but the pump won't enact them.  On Loop, you could notice it by the active IOB continually going down and then eventually negative IOB, as the basal is not delivered and the reservoir level remains constant.  However, the temp basal graph will still show the bars from the temp basal commands loop has been sending.
+In other words, finish all the prompts so that you get back to the (nearly
+blank) normal Medtronic pump screen. If you don't finish the priming menu, the
+pump will not begin basal insulin delivery, nor does it alarm. It is equivalent
+to the pump being suspended...but you won't be able to see any indication of
+that in Nightscout as a remote monitoring parent other than Loop's temp basals
+not being set. Loop will not detect the prime screen issue and will keep sending
+temp basal messages...but the pump won't enact them. On Loop, you could notice
+it by the active IOB continually going down and then eventually negative IOB, as
+the basal is not delivered and the reservoir level remains constant. However,
+the temp basal graph will still show the bars from the temp basal commands loop
+has been sending.
 
 So, remember to finish those prime menu screens through to the end.

--- a/docs/troubleshooting/pump-errors.md
+++ b/docs/troubleshooting/pump-errors.md
@@ -1,13 +1,24 @@
 # Medtronic Pump Errors
 
-The Medtronic pumps are used and typically not under warranty.  Use this section at your own risk.  However, that said, some of the most common pump errors are repairable, or not actually a real problem.
+The Medtronic pumps are used and typically not under warranty. Use this section
+at your own risk. However, that said, some of the most common pump errors are
+repairable, or not actually a real problem.
 
 ## A21 error
 
-This error message is common when a pump has been stored for a period of time without a battery.  Most pumps will show an A21 error when you first purchase them on the used market.  Not a big deal.  Press the down arrow (also has the symbol of a light bulb on it) and the pump screen message will scroll down to let you know how to clear that error message (press ESC then ACT).  If the message is coming up on a pump that hasn't been in storage, pull the battery out and replace with a fresh, new battery.  Chances are your battery or battery cap are old.  Look for signs of dirt or rust in the battery cap, give it a little cleaning.
+This error message is common when a pump has been stored for a period of time
+without a battery. Most pumps will show an A21 error when you first purchase
+them on the used market. Not a big deal. Press the down arrow (also has the
+symbol of a light bulb on it) and the pump screen message will scroll down to
+let you know how to clear that error message (press ESC then ACT). If the
+message is coming up on a pump that hasn't been in storage, pull the battery out
+and replace with a fresh, new battery. Chances are your battery or battery cap
+are old. Look for signs of dirt or rust in the battery cap, give it a little
+cleaning.
 
-!!!info "Display Tip"
-    When the pump screen has a little black/white bar on the right side, that is a scroll bar.  Use the arrow keys on the right of the pump screen to scroll and see the additional information.
+!!!info "Display Tip" When the pump screen has a little black/white bar on the
+right side, that is a scroll bar. Use the arrow keys on the right of the pump
+screen to scroll and see the additional information.
 
 <p align="center">
 <img src="../img/A21.jpg" width="400">
@@ -15,34 +26,47 @@ This error message is common when a pump has been stored for a period of time wi
 
 ## Batt Out Limit
 
-This error message "battery out of limits" has to do with the internal pump battery, not the AAA battery you replace.  The internal battery cannot be replaced, and unfortunately also has a finite lifespan.  The error message is more of an annoyance than a true problem.  You can try to change the AAA battery faster.  But, the worst-case scenario is that you'll have to re-enter the time and date when you get this message more often.  (Don't forget to use RileyLink to set the time after you get this message.)
+This error message "battery out of limits" has to do with the internal pump
+battery, not the AAA battery you replace. The internal battery cannot be
+replaced, and unfortunately also has a finite lifespan. The error message is
+more of an annoyance than a true problem. You can try to change the AAA battery
+faster. But, the worst-case scenario is that you'll have to re-enter the time
+and date when you get this message more often. (Don't forget to use RileyLink to
+set the time after you get this message.)
 
 <p align="center">
 <img src="../img/batt-out.jpg" width="400">
 </p>
 
-
 ## Button Error
 
-The Button Error message usually happens from water, moisture, or dust getting under the pump's button pad and causing button(s) to fail.  The fix luckily is quite straight-forward and takes less than 30 minutes.  Check out the fix [here for a YouTube video]('troubleshooting/time-change.md') or [here for photo gallery](https://imgur.com/a/iOXAP)
+The Button Error message usually happens from water, moisture, or dust getting
+under the pump's button pad and causing button(s) to fail. The fix luckily is
+quite straight-forward and takes less than 30 minutes. Check out the fix
+[here for a YouTube video]('troubleshooting/time-change.md') or
+[here for photo gallery](https://imgur.com/a/iOXAP)
 
 <p align="center">
 <img src="../img/button-error.jpg" width="400">
 </p>
 
-The solution involves simply prying up the button pad's sticker face to expose the layers beneath.
+The solution involves simply prying up the button pad's sticker face to expose
+the layers beneath.
 
 <p align="center">
 <img src="../img/button-fix.jpg" width="400">
 </p>
 
-You can see some evidence of crud/rust on the underside of this button pad which caused the button error.
+You can see some evidence of crud/rust on the underside of this button pad which
+caused the button error.
 
 <p align="center">
 <img src="../img/dirty-button.jpg" width="400">
 </p>
 
-After you finish your fix, another excellent idea is to make sure you add a length of clear packing tape across the front face of the pump to prevent errant water or dirt from having easy access to the button pad seams.
+After you finish your fix, another excellent idea is to make sure you add a
+length of clear packing tape across the front face of the pump to prevent errant
+water or dirt from having easy access to the button pad seams.
 
 <p align="center">
 <img src="../img/taped-pump.jpg" width="400">
@@ -50,11 +74,25 @@ After you finish your fix, another excellent idea is to make sure you add a leng
 
 ## Crack/Missing Piece Repairs
 
-Another common issue on these Medtronic pumps are cracks and/or missing bits of plastic near the battery cap or reservoir sleeve. You can repair these fairly easily. For filling small cracks, [Testor's plastic cement](https://www.amazon.com/Cement-Glue-Value-Testors-tubes/dp/B0013D53CS/ref=sr_1_2?s=toys-and-games&ie=UTF8&qid=1550883077&sr=1-2&keywords=testors+plastic+cement) or [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1) are good choices.
+Another common issue on these Medtronic pumps are cracks and/or missing bits of
+plastic near the battery cap or reservoir sleeve. You can repair these fairly
+easily. For filling small cracks,
+[Testor's plastic cement](https://www.amazon.com/Cement-Glue-Value-Testors-tubes/dp/B0013D53CS/ref=sr_1_2?s=toys-and-games&ie=UTF8&qid=1550883077&sr=1-2&keywords=testors+plastic+cement)
+or
+[Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1)
+are good choices.
 
-For more extensive repairs to replace missing chunks of plastic, [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1) or [Sugru](https://www.amazon.com/Sugru-Mouldable-Glue-Original-Formula/dp/B01BFE0KNQ/ref=sr_1_4?ie=UTF8&qid=1550883178&sr=8-4&keywords=sugru) are excellent choices.  
+For more extensive repairs to replace missing chunks of plastic,
+[Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1)
+or
+[Sugru](https://www.amazon.com/Sugru-Mouldable-Glue-Original-Formula/dp/B01BFE0KNQ/ref=sr_1_4?ie=UTF8&qid=1550883178&sr=8-4&keywords=sugru)
+are excellent choices.
 
-You can use [teflon thread tape](https://www.amazon.com/LASCO-11-1033-Sealant-2-Inch-100-Inch/dp/B00ITPHXZI/ref=sr_1_17?ie=UTF8&qid=1550883881&sr=8-17&keywords=teflon+thread+tape) on the battery cap to make sure the epoxy or Sugru don't stick to the battery cap, but still recreate the threads.  The first photos are of a Sugru repair and second set of photos are Gorilla epoxy repair.
+You can use
+[teflon thread tape](https://www.amazon.com/LASCO-11-1033-Sealant-2-Inch-100-Inch/dp/B00ITPHXZI/ref=sr_1_17?ie=UTF8&qid=1550883881&sr=8-17&keywords=teflon+thread+tape)
+on the battery cap to make sure the epoxy or Sugru don't stick to the battery
+cap, but still recreate the threads. The first photos are of a Sugru repair and
+second set of photos are Gorilla epoxy repair.
 
 <p align="center">
 <img src="../img/after-sugru.jpg" width="750">
@@ -66,7 +104,12 @@ You can use [teflon thread tape](https://www.amazon.com/LASCO-11-1033-Sealant-2-
 
 ## Motor error
 
-Often a motor error is the result of a poorly seated reservoir or tubing cap.  If you get a motor error, the first thing you should do is detach from your infusion site.  Remove and reseat the reservoir, prime again, and see if the motor error resolves.  If it does not, try replacing the tubing cap on the reservoir (new tubing).  If that does not resolve the motor error, also replace the entire reservoir.
+Often a motor error is the result of a poorly seated reservoir or tubing cap. If
+you get a motor error, the first thing you should do is detach from your
+infusion site. Remove and reseat the reservoir, prime again, and see if the
+motor error resolves. If it does not, try replacing the tubing cap on the
+reservoir (new tubing). If that does not resolve the motor error, also replace
+the entire reservoir.
 
 <p align="center">
 <img src="../img/motor-error.jpg" width="400">
@@ -74,10 +117,16 @@ Often a motor error is the result of a poorly seated reservoir or tubing cap.  I
 
 ## A33 error
 
-!!!warning "Safety warning"
-    If you get this error, DO NOT push on the bulged out end cap.  Always detach your tubing from your infusion set before addressing this error message.  If you push on the end cap in an attempt to get it back flush, you may delivery a dangerous amount of insulin mistakenly.
+!!!warning "Safety warning" If you get this error, DO NOT push on the bulged out
+end cap. Always detach your tubing from your infusion set before addressing this
+error message. If you push on the end cap in an attempt to get it back flush,
+you may delivery a dangerous amount of insulin mistakenly.
 
-This error is a bit more involved to repair.  The problem is that there is a loose drive support cap.  Most of the time this error message will appear during a priming event as the end cap of the drive will slip, releasing the ability of the reservoir plunger to get pressure to delivery insulin.  The pump senses the lack of pressure and delivers the A33 error.
+This error is a bit more involved to repair. The problem is that there is a
+loose drive support cap. Most of the time this error message will appear during
+a priming event as the end cap of the drive will slip, releasing the ability of
+the reservoir plunger to get pressure to delivery insulin. The pump senses the
+lack of pressure and delivers the A33 error.
 
 <p align="center">
 <img src="../img/A33-2.jpg" width="400">
@@ -87,22 +136,37 @@ This error is a bit more involved to repair.  The problem is that there is a loo
 <img src="../img/A33.jpg" width="400">
 </p>
 
-The solution is to UNHOOK from your site.  See warning above.  Remove reservoir and put your finger inside the reservoir sleeve.  Push on the drive so that the end cap is pushed out the most possible.  This will give your the most surface area possible to place the super glue GEL that you will use.  (don't use regular super glue...it must be gel.)  Remove the sticker that covers the end cap, save it for later because you can reattach when repair is completed.
+The solution is to UNHOOK from your site. See warning above. Remove reservoir
+and put your finger inside the reservoir sleeve. Push on the drive so that the
+end cap is pushed out the most possible. This will give your the most surface
+area possible to place the super glue GEL that you will use. (don't use regular
+super glue...it must be gel.) Remove the sticker that covers the end cap, save
+it for later because you can reattach when repair is completed.
 
-With the end cap pushed out, take some glue gel with the toothpick and apply it on the outside of the popped out cap . Be generous cause you can do this only once . Once you are done take a napkin and press hard the cap toward the pump so it can go back inside and keep it pressed for a few seconds. Then remove all the small parts of the napkin that has glued to the pump. Leave the pump to dry for about 10-15 minutes.
+With the end cap pushed out, take some glue gel with the toothpick and apply it
+on the outside of the popped out cap . Be generous cause you can do this only
+once . Once you are done take a napkin and press hard the cap toward the pump so
+it can go back inside and keep it pressed for a few seconds. Then remove all the
+small parts of the napkin that has glued to the pump. Leave the pump to dry for
+about 10-15 minutes.
 
 <p align="center">
 <img src="../img/A33-4.jpg" width="400">
 </p>
 
-Now to test whether the pumps was glued well. You have already waited about 10-15 minutes so put your finger back in and press hard the plunger.  If you glued it well, the end cap will not move.  If the cap goes out again, you have to glue one more time. If all looks well, put some glue back on top of the pump cap and reattach the sticker that was removed to start.
+Now to test whether the pumps was glued well. You have already waited about
+10-15 minutes so put your finger back in and press hard the plunger. If you
+glued it well, the end cap will not move. If the cap goes out again, you have to
+glue one more time. If all looks well, put some glue back on top of the pump cap
+and reattach the sticker that was removed to start.
 
 ## A32 and E22 error loop
 
-From what we know, this set of error codes seems like a pump killer.  A call to Medtronic support gave this less than hopeful information:
+From what we know, this set of error codes seems like a pump killer. A call to
+Medtronic support gave this less than hopeful information:
 
-A32 - failure of flash memory
-E22 - software re-installation is necessary
+A32 - failure of flash memory E22 - software re-installation is necessary
 
-We don't have any reports of a good fix for these error codes.  When seen, usually the E22 error comes up and as soon as it is cleared, the A32 error comes up.  And the loop continues with a pump restart.
-
+We don't have any reports of a good fix for these error codes. When seen,
+usually the E22 error comes up and as soon as it is cleared, the A32 error comes
+up. And the loop continues with a pump restart.

--- a/docs/troubleshooting/rileylink.md
+++ b/docs/troubleshooting/rileylink.md
@@ -1,29 +1,71 @@
 # RileyLink
 
-
 ## Tuning the Radio
 
-The RileyLink communicates with the pump through radio frequency communications.  Numerous factors can influence how well those communications can function...interferences from other devices, temperature, physical blocking, etc.
+The RileyLink communicates with the pump through radio frequency communications.
+Numerous factors can influence how well those communications can
+function...interferences from other devices, temperature, physical blocking,
+etc.
 
-When your RileyLink and pump first pair together, Loop performs a series of tests that you won't see...they are tuning tests. Basically, RileyLink sends little test messages to the pump and waits for a response. The RileyLink tries this same "ping" to the pump a range of various radio frequencies. The range of radio frequencies it tries is based on the pump you've told RileyLink to expect (Omnipod, Medtronic NA/CA, or Medtronic WW).  RileyLink will then record the radio frequencies that provided the strongest response and use that frequency for future pump communications.
+When your RileyLink and pump first pair together, Loop performs a series of
+tests that you won't see...they are tuning tests. Basically, RileyLink sends
+little test messages to the pump and waits for a response. The RileyLink tries
+this same "ping" to the pump a range of various radio frequencies. The range of
+radio frequencies it tries is based on the pump you've told RileyLink to expect
+(Omnipod, Medtronic NA/CA, or Medtronic WW). RileyLink will then record the
+radio frequencies that provided the strongest response and use that frequency
+for future pump communications.
 
-Usually this best frequency is pretty constant for any given pump+RL, but during temperature changes it may be that the best frequency is not the one currently set. In the event that RileyLink has prolems communicating with the pump, Loop has code built-in that will automatically tell the RileyLink "hey, try that tuning pump thing again...maybe there's a better frequency we need to try." This retuning is started automatically if pump communications fail for 14 minutes (in other words, two looping cycles).
+Usually this best frequency is pretty constant for any given pump+RL, but during
+temperature changes it may be that the best frequency is not the one currently
+set. In the event that RileyLink has prolems communicating with the pump, Loop
+has code built-in that will automatically tell the RileyLink "hey, try that
+tuning pump thing again...maybe there's a better frequency we need to try." This
+retuning is started automatically if pump communications fail for 14 minutes (in
+other words, two looping cycles).
 
-Knowing a little about the strength of the radio communications will help you troubleshoot Loop errors.  When you `Tune Radio Frequency` in the Riley Link menu, it is testing for the strongest frequency to communicate with the pump.  For example, in the screenshot below, the strength of the radio communications with the pump is shown by the last number of the tune.  Frequencies with tuning results of -99 means NO communications were established at that frequency.  RileyLink will use the strongest frequency tune for its pump communications.  In the screenshot, the best frequency returned a result of `-37` at a frequency of `916.60 MHz`, so RileyLink will set that `916.60 MHz` for its pump communications.
+Knowing a little about the strength of the radio communications will help you
+troubleshoot Loop errors. When you `Tune Radio Frequency` in the Riley Link
+menu, it is testing for the strongest frequency to communicate with the pump.
+For example, in the screenshot below, the strength of the radio communications
+with the pump is shown by the last number of the tune. Frequencies with tuning
+results of -99 means NO communications were established at that frequency.
+RileyLink will use the strongest frequency tune for its pump communications. In
+the screenshot, the best frequency returned a result of `-37` at a frequency of
+`916.60 MHz`, so RileyLink will set that `916.60 MHz` for its pump
+communications.
 
 <p align="center">
 <img src="../img/rl_tune.jpg" width="400">
 </p>
 
-Generally, if you have tuning in the -90s, your RileyLink-pump communications will not work.  If you have tuning in the -80s, you may have periodic communication failures.  If your tuning is in the -70s or better, your communications should be pretty stable.  
+Generally, if you have tuning in the -90s, your RileyLink-pump communications
+will not work. If you have tuning in the -80s, you may have periodic
+communication failures. If your tuning is in the -70s or better, your
+communications should be pretty stable.
 
-Experiment with your RileyLink by moving it closer and farther away from the pump.  Try putting it on the other side of your body, or put it in a purse.  Test the tuning results in real world situations that you think you'd be encountering, such as where you will have the RileyLink placed during overnight charging. Perform tunes at the various distances and situations.  This will help you understand how far from the pump your RileyLink can get before it will affect Loop performance.  
+Experiment with your RileyLink by moving it closer and farther away from the
+pump. Try putting it on the other side of your body, or put it in a purse. Test
+the tuning results in real world situations that you think you'd be
+encountering, such as where you will have the RileyLink placed during overnight
+charging. Perform tunes at the various distances and situations. This will help
+you understand how far from the pump your RileyLink can get before it will
+affect Loop performance.
 
 ## Bluetooth
 
-RileyLink communicates with your iPhone and Loop app through Bluetooth (BT).  If your iPhone has BT issues, your Loop will have failures.  There have been reports of BT audio devices (such as BT pairings in your car or home audio BT speakers) interfering with the Loop.  If you are finding Loop failures frequently happening at a particular location, you may try to troubleshoot if there are BT problems in the area.
+RileyLink communicates with your iPhone and Loop app through Bluetooth (BT). If
+your iPhone has BT issues, your Loop will have failures. There have been reports
+of BT audio devices (such as BT pairings in your car or home audio BT speakers)
+interfering with the Loop. If you are finding Loop failures frequently happening
+at a particular location, you may try to troubleshoot if there are BT problems
+in the area.
 
-Your BT signal strength can be seen in the Loop settings, under the RileyLink menu, on the `Signal Strength` line.  As you move closer and further away from your phone, you can watch that number dynamically change. This line is **not** displaying the signal strength of your pump communications discussed above (those are shown in the tuning results screen).
+Your BT signal strength can be seen in the Loop settings, under the RileyLink
+menu, on the `Signal Strength` line. As you move closer and further away from
+your phone, you can watch that number dynamically change. This line is **not**
+displaying the signal strength of your pump communications discussed above
+(those are shown in the tuning results screen).
 
 <p align="center">
 <img src="../img/RL_bt.jpg" width="400">
@@ -31,35 +73,81 @@ Your BT signal strength can be seen in the Loop settings, under the RileyLink me
 
 ## Lights
 
-RileyLink has several lights that you may notice from time to time.  There is no 'power' light.  If you suspect that your RileyLink is not being powered, try turning it off and on using the small sliding switch.  You should see lights in the middle of the board flash when you do this.  If they flash, that means the board has power.
+RileyLink has several lights that you may notice from time to time. There is no
+'power' light. If you suspect that your RileyLink is not being powered, try
+turning it off and on using the small sliding switch. You should see lights in
+the middle of the board flash when you do this. If they flash, that means the
+board has power.
 
-* Red light: Charging light.  The red light will remain on while RileyLink is charging, and it will turn off when charging is complete.  You may notice the red light turn on periodically even after charging is complete...it's just "topping off".
+- Red light: Charging light. The red light will remain on while RileyLink is
+  charging, and it will turn off when charging is complete. You may notice the
+  red light turn on periodically even after charging is complete...it's just
+  "topping off".
 
-* Green light: Bluetooth connection light.  The green light will remain on while you have BT connection with your iPhone.  If that green light fails to stay on, you should troubleshoot your BT connections.  Try restarting BT on your iPhone and/or turning the RileyLink off/on by its power switch.
+- Green light: Bluetooth connection light. The green light will remain on while
+  you have BT connection with your iPhone. If that green light fails to stay on,
+  you should troubleshoot your BT connections. Try restarting BT on your iPhone
+  and/or turning the RileyLink off/on by its power switch.
 
-* Blue light: Pump communications.  If you have an older firmware on your RileyLink, some of the blue lights will flash periodically as it is communicating with the pump.  It's just letting you know that it is busy talking and collecting info.  You will also see increased blue flashes if you have "Enabled Diagnositic LEDs" for RileyLinks that have the updated firmware (shipping since late August 2018).
+- Blue light: Pump communications. If you have an older firmware on your
+  RileyLink, some of the blue lights will flash periodically as it is
+  communicating with the pump. It's just letting you know that it is busy
+  talking and collecting info. You will also see increased blue flashes if you
+  have "Enabled Diagnositic LEDs" for RileyLinks that have the updated firmware
+  (shipping since late August 2018).
 
-A solid blue light that consistenly remains lit on the board could mean one of two things:
+A solid blue light that consistenly remains lit on the board could mean one of
+two things:
 
-* A temporary issue that can be resolved by rebooting the RileyLink physically (turning the switch off/on), or
+- A temporary issue that can be resolved by rebooting the RileyLink physically
+  (turning the switch off/on), or
 
-* An electrical short or damage to the board.  Sweat and moisture are most likely culprits, so try to keep case free from those environments (don't keep in sports bras or waist band next to skin, for example, while exercising)
+- An electrical short or damage to the board. Sweat and moisture are most likely
+  culprits, so try to keep case free from those environments (don't keep in
+  sports bras or waist band next to skin, for example, while exercising)
 
-If your blue light remains on despite trying a restart, it is time to pull out your backup RileyLink.
+If your blue light remains on despite trying a restart, it is time to pull out
+your backup RileyLink.
 
 ## Charging
 
-The battery that comes with RileyLink is not likely charged completely when it is shipped, so feel free to charge it up.  You'll need a [mini-USB cable](https://www.amazon.com/AmazonBasics-USB-2-0-Cable--Male/dp/B00NH13S44) and [0.5A USB charging power supply](https://www.amazon.com/Cellet-Powered-Charger-iPhones-Smartphones-/dp/B00FE8WFCO) like your iPhone power supply.  RileyLink takes about 2-4 hours to fully charge (the red light will turn off when fully charged, read note above about red light patterns) and should easily last at least a full day of constant Loop use.  Typically, it can go into the 30-hour range without problem.  Most people charge their RileyLink each night when they are sleeping.  You don't have to worry about leaving the RileyLink plugged in "too long" for charging.  It will automatically stop charging the battery when it is fully charged.
+The battery that comes with RileyLink is not likely charged completely when it
+is shipped, so feel free to charge it up. You'll need a
+[mini-USB cable](https://www.amazon.com/AmazonBasics-USB-2-0-Cable--Male/dp/B00NH13S44)
+and
+[0.5A USB charging power supply](https://www.amazon.com/Cellet-Powered-Charger-iPhones-Smartphones-/dp/B00FE8WFCO)
+like your iPhone power supply. RileyLink takes about 2-4 hours to fully charge
+(the red light will turn off when fully charged, read note above about red light
+patterns) and should easily last at least a full day of constant Loop use.
+Typically, it can go into the 30-hour range without problem. Most people charge
+their RileyLink each night when they are sleeping. You don't have to worry about
+leaving the RileyLink plugged in "too long" for charging. It will automatically
+stop charging the battery when it is fully charged.
 
-Since the best practice is to charge your RileyLink overnight while you sleep, and the battery lasts safely over 24 hours, there is no battery level indicator for the RileyLink.  The RileyLink's charge level is not viewable on Nightscout, nor within the Loop app.  If you forget to charge your RileyLink overnight, you can recharge it with a portable USB battery in a pinch.  A [short mini-USB cable](https://www.adafruit.com/product/899) could be a good addition to a small gear bag.
+Since the best practice is to charge your RileyLink overnight while you sleep,
+and the battery lasts safely over 24 hours, there is no battery level indicator
+for the RileyLink. The RileyLink's charge level is not viewable on Nightscout,
+nor within the Loop app. If you forget to charge your RileyLink overnight, you
+can recharge it with a portable USB battery in a pinch. A
+[short mini-USB cable](https://www.adafruit.com/product/899) could be a good
+addition to a small gear bag.
 
 ## Range
 
-The range that your RileyLink will function is **heavily** dependent on the environment that you are in. Read the section about Tuning to help determine how far your RileyLink can dependably maintain an adequate signal strength in your particular environment.  Most people wear the RileyLink in a pocket or carry a belt holster during the day.  Typically, RileyLink will need to be closer to the pump than the iPhone.  The radio frequency communications will have a shorter range than the BT communications.
+The range that your RileyLink will function is **heavily** dependent on the
+environment that you are in. Read the section about Tuning to help determine how
+far your RileyLink can dependably maintain an adequate signal strength in your
+particular environment. Most people wear the RileyLink in a pocket or carry a
+belt holster during the day. Typically, RileyLink will need to be closer to the
+pump than the iPhone. The radio frequency communications will have a shorter
+range than the BT communications.
 
 ## Lipo Battery
 
-If you ordered your RileyLink preassembled, you should plug in the battery cable.  Please make sure your RileyLink’s battery cable is securely pushed all the way into the socket.  Poor battery cable connection can make the Loop communications fail.
+If you ordered your RileyLink preassembled, you should plug in the battery
+cable. Please make sure your RileyLink’s battery cable is securely pushed all
+the way into the socket. Poor battery cable connection can make the Loop
+communications fail.
 
 <p><figure align="center">
   <img src="../img/rl_loose_battery.jpg" width="400">
@@ -71,7 +159,11 @@ If you ordered your RileyLink preassembled, you should plug in the battery cable
   <figcaption>RileyLink with properly secured battery cable.</figcaption>
 </figure></p>
 
-Keep your RileyLink and lipo battery protected from damage.  Lipo batteries are unsafe when damaged or punctured, so the case is an important part of safe Looping.  If your battery is damaged in some way, please disconnect it immediately, and dispose of it (they should be recycled). You can order new batteries on the [GetRileyLink website](http://getrileylink.org/)
+Keep your RileyLink and lipo battery protected from damage. Lipo batteries are
+unsafe when damaged or punctured, so the case is an important part of safe
+Looping. If your battery is damaged in some way, please disconnect it
+immediately, and dispose of it (they should be recycled). You can order new
+batteries on the [GetRileyLink website](http://getrileylink.org/)
 
 <p align="center">
 <img src="../img/rl_case.jpg" width="400">
@@ -79,8 +171,10 @@ Keep your RileyLink and lipo battery protected from damage.  Lipo batteries are 
 
 ## Removing Lipo Battery
 
-To remove the lipo battery from the RileyLink, please do so slowly and patiently.  Work the battery connection side to side slowly to loosen it from the plug.  Some people have reported success using small, curved needle nose pliers such as hemostats.  Others have used small flathead screwdrivers as shown in [this video](https://youtu.be/s2qNPLpfwww).
+To remove the lipo battery from the RileyLink, please do so slowly and
+patiently. Work the battery connection side to side slowly to loosen it from the
+plug. Some people have reported success using small, curved needle nose pliers
+such as hemostats. Others have used small flathead screwdrivers as shown in
+[this video](https://youtu.be/s2qNPLpfwww).
 
 <a href="https://youtu.be/s2qNPLpfwww" target="_blank"><img src="../img/rileylink_battery_removal.png"  title="RileyLink assembly video" /></a>
-
-

--- a/docs/troubleshooting/time-change.md
+++ b/docs/troubleshooting/time-change.md
@@ -1,29 +1,49 @@
 # Time Changes with Loop
 
-Loop is built to operate fully across time zone and daylight savings time changes as long as a few basic instructions are followed.
+Loop is built to operate fully across time zone and daylight savings time
+changes as long as a few basic instructions are followed.
 
-!!! warning "IMPORTANT"
-    **Always use RileyLink to change pump time instead of the Medtronic Pump's screen.  If you fail to set the pump time by using the RileyLink, Loop will not function properly.**
+!!! warning "IMPORTANT" **Always use RileyLink to change pump time instead of
+the Medtronic Pump's screen. If you fail to set the pump time by using the
+RileyLink, Loop will not function properly.**
 
 <p align="center">
 <img src="../img/time_change.png" width="400">
 </p>
 
 ## iPhone
-Loop will assume your iPhone's time (UTC, not timezone) is always correct. This theoretically may not be the case if a nearby cell tower is improperly configured (though there are likely resilience mechanisms in iOS to handle this). Automatic time setting can always be disabled in Settings.
+
+Loop will assume your iPhone's time (UTC, not timezone) is always correct. This
+theoretically may not be the case if a nearby cell tower is improperly
+configured (though there are likely resilience mechanisms in iOS to handle
+this). Automatic time setting can always be disabled in Settings.
 
 ## Minimed Pump and CGM
-The Minimed pump doesn't expose a universal clock, instead it exposes the components of a date (YMDHIS). It has no concept of political time zones, and just continues to increment its components on schedule. Therefore, Loop assumes that the pump's date, until changed, remains at a fixed offset from UTC.
 
-That offset is stored by Loop the first time the pump ID is changed, and every time the pump's time is changed from the RileyLink Settings screen.
+The Minimed pump doesn't expose a universal clock, instead it exposes the
+components of a date (YMDHIS). It has no concept of political time zones, and
+just continues to increment its components on schedule. Therefore, Loop assumes
+that the pump's date, until changed, remains at a fixed offset from UTC.
 
+That offset is stored by Loop the first time the pump ID is changed, and every
+time the pump's time is changed from the RileyLink Settings screen.
 
 ## Dexcom CGM
-No particular input is needed on your part for Loop to work with Dexcom CGM data. All times are UTC.  However for Dexcom receiver users, at time changes you may want to manually change your receiver's time setting just so the time visually appears correct when you are viewing the screen.
+
+No particular input is needed on your part for Loop to work with Dexcom CGM
+data. All times are UTC. However for Dexcom receiver users, at time changes you
+may want to manually change your receiver's time setting just so the time
+visually appears correct when you are viewing the screen.
 
 ## Traveling across time zones and daylight savings
-When traveling, there is no urgency to update the pump's time to match the wall-clocks in your geography. Configuration schedules—basal rates, target ranges, carb ratios, and insulin sensitivities—will all remain in the pump's time zone. The app's graphs and status will always display in the time zone of the iPhone, and Loop will understand the difference in offset between the two, highlighting it when attempting to change configuration schedules.
 
-When you're ready to update the pump's time, simply <u>**use the Loop's RileyLink "Change Time" command** </u>. This will also shift your configuration schedules to the current time zone.
+When traveling, there is no urgency to update the pump's time to match the
+wall-clocks in your geography. Configuration schedules—basal rates, target
+ranges, carb ratios, and insulin sensitivities—will all remain in the pump's
+time zone. The app's graphs and status will always display in the time zone of
+the iPhone, and Loop will understand the difference in offset between the two,
+highlighting it when attempting to change configuration schedules.
 
-
+When you're ready to update the pump's time, simply <u>**use the Loop's
+RileyLink "Change Time" command** </u>. This will also shift your configuration
+schedules to the current time zone.

--- a/docs/troubleshooting/yellow-red-loop.md
+++ b/docs/troubleshooting/yellow-red-loop.md
@@ -1,40 +1,61 @@
 # Yellow and Red Loops
 
-A properly operating Loop will remain green for 5 minutes.  To remain green, there are several things that Loop must do:
+A properly operating Loop will remain green for 5 minutes. To remain green,
+there are several things that Loop must do:
 
-* Loop obtains a BG value from your CGM source, and
-* Loop reads your pump history to know about insulin deliveries and recent events, and
-* Loop completes a run of its calculations based on those inputs
-* Loop recommends a temp basal and sends that instruction to the pump
-* Pump enacts the recommended temp basal
-* Loop confirms the pump enacted the recommended temp basal
+- Loop obtains a BG value from your CGM source, and
+- Loop reads your pump history to know about insulin deliveries and recent
+  events, and
+- Loop completes a run of its calculations based on those inputs
+- Loop recommends a temp basal and sends that instruction to the pump
+- Pump enacts the recommended temp basal
+- Loop confirms the pump enacted the recommended temp basal
 
-If something goes wrong in those steps and more than 5 minutes goes by, the Loop will turn yellow until it can solve the problem.  If more than 15 minutes goes by and the problem still exists, Loop will turn red.
+If something goes wrong in those steps and more than 5 minutes goes by, the Loop
+will turn yellow until it can solve the problem. If more than 15 minutes goes by
+and the problem still exists, Loop will turn red.
 
-!!! info ""
-    To see the latest Loop error messages, touch the yellow or red Loop Status circle on the main screen. If an error message is available, it will appear in a dialog window. Use that error message to help guide your next troubleshooting steps, as laid out in the discussion below.
+!!! info "" To see the latest Loop error messages, touch the yellow or red Loop
+Status circle on the main screen. If an error message is available, it will
+appear in a dialog window. Use that error message to help guide your next
+troubleshooting steps, as laid out in the discussion below.
 
-A healthy green loop will have timestamps less than 5 minutes old below the green loop, BG reading, and reservoir level.  This indicates that the Loop was run less than 5 minutes ago, fresh BGs have been coming in, temp basals have been enacted by the pump, and the pump is communicating with Loop.  The screenshot below is a very happy Loop.
+A healthy green loop will have timestamps less than 5 minutes old below the
+green loop, BG reading, and reservoir level. This indicates that the Loop was
+run less than 5 minutes ago, fresh BGs have been coming in, temp basals have
+been enacted by the pump, and the pump is communicating with Loop. The
+screenshot below is a very happy Loop.
 
 <p align="center">
 <img src="../img/loop_less_than_five.jpg" width="550">
 </p>
 </br></br>
 
-For Loopers who have already been successfully getting green loops, but suddenly find themselves with problems...we need to figure out which area your loop is failing in.
+For Loopers who have already been successfully getting green loops, but suddenly
+find themselves with problems...we need to figure out which area your loop is
+failing in.
 
-****************************
-**<p align="center">The displayed error message should help you narrow in on the cause of the red loop:</p>
-    <p align="center">Is this a CGM issue?</p>
-    <p align="center">Is this a pump issue?</p>
-    <p align="center">Is this a RileyLink/BT issue?</p>**
+---
 
-****************************
+\*\*<p align="center">The displayed error message should help you narrow in on
+the cause of the red loop:</p>
+
+<p align="center">Is this a CGM issue?</p>
+<p align="center">Is this a pump issue?</p>
+<p align="center">Is this a RileyLink/BT issue?</p>**
+
+---
+
 ## CGM issues
-###<p align="center">**Old BG data (CGM issue)**</p>
-</br>
 
-If your Loop turns yellow or red, easiest to start by checking the timestamps on the BG.  **If the BG reading is more than 5 minutes older than your iPhone time, your Loop will not be green.**  The screenshot below is a good example of missing BG data preventing the Loop from staying green.  The pump is still communicating (reservoir reading is only 2 minutes old)...BGs appear to be the problem.</br></br>
+###<p align="center">**Old BG data (CGM issue)**</p> </br>
+
+If your Loop turns yellow or red, easiest to start by checking the timestamps on
+the BG. **If the BG reading is more than 5 minutes older than your iPhone time,
+your Loop will not be green.** The screenshot below is a good example of missing
+BG data preventing the Loop from staying green. The pump is still communicating
+(reservoir reading is only 2 minutes old)...BGs appear to be the
+problem.</br></br>
 
 <p align="center">
 <img src="../img/loop_oldbg2.jpg" width="550">
@@ -45,21 +66,35 @@ If your Loop turns yellow or red, easiest to start by checking the timestamps on
 
 BG troubleshooting steps:
 
-* Verify you have enabled the correct [CGM Selection](https://loopkit.github.io/loopdocs/setup/loop-settings/settings/#cgm-selection) in Loop settings; it is easy to accidentally change the selection while scrolling through the settings page
-* For G5, verify your [transmitter ID](https://loopkit.github.io/loopdocs/setup/loop-settings/settings/#cgm-selection) is set correctly in Loop settings
-* For G4, verify the Dexcom Share app is running on your phone
-* **Fetch Recent Glucose** command in RL only works for Medtronic CGM users, by the way...so don't expect that command to solve Dexcom CGM issues
-* If your local CGM is working fine on the Dexcom app, but Loop isn't reading it:
-    * make sure you enter your Dexcom Share account info in the Loop settings. Loop will automatically switch to pulling from the Dexcom servers if the local reading isn't working.
-    * try turning Loop and Dexcom apps off, toggle BT off/on, restart Loop app, and then restart Dexcom app
-****************************
+- Verify you have enabled the correct
+  [CGM Selection](https://loopkit.github.io/loopdocs/setup/loop-settings/settings/#cgm-selection)
+  in Loop settings; it is easy to accidentally change the selection while
+  scrolling through the settings page
+- For G5, verify your
+  [transmitter ID](https://loopkit.github.io/loopdocs/setup/loop-settings/settings/#cgm-selection)
+  is set correctly in Loop settings
+- For G4, verify the Dexcom Share app is running on your phone
+- **Fetch Recent Glucose** command in RL only works for Medtronic CGM users, by
+  the way...so don't expect that command to solve Dexcom CGM issues
+- If your local CGM is working fine on the Dexcom app, but Loop isn't reading
+  it:
+  - make sure you enter your Dexcom Share account info in the Loop settings.
+    Loop will automatically switch to pulling from the Dexcom servers if the
+    local reading isn't working.
+  - try turning Loop and Dexcom apps off, toggle BT off/on, restart Loop app,
+    and then restart Dexcom app
+
+---
 
 ## Pump Issues
 
-###<p align="center">**Old Pump data (Pump Issue)**</p>
-</br>
+###<p align="center">**Old Pump data (Pump Issue)**</p> </br>
 
-If your pump reading is older than 5 minutes, but BGs are fine, then you will need to troubleshoot the pump communications.  The screenshot below is a good example of missing pump data preventing the Loop from staying green.  The CGM is still communicating (BG reading is only 2 minutes old)...but pump reservoir reading is older than 5 min.</br></br>
+If your pump reading is older than 5 minutes, but BGs are fine, then you will
+need to troubleshoot the pump communications. The screenshot below is a good
+example of missing pump data preventing the Loop from staying green. The CGM is
+still communicating (BG reading is only 2 minutes old)...but pump reservoir
+reading is older than 5 min.</br></br>
 
 <p align="center">
 <img src="../img/loop_old_pump.png" width="550">
@@ -68,89 +103,138 @@ If your pump reading is older than 5 minutes, but BGs are fine, then you will ne
 
 Pump troubleshooting steps:
 
-* Your pump battery may be low.  Replace the battery...even if the percentage doesn't look low, this is a good starting point
-* If you have an x23 or x54 model pump, make sure your mysentry is paired
-* Have the pump and RL gotten too far away from each other?  Try bringing them closer
-* Try retuning the RL.  Just a note though, the Loop has code embedded to automatically retune RL when the pump comms are failing for 20 minutes.  So, manual retuning is more about speeding things along rather than being a necessary intervention to fixing pump comms.
-* Try a **Send Button Press** to "wake up the pump" a bit.
-* Try a **Fetch Pump History**.  Same as retuning though, the Loop has code embedded to automatically pull pump history.  Manual fetching of pump history is more about speeding things along than being a necessary step to fixing pump comms.
-* If you have a backup pump, try switching to that pump and see whether the issue persists.
+- Your pump battery may be low. Replace the battery...even if the percentage
+  doesn't look low, this is a good starting point
+- If you have an x23 or x54 model pump, make sure your mysentry is paired
+- Have the pump and RL gotten too far away from each other? Try bringing them
+  closer
+- Try retuning the RL. Just a note though, the Loop has code embedded to
+  automatically retune RL when the pump comms are failing for 20 minutes. So,
+  manual retuning is more about speeding things along rather than being a
+  necessary intervention to fixing pump comms.
+- Try a **Send Button Press** to "wake up the pump" a bit.
+- Try a **Fetch Pump History**. Same as retuning though, the Loop has code
+  embedded to automatically pull pump history. Manual fetching of pump history
+  is more about speeding things along than being a necessary step to fixing pump
+  comms.
+- If you have a backup pump, try switching to that pump and see whether the
+  issue persists.
 
-!!! info "About Pump Communications"
-    Pump communications errors can and will happen. Just be patient, and they almost always correct themselves.  Yellow loops happen sometimes, and aren't usually worth troubleshooting.  Red loops are more infrequent and usually a good time to start investigating possible source.  **Some environments will be noisy for rf comms (such as concerts, amusement parks, tech venues, conferences with OpenAPS users in attendance, etc.), and your loop may not stay green as often as usual.  Just be patient. When you leave that environment, looping will go back to normal.**  Wireless microphones, baby monitors, and other similar types of devices can interfere with pump communications if there are lots of competing radio devices in a tight environment.  If you find you have areas of your house that consistently have poor pump communications, look for potential sources of interference from wireless devices.
-    
-    Another common area for failed pump communications are at night if you tend to sleep on your pump, or otherwise "body block" the RL's ability to communicate with the pump.  Try to place your pump and RL such that your body will not block the signal to/from RL.  Standing the RL on its base with antenna pointing up, on a nearby nightstand should be sufficient proximity/orientation for overnight looping.
-    
-    These examples below are pump error messages.  Notice they all mention the pump specifically.
+!!! info "About Pump Communications" Pump communications errors can and will
+happen. Just be patient, and they almost always correct themselves. Yellow loops
+happen sometimes, and aren't usually worth troubleshooting. Red loops are more
+infrequent and usually a good time to start investigating possible source.
+**Some environments will be noisy for rf comms (such as concerts, amusement
+parks, tech venues, conferences with OpenAPS users in attendance, etc.), and
+your loop may not stay green as often as usual. Just be patient. When you leave
+that environment, looping will go back to normal.** Wireless microphones, baby
+monitors, and other similar types of devices can interfere with pump
+communications if there are lots of competing radio devices in a tight
+environment. If you find you have areas of your house that consistently have
+poor pump communications, look for potential sources of interference from
+wireless devices.
+
+Another common area for failed pump communications are at night if you tend to
+sleep on your pump, or otherwise "body block" the RL's ability to communicate
+with the pump. Try to place your pump and RL such that your body will not block
+the signal to/from RL. Standing the RL on its base with antenna pointing up, on
+a nearby nightstand should be sufficient proximity/orientation for overnight
+looping.
+
+These examples below are pump error messages. Notice they all mention the pump
+specifically.
 
     <p align="center">
     <img src="../img/loop_framerate.jpg" width="750">
     </p>
     </br></br>
 
-*************************
-###<p align="center">**Incorrect Pump Time (Pump Issue)**</p>
-</br>
+---
 
-And here's an interesting problem.  BGs are current, but notice that the pump time is 2 hours into the future of the current iPhone time.  In this case, the Loop user had manually set their pump time during travels and caused the pump time to be out of sync with Loop.  Remember, **<u>do not change your pump time manually...always use the RL to set the pump time</u>**.  This red loop was resolved as soon as the Looper used RL to set the pump time.</br></br>
+###<p align="center">**Incorrect Pump Time (Pump Issue)**</p> </br>
+
+And here's an interesting problem. BGs are current, but notice that the pump
+time is 2 hours into the future of the current iPhone time. In this case, the
+Loop user had manually set their pump time during travels and caused the pump
+time to be out of sync with Loop. Remember, **<u>do not change your pump time
+manually...always use the RL to set the pump time</u>**. This red loop was
+resolved as soon as the Looper used RL to set the pump time.</br></br>
 
 <p align="center">
 <img src="../img/loop_bad_pump_time.jpg" width="550">
 </p>
 </br></br>
 
-****************************
-###<p align="center">**Failure to Enact Temp Basals (Pump Issue)**</p>
-</br>
+---
 
-If you see messages about "Could not verify TempBasal on attempt  2", that is likely one of just a few issues.  The message indicates that Loop has BGs and pump data, has sent a recommended basal to the pump, but the pump does not appear to be enacting those basals.</br></br>
+###<p align="center">**Failure to Enact Temp Basals (Pump Issue)**</p> </br>
+
+If you see messages about "Could not verify TempBasal on attempt 2", that is
+likely one of just a few issues. The message indicates that Loop has BGs and
+pump data, has sent a recommended basal to the pump, but the pump does not
+appear to be enacting those basals.</br></br>
 
 <p align="center">
 <img src="../img/loop_verify.jpg" width="250">
 </p>
 </br></br>
 
-* Your pump cannot be suspended.  Resume insulin deliveries
-* Max basal rate in Loop app cannot be greater than max basal rate in pump settings
-* Temp basal type must be set to unit/hour, not percent, in pump
+- Your pump cannot be suspended. Resume insulin deliveries
+- Max basal rate in Loop app cannot be greater than max basal rate in pump
+  settings
+- Temp basal type must be set to unit/hour, not percent, in pump
 
-****************************
+---
 
 ## Bluetooth/RL issues
 
-###<p align="center">**Bluetooth failures (RL or iPhone issue)**</p>
-</br>
+###<p align="center">**Bluetooth failures (RL or iPhone issue)**</p> </br>
 
-Sometimes the RilleyLink and iPhone fail to communicate via BT.  You need to determine if this is due to RL's problems, iPhone's problems, or just BT communications problem.  There can be messages when BT fails, such as the message below, or "RileyLink Timeout" error messages.</br></br>
+Sometimes the RilleyLink and iPhone fail to communicate via BT. You need to
+determine if this is due to RL's problems, iPhone's problems, or just BT
+communications problem. There can be messages when BT fails, such as the message
+below, or "RileyLink Timeout" error messages.</br></br>
 
 <p align="center">
 <img src="../img/loop_bt_error.jpg" width="250">
 </p>
 </br></br>
 
-* Has your RL been fully charged? Try charging your RL for an hour or two, make sure the red light comes on while charging
-* Is your lipo battery old and perhaps dying earlier in the day?  Order a new battery, replace lipo battery
-* Check your lipo battery wires?  If your wires are dislodged from the lipo itself, RL will not likely work for long
-* Your RL battery needs to be securely plugged in, check those connections.
-* Check if your RL is on and says "connected" in the [status screen for bluetooth](https://loopkit.github.io/loopdocs/setup/loop-settings/rileylink_menu/#device). If it says "connecting" or "disconnected", you have a BT problem with RL and iPhone.
-* Make sure your iPhone's BT is turned on, and BT is not being affected by other BT systems (such as car audio)
-* Check if any of the RL command buttons work...such as **Send Button Press**.
-* If you've checked all of the above, toggle your RL power switch and turn your iPhone BT off/on.  Try rebooting your phone.  If those steps don't work and the RL is properly charging otherwise, likely you have a bad RileyLink and will need to replace it.
+- Has your RL been fully charged? Try charging your RL for an hour or two, make
+  sure the red light comes on while charging
+- Is your lipo battery old and perhaps dying earlier in the day? Order a new
+  battery, replace lipo battery
+- Check your lipo battery wires? If your wires are dislodged from the lipo
+  itself, RL will not likely work for long
+- Your RL battery needs to be securely plugged in, check those connections.
+- Check if your RL is on and says "connected" in the
+  [status screen for bluetooth](https://loopkit.github.io/loopdocs/setup/loop-settings/rileylink_menu/#device).
+  If it says "connecting" or "disconnected", you have a BT problem with RL and
+  iPhone.
+- Make sure your iPhone's BT is turned on, and BT is not being affected by other
+  BT systems (such as car audio)
+- Check if any of the RL command buttons work...such as **Send Button Press**.
+- If you've checked all of the above, toggle your RL power switch and turn your
+  iPhone BT off/on. Try rebooting your phone. If those steps don't work and the
+  RL is properly charging otherwise, likely you have a bad RileyLink and will
+  need to replace it.
 
-**********************
+---
 
 ## Loop Settings Issues
 
 ###<p align="center">**Failure to set Insulin Curve Model (Loop settings)**</p>
 </br>
 
-If you see messages about "Missing data: Glucose effects", you likely have **forgotten to set your Insulin Curve Model**.  The message indicates that Loop is missing a component of its algorithm inputs to calculate glucose effects on predicted BGs.   Return to your Loop app settings and pick an Insulin Curve.</br></br>
+If you see messages about "Missing data: Glucose effects", you likely have
+**forgotten to set your Insulin Curve Model**. The message indicates that Loop
+is missing a component of its algorithm inputs to calculate glucose effects on
+predicted BGs. Return to your Loop app settings and pick an Insulin
+Curve.</br></br>
 
 <p align="center">
 <img src="../img/loop_select_model.jpg" width="250">
 </p>
 </br></br>
 
-**********************
-
-
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,93 +1,93 @@
 site_name: LoopDocs
 theme: flatly
-google_analytics: ['UA-109876065-1', 'loopkit.github.io']
+google_analytics: ["UA-109876065-1", "loopkit.github.io"]
 extra_css:
-    - css/admonitions.css
+  - css/admonitions.css
 markdown_extensions:
-    - admonition
-    - toc:
-        permalink: ⌁
+  - admonition
+  - toc:
+      permalink: ⌁
 
 pages:
-- Home: 'index.md'
-- FAQs:
-    - 'Using This Site FAQs': 'faqs/docs-faqs.md'
-    - 'General Loop FAQs': 'faqs/FAQs.md'
-    - 'Omnipod FAQs': 'faqs/omnipod-faqs.md'
-    - 'Branch FAQs': 'faqs/branch-faqs.md'
-    - 'Update/Rebuild Loop FAQs': 'faqs/update-faqs.md'
-    - 'iOS 13 FAQs': 'faqs/ios13.md'
-    - 'RileyLink FAQs': 'faqs/rileylink-faqs.md'
-    - 'Algorithm FAQs': 'faqs/algorithm-faqs.md'
-    - 'CGM FAQs': 'faqs/cgm-faqs.md'
-    - 'Safety Tips': 'faqs/safety-faqs.md'
-- Build App:
-    - Overview: 'build/overview.md'
-    - 'Step 1 Compatible Computer': 'build/step1.md'
-    - 'Step 2 Compatible iPhone/iPod touch': 'build/step2.md'
-    - 'Step 3 Compatible Pump': 'build/step3.md'
-    - 'Step 4 Compatible CGM': 'build/step4.md'
-    - 'Step 5 Order a RileyLink': 'build/step5.md'
-    - 'Step 6 Enroll in Apple Developer Program': 'build/step6.md'
-    - 'Step 7 Install Homebrew': 'build/step7.md'
-    - 'Step 8 Download Xcode': 'build/step8.md'
-    - 'Step 9 Xcode Preferences': 'build/step9.md'
-    - 'Step 10 Test Settings': 'build/step10.md'
-    - 'Step 11 Make plans for Loop Data': 'build/step11.md'
-    - 'Step 12 Meet Community': 'build/step12.md'
-    - 'Step 13 Download Loop code': 'build/step13.md'
-    - 'Step 14 Build Loop app': 'build/step14.md'
-    - 'Oh dear! Build errors?': 'build/build_errors.md'
-    - 'Customize your Loop': 'build/code_customization.md'
-    - 'Ready to Update your Loop?': 'build/updating.md'
-- Set up App:
-    - 'Overview': 'operation/overview.md'
-    - 'Step 1: Health Permissions': 'build/health.md'
-    - 'Step 2: Add Pump':
-        - 'Add Medtronic': 'operation/loop-settings/mdt-pump.md'
-        - 'Add Omnipod': 'operation/loop-settings/omnipod-pump.md'
-    - 'Step 3: Add CGM': 'operation/loop-settings/cgm.md'
-    - 'Step 4: Configurations': 'operation/loop-settings/configurations.md'
-    - 'Step 5: Loop Services': 'operation/loop-settings/services.md'
-    - 'Loop Displays': 'operation/loop-settings/displays.md'
-    - 'RileyLink menu': 'operation/loop-settings/rileylink.md'
-- Operate:
-    - How to Use Loop App:
-        - 'Carb Entries': 'operation/features/carbs.md'
-        - 'Bolus': 'operation/features/bolus.md'
-        - 'Workout Targets': 'operation/features/workout.md'
-        - 'Using ICE info': 'operation/features/ice.md'
-        - 'Apple Watch': 'operation/features/watch.md'
-        - 'iPhone widget': 'operation/features/widget.md'
-        - 'Loop Notifications': 'operation/features/notifications.md'
-        - 'Pump Battery': 'operation/features/battery.md'
-    - 'Looping Tips':
-        - 'Open Loop': 'operation/loop/open-loop.md'
-        - 'Closed Loop': 'operation/loop/close-loop.md'
-        - 'Loop Tips': 'operation/loop/looptips.md'
-    - Algorithm:
-        - 'Overview': 'operation/algorithm/overview.md'
-        - 'Bolus Recommendations': 'operation/algorithm/bolus.md'
-        - 'Glucose Prediction': 'operation/algorithm/prediction.md'
-        - 'Temp Basal Adjustments': 'operation/algorithm/temp-basal.md'
-    - Troubleshoot:
-        - 'Overview': 'troubleshooting/overview.md'
-        - 'Loop crashes': 'troubleshooting/loop-crashing.md'
-        - 'Grey Loop': 'troubleshooting/green-loop.md'
-        - 'Yellow/Red Loop': 'troubleshooting/yellow-red-loop.md'
-        - 'Pod Pairing Failures': 'troubleshooting/pod-pairing.md'
-        - 'MDT Priming and Sites': 'troubleshooting/priming.md'
-        - 'Time Changes': 'troubleshooting/time-change.md'
-        - 'MDT Pump Errors': 'troubleshooting/pump-errors.md'
-        - 'Omnipod Faults': 'troubleshooting/omnipod-faults.md'
-- Nightscout:
-    - 'Overview': 'nightscout/overview.md'
-    - 'Brand New NS': 'nightscout/new_user.md'
-    - 'Retrofit Existing NS': 'nightscout/update_user.md'
-    - 'Setup Troubleshooting': 'nightscout/troublehoot.md'
-    - 'NS Stopped Working': 'nightscout/mlab_cleanup.md'
-    - 'Azure to Heroku': 'nightscout/azure_migration.md'
-    - 'IFTTT': 'nightscout/ifttt.md'
-    - 'Pebble': 'nightscout/pebble.md'
-    - 'Remote Notifications': 'nightscout/pushover.md'
-    - 'Reports': 'nightscout/reports.md'
+  - Home: "index.md"
+  - FAQs:
+      - "Using This Site FAQs": "faqs/docs-faqs.md"
+      - "General Loop FAQs": "faqs/FAQs.md"
+      - "Omnipod FAQs": "faqs/omnipod-faqs.md"
+      - "Branch FAQs": "faqs/branch-faqs.md"
+      - "Update/Rebuild Loop FAQs": "faqs/update-faqs.md"
+      - "iOS 13 FAQs": "faqs/ios13.md"
+      - "RileyLink FAQs": "faqs/rileylink-faqs.md"
+      - "Algorithm FAQs": "faqs/algorithm-faqs.md"
+      - "CGM FAQs": "faqs/cgm-faqs.md"
+      - "Safety Tips": "faqs/safety-faqs.md"
+  - Build App:
+      - Overview: "build/overview.md"
+      - "Step 1 Compatible Computer": "build/step1.md"
+      - "Step 2 Compatible iPhone/iPod touch": "build/step2.md"
+      - "Step 3 Compatible Pump": "build/step3.md"
+      - "Step 4 Compatible CGM": "build/step4.md"
+      - "Step 5 Order a RileyLink": "build/step5.md"
+      - "Step 6 Enroll in Apple Developer Program": "build/step6.md"
+      - "Step 7 Install Homebrew": "build/step7.md"
+      - "Step 8 Download Xcode": "build/step8.md"
+      - "Step 9 Xcode Preferences": "build/step9.md"
+      - "Step 10 Test Settings": "build/step10.md"
+      - "Step 11 Make plans for Loop Data": "build/step11.md"
+      - "Step 12 Meet Community": "build/step12.md"
+      - "Step 13 Download Loop code": "build/step13.md"
+      - "Step 14 Build Loop app": "build/step14.md"
+      - "Oh dear! Build errors?": "build/build_errors.md"
+      - "Customize your Loop": "build/code_customization.md"
+      - "Ready to Update your Loop?": "build/updating.md"
+  - Set up App:
+      - "Overview": "operation/overview.md"
+      - "Step 1: Health Permissions": "build/health.md"
+      - "Step 2: Add Pump":
+          - "Add Medtronic": "operation/loop-settings/mdt-pump.md"
+          - "Add Omnipod": "operation/loop-settings/omnipod-pump.md"
+      - "Step 3: Add CGM": "operation/loop-settings/cgm.md"
+      - "Step 4: Configurations": "operation/loop-settings/configurations.md"
+      - "Step 5: Loop Services": "operation/loop-settings/services.md"
+      - "Loop Displays": "operation/loop-settings/displays.md"
+      - "RileyLink menu": "operation/loop-settings/rileylink.md"
+  - Operate:
+      - How to Use Loop App:
+          - "Carb Entries": "operation/features/carbs.md"
+          - "Bolus": "operation/features/bolus.md"
+          - "Workout Targets": "operation/features/workout.md"
+          - "Using ICE info": "operation/features/ice.md"
+          - "Apple Watch": "operation/features/watch.md"
+          - "iPhone widget": "operation/features/widget.md"
+          - "Loop Notifications": "operation/features/notifications.md"
+          - "Pump Battery": "operation/features/battery.md"
+      - "Looping Tips":
+          - "Open Loop": "operation/loop/open-loop.md"
+          - "Closed Loop": "operation/loop/close-loop.md"
+          - "Loop Tips": "operation/loop/looptips.md"
+      - Algorithm:
+          - "Overview": "operation/algorithm/overview.md"
+          - "Bolus Recommendations": "operation/algorithm/bolus.md"
+          - "Glucose Prediction": "operation/algorithm/prediction.md"
+          - "Temp Basal Adjustments": "operation/algorithm/temp-basal.md"
+      - Troubleshoot:
+          - "Overview": "troubleshooting/overview.md"
+          - "Loop crashes": "troubleshooting/loop-crashing.md"
+          - "Grey Loop": "troubleshooting/green-loop.md"
+          - "Yellow/Red Loop": "troubleshooting/yellow-red-loop.md"
+          - "Pod Pairing Failures": "troubleshooting/pod-pairing.md"
+          - "MDT Priming and Sites": "troubleshooting/priming.md"
+          - "Time Changes": "troubleshooting/time-change.md"
+          - "MDT Pump Errors": "troubleshooting/pump-errors.md"
+          - "Omnipod Faults": "troubleshooting/omnipod-faults.md"
+  - Nightscout:
+      - "Overview": "nightscout/overview.md"
+      - "Brand New NS": "nightscout/new_user.md"
+      - "Retrofit Existing NS": "nightscout/update_user.md"
+      - "Setup Troubleshooting": "nightscout/troublehoot.md"
+      - "NS Stopped Working": "nightscout/mlab_cleanup.md"
+      - "Azure to Heroku": "nightscout/azure_migration.md"
+      - "IFTTT": "nightscout/ifttt.md"
+      - "Pebble": "nightscout/pebble.md"
+      - "Remote Notifications": "nightscout/pushover.md"
+      - "Reports": "nightscout/reports.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 
 mkdocs<0.17
 mkdocs-bootswatch==0.4.0
+pre-commit==1.18.3


### PR DESCRIPTION
Hi Loopers!

I set up Loop a while ago and wanted to give back to the community, but when I started editing markdown files, I got overwhelmed by 300+ character lines! So I figured I'd set up an automated tool to make this repo a bit prettier and accessible to people who want to help add to it. To do this, I did a few things:

1. Configure a `pre-commit` hook to run each time a dev commits new code.
2. Hook executes Prettier's `prose-wrap` auto formatter. This will automatically limit markdown lines to 80 characters.

I will admit, this is the first time I am using either of these tools, so I would appreciate if someone could checkout this branch and see if the instructions I added in the README are clear.