### PR TITLE
FIX: Broken images showing Heroku Settings tab

### DIFF
--- a/docs/nightscout/azure_migration.md
+++ b/docs/nightscout/azure_migration.md
@@ -165,7 +165,7 @@ You do not have to enter all the information in the profile if you are using Loo
 * Assuming your previous browser tab is still open for "Create a new App | Heroku", let's go back to that tab.  This time instead of choosing the `View` option, we are going to select the `Manage App` button. Then, select the `Settings` tab near the top of the screen on your Heroku app.
 
 <p align="center">
-<img src="../img/settings_heroku.jpg" width="450">
+<img src="../img/heroku5.png" width="450">
 </p> 
 
 * Click on `Reveal Config  Vars`. Scroll down the bottom of the Config Vars lines until you find the last blank one.  You are going to add several additional lines of config vars for Loop use; the DEVICESTATUS_ADVANCED is a required line, the others just make Nightscout more useful when Looping.

--- a/docs/nightscout/update_user.md
+++ b/docs/nightscout/update_user.md
@@ -17,7 +17,7 @@ The modifications for retrofitting an existing NS site for new Loop users will r
 [Login to your Heroku account](https://id.heroku.com/login), select the `Settings` tab near the top of the screen on your Heroku app.
 
 <p align="center">
-<img src="../img/settings_heroku.jpg" width="450">
+<img src="../img/heroku5.png" width="450">
 </p> 
 
 ### Step 2: Edit/Add Config Vars


### PR DESCRIPTION
Fixed image path showing Heroku settings tab & reveal Config vars. This image was broken here: https://loopkit.github.io/loopdocs/nightscout/azure_migration/

and here

https://loopkit.github.io/loopdocs/nightscout/update_user/#step-1-login-to-heroku-settings-tab

Appropriate image was already located in `/img` folder, just needed to update filename. 