### PR TITLE
Increase basal rate when at correction range

### DIFF
--- a/docs/operation/algorithm/temp-basal.md
+++ b/docs/operation/algorithm/temp-basal.md
@@ -11,7 +11,7 @@ If the eventual blood glucose is less than the correction range and all of the p
 ![decrease basal rate example](img/decrease.png)
 
 ### Increase Basal Rate
-If the eventual blood glucose is greater than the correction range and all of the predicted glucose values are equal to or above the correction range, then Loop will issue a temporary basal rate that is higher than the current basal rate to bring the eventual blood glucose down to the correction target.
+If the eventual blood glucose is greater than the correction range and all of the predicted glucose values are both above the suspend threshold and equal to or above the correction range, then Loop will issue a temporary basal rate that is higher than the current basal rate to bring the eventual blood glucose down to the correction target.
 
 ![increase basal rate example](img/increase.png)
 

--- a/docs/operation/algorithm/temp-basal.md
+++ b/docs/operation/algorithm/temp-basal.md
@@ -11,7 +11,7 @@ If the eventual blood glucose is less than the correction range and all of the p
 ![decrease basal rate example](img/decrease.png)
 
 ### Increase Basal Rate
-If the eventual blood glucose is greater than the correction range and all of the predicted glucose values are above the suspend threshold, then Loop will issue a temporary basal rate that is higher than the current basal rate to bring the eventual blood glucose down to the correction target.
+If the eventual blood glucose is greater than the correction range and all of the predicted glucose values are equal to or above the correction range, then Loop will issue a temporary basal rate that is higher than the current basal rate to bring the eventual blood glucose down to the correction target.
 
 ![increase basal rate example](img/increase.png)
 


### PR DESCRIPTION
Loop increases temp basal rates (or delivers auto boluses) when the entire prediction is at or above the correction range and eventual BG is higher than the correction range. This makes the information consistent with the second RESUME example.