### PR TITLE
Update update_user.md on ENABLE line (was duplicate "basal")

### DIFF
--- a/docs/nightscout/update_user.md
+++ b/docs/nightscout/update_user.md
@@ -38,8 +38,8 @@ Click on `Reveal Config Vars`.  Scroll down the bottom of the Config Vars lines 
 <tbody>
 <tr>
 <th>ENABLE</th>
-<td>bridge loop pump iob cob basal careportal sage cage basal override dbsize</br></br>
-<b>(Note: If you are an existing NS user, you likely already have an ENABLE line in this section of Heroku. Don't add a new one. Simply find the existing ENABLE line, click on the little pencil icon to the right of it, and add the words shown on the ENABLE line below to the existing words already on the enable line.  Avoid duplicates. The remainder of the lines are likely going to be brand new additions to your Heroku settings.)</b></td>
+<td>bridge loop pump iob cob basal careportal sage cage bage override dbsize</br></br>
+<b>(Note: If you are an existing NS user, you likely already have an ENABLE line in this section of Heroku. Don't add a new one. Simply find the existing ENABLE line, click on the little pencil icon to the right of it, and add the words shown on the ENABLE line above to the existing words already on the enable line.  Avoid duplicates. The remainder of the lines are likely going to be brand new additions to your Heroku settings.)</b></td>
 </tr>
 <tr>
 <th>DEVICESTATUS_ADVANCED</th>


### PR DESCRIPTION
On ENABLE line, entered "bage" as replacement for duplicate word "basal", because (1) ENABLE note says "avoid duplicates", (2) "bage" has that position in the line of words on the "new_user.md" page, that is, following "sage" and "cage". Plus a minor change in ENABLE note to more accurately reference the code "above" rather than "below".