### PR TITLE
Update homebrew instructions

### DIFF
--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -87,6 +87,13 @@ For example, if you see "Invalid active developer path (/Library/Developer/Comma
 
 ## Specific Error Messages
 
+### Error: homebrew-core is a shallow clone.
+
+If you get an error about homebrew-core being a "shallow clone""
+You will need to follow the instructions given in the error, and update your homebrew installation with the following command:
+
+`git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow`
+
 ### Could not locate device support files
 
 If you see an error message that says "Could not locate device support files." That messages is telling you that your iOS on the phone requires you to get a newer version of Xcode to be able to build Loop onto that phone. Update your Xcode version.

--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -20,11 +20,11 @@ Before you start trying to resolve your red errors...start with the most obvious
 
 5. **Did you get a fresh download of Loop code, don't just recycle an old download that you built with a long time ago?** That old version may not be compatible with new iOS and new Xcode versions.
 
-6. **Are you are using a free developer account?** Make sure you finished the [removal of Siri and Push Notification capabilities](https://loopkit.github.io/loopdocs/build/step14/#sign-four-targets). 
+6. **Are you are using a free developer account?** Make sure you finished the [removal of Siri and Push Notification capabilities](https://loopkit.github.io/loopdocs/build/step14/#sign-four-targets).
 
 ## First good step to 95% of all errors
 
-If you have checked all those steps above and think you have a true build error...here's the best starting place that resolves 95% of all build errors. 
+If you have checked all those steps above and think you have a true build error...here's the best starting place that resolves 95% of all build errors.
 
 1. Open your project in Xcode as normal. Then go to the Xcode menu at the top of the screen and find the "Product" menu item. Use the drop down selection for "Clean Build Folder" or press shift-command-K. Either will work the same.
 2. Open the Terminal app on your computer.
@@ -38,7 +38,7 @@ If you have checked all those steps above and think you have a true build error.
 </p>
 6. Return to Xcode and now trying building your app again.
 
-If the build fails again, look through the list below and see if you can match up your error message with one specific error messages listed in the later section of this page. If you really can't find your solution (PLEASE LOOK for it...you need to see the circled bits to know where to look perhaps. There's a section below to help you with finding the error message), then post for help. BUT, use the section below to post. WE CANNOT HELP without that info covered in the section. 
+If the build fails again, look through the list below and see if you can match up your error message with one specific error messages listed in the later section of this page. If you really can't find your solution (PLEASE LOOK for it...you need to see the circled bits to know where to look perhaps. There's a section below to help you with finding the error message), then post for help. BUT, use the section below to post. WE CANNOT HELP without that info covered in the section.
 
 ## Posting for help
 
@@ -48,7 +48,7 @@ Before you post in Zulipchat or Looped Group asking for help with build errors, 
 
 Therefore, first use the error topics (listed in sections below) to try to resolve your build error yourself. Then, if you need to post for help because this page did not fix your problem, you'll need to include information with the post so we (the troubleshooters) know you read this page and where you are in your troubleshooting attempts
 
-!!!danger "Must include in your post" 
+!!!danger "Must include in your post"
     * The version of Xcode you are using
     * The version of Loop you are building with
     * The version of iOS on your Loop iPhone
@@ -61,7 +61,7 @@ Helpful tip: Shift-Command-4-spacebar will give you a screenshot tool that you c
 
 ## Find your error message(s)
 
-To begin fixing the error, use the Report Navigator view to find your error message. 
+To begin fixing the error, use the Report Navigator view to find your error message.
 
 </p>
 <p align="center">
@@ -97,7 +97,7 @@ If you see an error message that says "Could not locate device support files." T
 
 Often people get confused at this point because their App Store may be telling them "no updates available" for Xcode, so they incorrectly assume that they have the most current Xcode.  
 
-Instead, realize that the App Store only shows the updates available for your macOS version. If your macOS version falls behind...then the App Store will not show you Xcode versions that are incompatible with your older macOS. In other words if you are have Mojave macOS, you won't see newer versions of Xcode in the App Store that would require you to have the newer Catalina macOS. 
+Instead, realize that the App Store only shows the updates available for your macOS version. If your macOS version falls behind...then the App Store will not show you Xcode versions that are incompatible with your older macOS. In other words if you are have Mojave macOS, you won't see newer versions of Xcode in the App Store that would require you to have the newer Catalina macOS.
 
 How are the versions all related? Use the figure below to determine your minimum.  
 
@@ -107,7 +107,7 @@ How are the versions all related? Use the figure below to determine your minimum
 <img src="../img/minimum-related.png" width="750">
 </p></br>
 
-If you're using iOS 13.4.x on your iPhone, you'll need Catalina macOS 10.15.x at a minimum to be able to see Xcode 11.4.x in the App Store for download. Therefore, update to Catalina and then update to Xcode 11.4.x to resolve your build error message about "device support logs missing". 
+If you're using iOS 13.4.x on your iPhone, you'll need Catalina macOS 10.15.x at a minimum to be able to see Xcode 11.4.x in the App Store for download. Therefore, update to Catalina and then update to Xcode 11.4.x to resolve your build error message about "device support logs missing".
 
 
 ### No such module 'LoopKit' or similar message
@@ -136,13 +136,13 @@ Error message: This one could be a variety of error messages, so there's not one
 
 Solution: You'll need to uninstall Homebrew and then resinstall. Two simple copy and paste commands in Terminal.
 
-First you need to uninstal using this command in Terminal app:
+First you need to uninstall using this command in Terminal app:
 
-`ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"`
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"`
 
 And then repeat the installation command from step 7 in the build process by using this command in Terminal app:
 
-`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 
 Now try building your Loop app again, you shouldn't have any problems.
 
@@ -285,7 +285,7 @@ Error message: "**<u>Unrecognized arguments: --cache-builds</u>**"
 </p>
 
 
-Solution: Please open your Terminal app found in the Applications>>Utilities folder and then enter `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`  Confirm installation by pressing enter, and then typing in your computer password.  When the installation finishes, use the command `brew link --overwrite carthage`.  After those two steps, you can close out Terminal app, return to Xcode and press the build/play button again.
+Solution: Please open your Terminal app found in the Applications>>Utilities folder and then enter `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`  Confirm installation by pressing enter, and then typing in your computer password.  When the installation finishes, use the command `brew link --overwrite carthage`.  After those two steps, you can close out Terminal app, return to Xcode and press the build/play button again.
 
 
 ### Abort with Payload
@@ -305,10 +305,8 @@ Error: **<u>The Loop app appears on the list of apps available to install on the
 
 Solution:  Plug your iPhone into the computer and start Xcode.  On your watch, look for a prompt that says "Trust this computer".  Scroll down on the watch face and select the "Trust" button.  
 
-Now we need to do one step before rebuilding Loop app again. Go to the top menu bar of Xcode and select "Clean Build Folder" from the Product menu option. Rebuild your Loop app. 
+Now we need to do one step before rebuilding Loop app again. Go to the top menu bar of Xcode and select "Clean Build Folder" from the Product menu option. Rebuild your Loop app.
 
 For an unknown reason (developers are working on fixing it currently), if you do repeated builds in the same Loop project folder...the watch app can fail to install properly after the first build. Therefore, a simple "Clean Build Folder" will reset the folder back to new and you should be able to install the watch after that fresh build.
 
 Sometimes, if the problem is really a bugger...you have to do a more painful troubleshooting. If you still can't get the Loop app to install on the watch after a "Clean Build Folder" attempt at rebuilding, we need to start at square one. Unpair your watch from the iPhone and setup as a brand new device. Yes, pain in the butt. But, usually wiping the watch, re-pairing fresh, and then building Loop again on the phone will fix the issue. Sorry, wish I had a shorter path to fixing that problem, but this is where the current state is. This is a known bug and may take several tries and include wiping devices of content. It is a pain...but we really don't have a magic bullet solution other than keep trying...and starting your devices from scratch is a pain for sure...but also the most likely to get rid of the bug.
-
-

--- a/docs/build/step7.md
+++ b/docs/build/step7.md
@@ -3,7 +3,7 @@
 !!!danger "Time Estimate"
     * 10-15 minutes assuming you know your computer's password
     * 35 minutes if you can't remember your password and have to guess
-    
+
 !!!info "Summary"
     * Install Homebrew by simply copying and pasting a long line of gibberish into the ugly Terminal application.
 
@@ -31,22 +31,22 @@ Ok, now that we have the user account confirmed, let's open the Terminal applica
 
 !!!info "New Apple M1 chip users: IMPORTANT STEP"
     If you purchased one of the new Apple computers that have the brand new Apple M1 chip, you will need to do a little step to start with. Homebrew doesn't run natively on the new M1 chips...so we have to open Terminal app using a little "converter" app, in these situations, called Rosetta. It's no big deal...simply find the Terminal app like was described above and instead of opening it by double clicking...I want you to click on the Terminal app's name just once so it is highlighted. Then right-click on the Terminal app's name to bring up some additional choices. You will want to select the "Get Info" option.</br></br>
-    
+
     <p align="center">
     <img src="../img/get-info.png" width="550">
     </p>
-    
+
     Now in the informational window that appears...you'll see a checkbox that says "Open using Rosetta". Check that box...that will allow Terminal app to open in such a way that we can install Homebrew in the next steps.  You can close that informational window, after you check the box for "Open using Rosetta", and proceed with the rest of the directions just like normal. Thanks!
     <p align="center">
     <img src="../img/rosetta.png" width="350">
     </p>
-    
 
-Now that you've located where the Terminal app is located in the Utilities folder (and already turned on Rosetta check box, if you are an M1 user)...double-click the Terminal app's name so that the app opens. The Terminal app is very plain looking when you open it. That is normal. Copy and paste the line in the little grey box below into Terminal prompt. 
 
-`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
+Now that you've located where the Terminal app is located in the Utilities folder (and already turned on Rosetta check box, if you are an M1 user)...double-click the Terminal app's name so that the app opens. The Terminal app is very plain looking when you open it. That is normal. Copy and paste the line in the little grey box below into Terminal prompt.
 
-Your screen should look like something like this after you copy it in...if it does, then go ahead and press return to continue on with the installation command. 
+ `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+Your screen should look like something like this after you copy it in...if it does, then go ahead and press return to continue on with the installation command.
 
 <p align="center">
 <img src="https://loopkit.github.io/loopdocs/build/img/homebrew-copy-line.png" width="450">
@@ -67,13 +67,6 @@ Wait while the script does its thing...you’ll see info scroll by and then it w
 ## Install Carthage
 
 We are going to finish with one little last installation of something called Carthage. It's a helper that does some of the work during Loop building. Technically, Loop has an automated script that will use Homebrew to install Carthage when you first build Loop.
-
-!!!warning "new M1 chip computer users (aka the new Apples just released in November 2020)"
-    For M1 users, the automatic installation won't work currently (because Homebrew isn't quite updated for the M1 chips). So, we are going to do it manually. You cannot skip this step. You must perform this installation as described below.
-
-
-!!!danger "non-M1 chip computer users (older apple computers)"
-    TECHNICALLY, non-M1 computer users can skip this carthage installation step.  BUT, this step also won't do any harm to do now...so if you want to install carthage, it just saves the automated step later. Totally up to you. 
 
 Now that Homebrew has successfully installed, copy and paste the line in the little grey box below into Terminal prompt (similar to how you did for Homebrew installation line above).
 

--- a/docs/build/step7.md
+++ b/docs/build/step7.md
@@ -64,6 +64,7 @@ Wait while the script does its thing...you’ll see info scroll by and then it w
 </p>
 </br>
 
+
 ## Install Carthage
 
 We are going to finish with one little last installation of something called Carthage. It's a helper that does some of the work during Loop building. Technically, Loop has an automated script that will use Homebrew to install Carthage when you first build Loop.
@@ -81,11 +82,21 @@ You should see something like below when the command has finished running succes
 
 You can close the Terminal application now. You’re done with it. You do not need to do these steps again for any subsequent Loop builds. This is one of those "just do it once" on new computer installations. If you get a new computer though, you will have to repeat this step for the new computer.
 
+!!!info "If you get an error about homebrew-core being a "shallow clone""
+    You will need to follow the instructions given in the error, and update your homebrew installation with the following command:
+
+    `git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow`
+
+    This command can take a long time to run. After it finishes, re-attempt the carthage installation with:
+
+    `brew install carthage`
+
+
 ## Uninstall Homebrew
 
 If you have something go wrong in Homebrew installation, want to delete it and start fresh, the uninstall command is:
 
-`ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"`
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"`
 
 Copy and paste that entire line into Terminal application. Then you can retry the installation of Homebrew using the install command listed earlier in this page.
 

--- a/docs/build/step7.md
+++ b/docs/build/step7.md
@@ -64,6 +64,11 @@ Wait while the script does its thing...you’ll see info scroll by and then it w
 </p>
 </br>
 
+!!!info "If you get an error about homebrew-core being a "shallow clone""
+    You will need to follow the instructions given in the error, and update your homebrew installation with the following command:
+
+    `git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow`
+
 
 ## Install Carthage
 
@@ -81,15 +86,6 @@ You should see something like below when the command has finished running succes
 </br>
 
 You can close the Terminal application now. You’re done with it. You do not need to do these steps again for any subsequent Loop builds. This is one of those "just do it once" on new computer installations. If you get a new computer though, you will have to repeat this step for the new computer.
-
-!!!info "If you get an error about homebrew-core being a "shallow clone""
-    You will need to follow the instructions given in the error, and update your homebrew installation with the following command:
-
-    `git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core" fetch --unshallow`
-
-    This command can take a long time to run. After it finishes, re-attempt the carthage installation with:
-
-    `brew install carthage`
 
 
 ## Uninstall Homebrew


### PR DESCRIPTION
Updates homebrew instructions to use the bash install/uninstall scripts, and adds a note about dealing with the "shallow clone" error.