### PR TITLE
Removing incorrect information

### DIFF
--- a/docs/faqs/branch-faqs.md
+++ b/docs/faqs/branch-faqs.md
@@ -114,7 +114,7 @@ Japanese, Danish, Swedish, Vietnamese, Finnish, Portuguese (Brazilian), Polish, 
 
 All branches (master and dev) now use a "non-linear" carb model, so let's give some info about the change.
 
-Previously, the carb model Loop used had a linear absorption predicted with dynamic carbs adjustments (Master and omnipod-testing branch still use that model). What this means is that food absorption was modeled as a flat, even effect (like the straight grey graph that you'll see in the [Insulin Counteraction Effects chart](https://loopkit.github.io/loopdocs/operation/features/ice/) after you added a carb entry. But looking at large groups of meals' datasets (and supported by personal, anecdotal experiences), food really has a bit more of a non-linear absorption. Meaning, we usually see more of a food impact up-front than the old carb model in Loop predicted.
+Previously, the carb model Loop used had a linear absorption predicted with dynamic carbs adjustments. What this means is that food absorption was modeled as a flat, even effect (like the straight grey graph that you'll see in the [Insulin Counteraction Effects chart](https://loopkit.github.io/loopdocs/operation/features/ice/) after you added a carb entry. But looking at large groups of meals' datasets (and supported by personal, anecdotal experiences), food really has a bit more of a non-linear absorption. Meaning, we usually see more of a food impact up-front than the old carb model in Loop predicted.
 
 What did that mismatch mean for us if the model predicts a linear absorption, but the meal actually behaves differently? 
 


### PR DESCRIPTION
Removing the statement:

> Master and omnipod-testing branch still use that model

As this is no longer the case and the 'non-linear' model is used on both master and dev as stated immediately above.