### PR TITLE
warn first time builders before starting build

### DIFF
--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -147,6 +147,15 @@ Ok, so now that I've got your attention, you can continue on with the last step 
 
 Have you signed the four targets? Are you all done with any customizations? Has your Apple watch been paired and updated? Is your iPhone unlocked and plugged into the computer?
 
+!!!info "First-time builders"
+    Be aware though! Sometime during your first ever build on a computer, be ready for a codesign/keychain access prompt that you will see part-way through the build process.</br></br>
+
+    <p align="center">
+    <img src="../img/keychain-prompt.png" width="350">
+    </p></br>
+
+    This prompt above, when you see it, requires you to enter your computer password and then select "Always Allow". Normal behavior, this prompt will come up four times in a row even after you enter the correct password. In frustration, people think the prompt must be broken because it keeps reappearing and then people will press deny or cancel. **Don't press deny.** Keep entering your computer password and pressing the "Always Allow" button...as many times as it takes (four times to be exact; one for each target that Xcode is saving the password for). After four times of successful password entry, the build will keep proceeding.
+
 Let’s finish the installation of the Loop app onto your iPhone. Double-check to make sure your iPhone's name is still selected and then press the “build” button to start Xcode on its way. 
 
 <p align="center">
@@ -160,15 +169,6 @@ You’ll see the progression of the build in the status window (top middle of Xc
     <p align="center">
     <img src="../img/build-scheme.png" width="650">
     </p></br>
-
-!!!info "First-time builders"
-    Be aware though! Sometime during your first ever build on a computer, be ready for a codesign/keychain access prompt that you will see part-way through the build process.</br></br>
-
-    <p align="center">
-    <img src="../img/keychain-prompt.png" width="350">
-    </p></br>
-
-    This prompt above, when you see it, requires you to enter your computer password and then select "Always Allow". Normal behavior, this prompt will come up four times in a row even after you enter the correct password. In frustration, people think the prompt must be broken because it keeps reappearing and then people will press deny or cancel. **Don't press deny.** Keep entering your computer password and pressing the "Always Allow" button...as many times as it takes (four times to be exact; one for each target that Xcode is saving the password for). After four times of successful password entry, the build will keep proceeding.
 
 !!!warning "While I have you here..."
     While I have you here, I'm going to give you a piece of Loop troubleshooting advice for once you start looping. This is a little out of order, but too many people miss this super simple troubleshooting step when their Loop turns red. Try turning your RileyLink off/on at its physical switch on the side of the case. Carrying a paperclip on the keychain can help you access that recessed switch. The other useful troubleshooting step is to simply close the Loop app (upswipe in iPhone app selector) and reopen it. Wait 5 minutes after each of these steps and see if your issue resolves. It usually will. Don't forget to do these two simple steps to get back to a green loop.  Ok, back to the building instructions.


### PR DESCRIPTION
It would be helpful for first time builders to warn before they press the "build" button so that they know in advance what to expect. I followed the excellent loopdocs step by step and this was the only step where I found a pre warning could have helped because the message box comes multiple times.