### PR TITLE
Remove mkdocs 0.17.x warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ $ cd <loopdocs project location>
 $ pip install -r requirements.txt
 ```
 
-**mkdocs Version Warning:** Use the latest `0.16.x` patch version of `mkdocs`, but don't upgrade `mkdocs` to version `0.17.x`. It is NOT compatible with the theme being used.  Same for updated versions of `mkdocs-bootswatch`, do not use the latest version.
-
 * Or, install modules individually
 ```bash
 $ pip install mkdocs<0.17


### PR DESCRIPTION
Based on changes to requirements.txt, this README warning is no longer valid.