### PR TITLE
Update workout.md

### DIFF
--- a/docs/operation/features/workout.md
+++ b/docs/operation/features/workout.md
@@ -10,7 +10,7 @@ Override presets are (1) optional and (2) can be configured within Loop's workou
 
 ## How overrides work
 
-Overrides allow you to specify an overall insulin needs adjustment, a target range, and a duration for the override with each preset. The overall insulin needs adjustment is a multiplier adjustment to your scheduled basal rates, carb ratios, and insulin sensitivities all together. In other words, overall insulin needs percent will affect boluses and temp basal recommendations both.  
+Overrides allow you to specify an overall insulin needs adjustment, a target range, and a duration for the override with each preset. The overall insulin needs adjustment is an adjustment to your scheduled basal rates, carb ratios, and insulin sensitivities all together. In other words, overall insulin needs percent will affect boluses, temp basals, and correction recommendations.  
 
 Notice the fine-print below the orange bar showing the overall adjustment graphic..."Basal, bolus, and correction insulin dose amounts are increased by 20%" in the example with a 120% overall insulin needs adjustment. So, 100% overall needs means no multiplier will be applied to your basal, insulin sensitivities, or carb ratio...but you could still use a 100% preset simply to define a different target range for a period of time. 
 


### PR DESCRIPTION
Clarify that override percent applies to insulin needs overall, it is not always a multiplier.