### PR TITLE
Add alt-text, fix mobile icon sizes in displays.md

### DIFF
--- a/docs/build/health.md
+++ b/docs/build/health.md
@@ -1,16 +1,24 @@
 # Health Data
 
-Loop app uses the iPhone's Health app to store blood glucose, insulin, and carbohydrate data. Additional details about how to use Health to interpret your longer-term looping data can be found [here in LoopTips](https://kdisimone.github.io/looptips/data/health/). Health data can also be accessed and uploaded by Tidepool's Mobile app and is an important step in Jaeb Observational Study enrollment. Please review the settings below to ensure you have the proper settings.
+The Loop app uses the iPhone's Health app to store blood glucose, insulin, and carbohydrate data. Health data can also be accessed and uploaded by Tidepool's Mobile app and was an important step in the Jaeb Observational Study enrollment (that study has completed). Please review the settings below to ensure you have the proper settings.
 
 ## Loop Permissions
 
-|    |   |
-|----|---|
-|![img/healthapp.jpg](img/healthapp.jpg){width="100%"} &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;   |   When you first finish building your Loop app, you need to set up Loop's permissions to store data in Health.</br></br>When this screen appears, you should toggle on all of the categories for Loop for both reading and writing, so that the green sliders are showing. If you didn't turn those on, you should go back and set the permissions directly in Health app. </br></br>It is important at this point to also consider other apps which you may have previously given Health permissions to. In particular, **you do not want other apps, like myFitness Pal or Spike app, writing carbohydrate data to Loop**. This can cause Loop to have "doubled" carb entries and you will get incorrect insulin deliveries related to doubled carb entries. You can check your various apps' permissions by clicking on the sources button at the bottom of the Health app. Click on the apps listed as a source, and make sure none of them have permission to write carbohydrates to Health.      |
+You need to set up Loop's permissions to store data in Health. When you finish building your first Loop app, the Health App screen automatically appears (figure below is older iOS version). You should toggle on all of the categories for Loop for both reading and writing, so that the green sliders are showing. Do it now - easiest time.
+
+If you didn't turn those on initially or you need to check the settings, you need to go to the Health app (Red Heart). Directions for finding the right screen depend on iOS, so please google "how do I set Apple Health read/write permissions".  The top link for that search took me to the Apple help page. Select your iOS version to see how to do it on your phone. You need to find the place to set Health Permission for the Loop app inside the Health app.
+
+You may see Sleep as a read option for Loop. Sleep is used to decide which times of day to use the limited daily allocation from Apple for updates to the Loop watch complication.
+
+![Apple Health app, iOS 12, Loop app permissions screen](img/healthapp.jpg){width="300"}
+{align="center"}
+
+It is important at this point to also consider other apps which you may have previously given permission to write to Health. In particular, **you do not want other apps, like myFitness Pal or Spike, writing carbohydrate data to Loop**. This can cause Loop to have "doubled" carb entries and you will get incorrect insulin deliveries related to doubled carb entries. Once again - checking sources depends on iOS.  For iOS 12, you can check your various permissions by clicking on the sources button at the bottom of the Health app. Click on the apps listed as a source, and make sure none of them have permission to write carbohydrates to Health.  For iOS 13 and 14, find Carbohydrates, then scroll to the bottom and tap on Data Sources & Access, then scroll down to Data Sources.  There may be several apps listed that could write to carbohydrates.  You want all of them to say "Inactive" except for Loop. If you need to changes settings for an app, go back to the main health screen (iOS 13/14), Tap on Summary, tap on your profile icon (upper right), look for Apps under Privacy, select the app with permissions that you need to modify.
+
 
 ## Dexcom Permissions
 
-You also need to enable your Dexcom app to write to the Health app. You can find this in your Dexcom app's Settings, under Health.  Click on the `Enable` button and then `Turn All Categories On` so that the toggle for allowing Dexcom to write data is now a green color.
+You also need to enable your Dexcom app to write to the Health app. The steps shown in the figure below are valid for iOS 12. For iOS 13/14, open the Health app, tap on Summary, tap on your profile icon (upper right), look for Apps under Privacy, select your Dexcom app, make sure it has permission to write Blood Glucose.  If you do not do this, you will have a maximum history of 3 hours displayed in the Loop Glucose screen.
 
-![img/health_g5.jpg](img/health_g5.jpg){width="550"}
+![G5 Dexcom app, iOS 12, instructions for enabling Dexcom to write to Health](img/health_g5.jpg){width="550"}
 {align="center"}

--- a/docs/build/step8.md
+++ b/docs/build/step8.md
@@ -33,7 +33,7 @@ If you've done your homework (read this entire page) and are ready to download a
     - This image is old - latest Xcode version is 12.4 (March 17, 2021)
 
 
-![img/xcode.png](img/xcode.png){width="750"}
+![Screenshot: Apple Store search for Xcode](img/xcode.png){width="750"}
 {align="center"}
 
 ## How do all the minimum versions relate to each other?
@@ -81,16 +81,16 @@ The chart below is a helpful map of how to read of the minimum versions you'll n
 * Xcode: Now that your macOS is updated to at least 10.15.4, the App Store in your computer will have Xcode 12.4 (or newer) available for you to download/update.
 
 
-(Source for the chart is [wikipedia](https://en.wikipedia.org/wiki/Xcode). Remember - follow the link and scroll down to the figure to actually check versions - the graphic shown below is a map of how to read the figure at wikipedia.)
+(Source for the chart is [Wikipedia](https://en.wikipedia.org/wiki/Xcode). Remember - follow the link and scroll down to the figure to actually check versions - the graphic shown below is a map of how to read the figure at Wikipedia.)
 
-![img/minimum-related.png](img/minimum-related.png){width="750"}
+![Screenshot: Wikipedia Xcode 11.x-12.x example; relationship for iOS, Xcode, macOS; highlights how to read current graphic](img/minimum-related.png){width="750"}
 {align="center"}
 
 ## What happens if you try using too old of Xcode?
 
 It isn't some catastrophic failure if you try to build with an outdated Xcode without realizing it. If the build fails, nothing happens to your phone (or Loop on your phone if you are rebuilding).  Nothing is copied from the computer to the phone until after you see the Build Succeeded message. You'll see a pretty obvious error message during your Loop build that says "Could not locate device support files." That messages is telling you that your iOS on the phone requires you to get a newer version of Xcode to be able to build Loop onto that phone.
 
-![img/device-support-files.jpg](img/device-support-files.jpg){width="750"}
+![Screenshot: Xcode, error message when Xcode too old for iOS or missing simulators](img/device-support-files.jpg){width="750"}
 {align="center"}
 
 So, if you see that error message, realize you may have to update your macOS to be able to see the newest Xcode version that you will need. Make sure to check that chart to see what your minimum versions are for the iOS you are running on your iPhone.

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -30,7 +30,7 @@ The apps built and signed by you in Xcode with a paid developer account will onl
 
 Under ordinary circumstances, you do not *have to* update your Loop app until you are ready to grab new features. However, we encourage regular updates when a new version is released because they often contain bug fixes or improvements which may increase operational stability. Also, if you have updated your phone iOS since the last build, you should download a new copy of the code.
 
-## Step 1: Verify/Update macOS and Xcode
+## Step 1: Install macOS and Xcode updates
 
 !!! warning "Verify macOS"
 
@@ -58,7 +58,7 @@ If you think you are immune from needing to update and want to skip Step 1 on th
 
 Apple updates its License Agreement for the Developer Program frequently. You need to login to your [developer account](https://developer.apple.com/account/) to manually check if there is a new agreeement to accept.  If you see a big red or orange banner across the top of your Developer Account announcing a new license agreement like shown below...please read and accept it before building Loop.
 
-![img/license.png](img/license.png)
+![Screenshot: Account - Apple Developer](img/license.png)
 
 ## Step 3: Download Updated Loop Code
 
@@ -98,7 +98,7 @@ Older versions of Xcode used to automatically create a new "provisioning profile
 
 You can always check the expiration date immediately after a successful build of your loop app by clicking the little "i" icon next the "Provisioning Profile" line in the target signing area. Add 12 months to the "created" date (paid account), or 7 days (free account), and you'll have your app's date of future spontaneous death, which you can record in your calendar.
 
-![img/provisioning-profile-date.png](img/provisioning-profile-date.png){width="850"}
+![Screenshot: Xcode showing Provisioning Profile](img/provisioning-profile-date.png){width="850"}
 {align="center"}
 
 Here's what started happening about September 2019 with Xcode 11, the provisioning profiles were being reused so the date was not updated each time you built. This change resulted in many people's apps expiring unexpectedly (and therefore dying suddenly) starting in September 2020 despite having updated/rebuilt recently and having current developer accounts (either manually renewed or automatically renewed, doesn't matter).
@@ -115,7 +115,7 @@ Once you follow the steps in the orange box below, Xcode will have no memory of 
     `rm ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision`
     </br></br>You won't see anything special after you enter the command...your Terminal screen should look as boring as shown below when successful.
 
-    ![img/empty-profiles.png](img/empty-profiles.png){width="650"}
+    ![Screenshot: terminal after provisioning profile deletion](img/empty-profiles.png){width="650"}
     {align="center"}
 
 ### Revoke Certificate Issue
@@ -123,7 +123,7 @@ Once you follow the steps in the orange box below, Xcode will have no memory of 
 What does it look like if you run into the force new certificate problem? When you prepare to Sign the Targets with Xcode, you'll see the message highlighted in the figure below.  
 
 <br/>
-![img/rejected-cert.svg](img/rejected-cert.svg){width="850"}
+![Screenshot: Xcode showing Revoke Certificate message](img/rejected-cert.svg){width="850"}
 {align="center"}
 
 More information is shown in the orange box below.
@@ -149,7 +149,7 @@ This may not be necessary, but it is one of the first steps to try if you do get
     2. Copy and paste this command and press return: `rm -rf ~/Library/Developer/Xcode/DerivedData` Note: you won't see any message back if the command runs successfully.
     </br></br>You won't see anything special after you enter the commands...your Terminal screen should look as boring as it did in the previous step 4a.
 
-    ![img/cleaned-terminal.png](img/cleaned-terminal.png){width="650"}
+    ![Screenshot: terminal after clean cache and derived data](img/cleaned-terminal.png){width="650"}
     {align="center"}
 
 ## Step 5: Build like normal

--- a/docs/operation/loop-settings/displays.md
+++ b/docs/operation/loop-settings/displays.md
@@ -6,7 +6,7 @@ This section of the docs will go over the Loop displays available and what infor
 
 The Status Screen is the main root navigation screen in Loop. It is broken up into 3 main display areas; Heads Up Display (HUD), Charts, and Toolbar. The HUD is the top area of the screen. This shows the status of the last time loop ran, current BG Reading, current temp basal, and current pump information. The next area is the charting area. This includes, glucose trend and prediction, Active Insulin, Insulin Delivery, and Carbohydrates. The final display area is the toolbar which has buttons for Carbs, Pre-Meal, Bolus, Overrides, and Settings.
 
-![img/main_screen.jpg](img/main_screen.jpg){width="550"}
+![Loop Primary Display with Heads-Up Display, Charts and Toolbar](img/main_screen.jpg){width="550"}
 {align="center"}
 
 ### Heads Up Display
@@ -15,25 +15,25 @@ The Heads Up Display (HUD) is a very useful quick reference guide to your Loop's
 
 Medtronic users: The last two icons are the most recent (1) pump/reservoir status and (2) pump percentage battery remaining. [Details below](displays.md#reservoir-medtronic-users)
 
-![img/mdt-hud.jpeg](img/mdt-hud.jpeg){width="400"}
+![Heads-Up Display for Medtronic](img/mdt-hud.jpeg){width="400"}
 {align="center"}
 
 Omnipod users: The last two icons are the most recent (1) pod status and (2) hours of pod use. [Details below](displays.md#reservoir-omnipod-users)
 
-![img/pod-hud.jpeg](img/pod-hud.jpeg){width="400"}
+![Heads-Up Display for Omnipod](img/pod-hud.jpeg){width="400"}
 {align="center"}
 
 #### Loop Status
 
 The Loop Status is the colored circle in the upper left corner of the main Loop display.  There are four colors that are typically displayed.
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/grey_loop.jpg](img/grey_loop.jpg){width="250"}|A grey circle indicates the Loop is warming up and hasn’t yet completed its initial loop.  When the Loop is first activated, it may take about 15-20 minutes to complete the first Loop, and the grey circle will be displayed.  It needs CGM data to be gathered, so be patient.  When it finally completes its first loop, the circle will turn green.  If you can't get your grey loop to turn green, please see the [Yellow and Red Loop troubleshooting page](../../troubleshooting/yellow-red-loop.md)  for tips.|
-|![img/green_loop.jpg](img/green_loop.jpg){width="250"}|A green circle indicates the Loop has been successfully completed within the last 5 minutes.  The time since the loop last completed will be displayed under the circle.|
-|![img/yellow_loop.jpg](img/yellow_loop.jpg){width="250"}|A yellow circle indicates the Loop has not completed in the last 5-15 minutes.  It is not unusual to have a few instances of yellow circles throughout a day of looping.  They can be caused by temporarily getting too far away from RileyLink or iPhone (more than about 3-10 feet depending on conditions), CGM failing to read or being in ???, radio frequency “noise” interference, and such.  Generally, most yellow circles will self-resolve without needing any special troubleshooting.|
-|![img/red_loop.jpg](img/red_loop.jpg){width="250"}|A red circle indicates the Loop has not completed in over 15 minutes.  This is not a typical state, and you should troubleshoot why Loop is not completing.  Please review the [Yellow and Red Loop troubleshooting page](../../troubleshooting/yellow-red-loop.md) for tips on how to get your green Loop back.  Clicking on the red circle will also pop-up the last error message to help guide your troubleshooting.|
-|![img/open_loop.jpg](img/open_loop.jpg){width="250"}|When the circle is notched and not complete, that means the Loop is operating in “open-loop” mode.  When the “closed-loop” setting is turned on, the loop status will show a completed circle.|
+|![Closed Grey Circle Icon](img/grey_loop.jpg)|A grey circle indicates the Loop is warming up and hasn’t yet completed its initial loop.  When the Loop is first activated, it may take about 15-20 minutes to complete the first Loop, and the grey circle will be displayed.  It needs CGM data to be gathered, so be patient.  When it finally completes its first loop, the circle will turn green.  If you can't get your grey loop to turn green, please see the [Yellow and Red Loop troubleshooting page](../../troubleshooting/yellow-red-loop.md)  for tips.|
+|![Closed Green Circle Icon](img/green_loop.jpg)|A green circle indicates the Loop has been successfully completed within the last 5 minutes.  The time since the loop last completed will be displayed under the circle.|
+|![Closed Yellow Circle Icon](img/yellow_loop.jpg)|A yellow circle indicates the Loop has not completed in the last 5-15 minutes.  It is not unusual to have a few instances of yellow circles throughout a day of looping.  They can be caused by temporarily getting too far away from RileyLink or iPhone (more than about 3-10 feet depending on conditions), CGM failing to read or being in ???, radio frequency “noise” interference, and such.  Generally, most yellow circles will self-resolve without needing any special troubleshooting.|
+|![Closed Red Circle Icon](img/red_loop.jpg)|A red circle indicates the Loop has not completed in over 15 minutes.  This is not a typical state, and you should troubleshoot why Loop is not completing.  Please review the [Yellow and Red Loop troubleshooting page](../../troubleshooting/yellow-red-loop.md) for tips on how to get your green Loop back.  Clicking on the red circle will also pop-up the last error message to help guide your troubleshooting.|
+|![Green Circle Icon with gap at top denoting open loop](img/open_loop.jpg)|When the circle is notched and not complete, that means the Loop is operating in “open-loop” mode.  When the “closed-loop” setting is turned on, the loop status will show a completed circle.|
 
 !!! info "Fun Fact"
     The loop status icon will pulse slightly when Loop is communicating with the pump.  The pulsing will stop when the communication has completed (green loop) or given up (yellow or red loop).
@@ -41,41 +41,42 @@ The Loop Status is the colored circle in the upper left corner of the main Loop 
 
 #### Glucose
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/cgm.jpg](img/cgm.jpg){width="200"}|The current BG reading from the CGM will display, including trending arrow and time the reading was taken.  If the BG is being read straight from the G5/G6 transmitter or G4 receiver, no special symbols will appear.|
-|![img/cgm_cloud.jpg](img/cgm_cloud.jpg){width="200"}|If the BG is being read from the Dexcom Share Servers, a small cloud icon will be in the corner of the BG reading.  Internet access is required to run in this mode.|
-|![img/cgm_alert.jpg](img/cgm_alert.jpg){width="200"}|When you first start Loop, there may be a small yellow alert next to the BG.  This should go away within a short period of time (around 5 minutes or less).  If the yellow alert remains, something may be wrong with fetching BG data.  You can try restarting the Loop app (double tap home button, up-swipe on the app to close it) to see if BG data will resume. </br></br> **Special note for Dexcom G5/G6 users**>, a yellow alert will appear when calibration is needed.  The alert will clear once the calibration is given, but typically Loop will work IF the yellow alert is only for a needed G5/G6 calibration.|
+|![Blood Glucose Reading](img/cgm.jpg)|The current BG reading from the CGM will display, including trending arrow and time the reading was taken.  If the BG is being read straight from the G5/G6 transmitter or G4 receiver, no special symbols will appear.|
+|![Blood Glucose with Cloud Icon](img/cgm_cloud.jpg)|If the BG is being read from the Dexcom Share Servers, a small cloud icon will be in the corner of the BG reading.  Internet access is required to run in this mode.|
+|![Blood Glucose with Alert Symbol](img/cgm_alert.jpg)|When you first start Loop, there may be a small yellow alert next to the BG.  This should go away within a short period of time (around 5 minutes or less).  If the yellow alert remains, something may be wrong with fetching BG data.  You can try restarting the Loop app (double tap home button, up-swipe on the app to close it) to see if BG data will resume. </br></br> **Special note for Dexcom G5/G6 users**>, a yellow alert will appear when calibration is needed.  The alert will clear once the calibration is given, but typically Loop will work IF the yellow alert is only for a needed G5/G6 calibration.|
 
 #### Temp Basal
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/temp_basal.jpg](img/temp_basal.jpg){width="175"}|The temp basal will display the enacted temp basal change relative to the scheduled basal.  So if the scheduled basal was 1.0 units per hour and Loop has set a temp basal of 0.2 units per hour, the temp basal icon will display -0.8 U, as shown in the graphic to the left.|
+|![Temporary basal delta with respect to scheduled basal](img/temp_basal.jpg)|The temp basal will display the enacted temp basal change relative to the scheduled basal.  So if the scheduled basal was 1.0 units per hour and Loop has set a temp basal of 0.2 units per hour, the temp basal icon will display -0.8 U, as shown in the graphic to the left.|
 
 #### Reservoir (Medtronic Users)
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/red_reservoir.jpg](img/red_reservoir.jpg){width="175"}|The reservoir icon will remain grey and plain until insulin volume decreases.  At 25% reservoir volume remaining, the reservoir icon will turn yellow.  At 10% reservoir volume remaining, the reservoir icon will turn red.  The remaining units will be displayed when it gets to these lower thresholds.|
+|![Medtronic reservoir indicator is red with <10% remaining](img/red_reservoir.jpg)|The reservoir icon will remain grey and plain until insulin volume decreases.  At 25% reservoir volume remaining, the reservoir icon will turn yellow.  At 10% reservoir volume remaining, the reservoir icon will turn red.  The remaining units will be displayed when it gets to these lower thresholds.|
 
 #### Battery (Medtronic Users)
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/battery.jpg](img/battery.jpg){width="200"}|For x54 pumps, the battery icon will show 100/75/50/25% increments just as the pump does.  As the battery level decreases, the icon will turn from grey to yellow to red.  For x22, x23 pumps, the battery icon will read discrete % values.  </br></br>The warning colors/levels on Loop's battery indicator work in conjunction with the type of battery selected.  If you change battery types, please make sure to update your battery selection in the Loop app settings.   </br></br>The pump's on-screen battery indicator is not a good indicator of remaining battery life for the purposes of looping.  Loop's pump communications will fail from low battery levels sooner than the insulin delivery will fail.  The Loop's battery level warnings are designed to give you approximately 8 hours of notice before the pump battery will need changing.|
+|![Medtronic battery indicator is grey showing 100%](img/battery.jpg)|For x54 pumps, the battery icon will show 100/75/50/25% increments just as the pump does.  As the battery level decreases, the icon will turn from grey to yellow to red.  For x22, x23 pumps, the battery icon will read discrete % values.  </br></br>The warning colors/levels on Loop's battery indicator work in conjunction with the type of battery selected.  If you change battery types, please make sure to update your battery selection in the Loop app settings.   </br></br>The pump's on-screen battery indicator is not a good indicator of remaining battery life for the purposes of looping.  Loop's pump communications will fail from low battery levels sooner than the insulin delivery will fail.  The Loop's battery level warnings are designed to give you approximately 8 hours of notice before the pump battery will need changing.|
 
 #### Reservoir (Omnipod Users)
 
-|||
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/pod-reservoir.jpg](img/pod-reservoir.jpg){width="175"}|The pod icon will remain grey and plain until insulin volume decreases.  At 50 units or less insulin remaining, the reservoir icon will turn yellow. At 20 units or less remaining, the reservoir icon will turn red.  The remaining units will be displayed when it gets to these lower thresholds. </br></br>When the reading is 0 units, there may be up to 4 unit of insulin available but don't count on it. If the pod senses insulin can no longer be delivered, the pod will have a sustained audible alarm (the scream). Tapping Replace Pod in Loop->Pod->Settings should silence the alarm.|
+|![Omnipod reservoir indicator is red with <20u remaining](img/pod-reservoir.jpg)|The pod icon will remain grey and plain until insulin volume decreases.  At 50 units or less insulin remaining, the reservoir icon will turn yellow. At 20 units or less remaining, the reservoir icon will turn red.  The remaining units will be displayed when it gets to these lower thresholds. </br></br>When the reading is 0 units, there may be up to 4 unit of insulin available but don't count on it. If the pod senses insulin can no longer be delivered, the pod will have a sustained audible alarm (the scream). Tapping Replace Pod in Loop->Pod->Settings should silence the alarm.|
 
 #### Pod Age (Omnipod Users)
 
-|||
+
+| <div style="width:55px"></div> ||
 |---|---|
-|![img/pod-age.jpg](img/pod-age.jpg){width="250"}|The pod's age, typically a 3-day lifespan, is represented by three equal segments of the pod age icon. As the pod ages, the segments are converted to a darker grey color. At 54 hours old, the pod age icon will turn yellow. At 72 hours old, the pod age icon will turn red, the pod will begin the periodic warning beep, and the pod age icon will show a "replace pod" message in the HUD. </br></br>When you reach 80 hours of pod use, the pod will have a sustained audible alarm (the scream) and stops all insulin delivery. Tapping Replace Pod in Loop->Pod->Settings should silence the alarm.|
+|![Omnipod age icon is yellow showing 2 hours remaining in guaranteed life, 10 hours until shutdown](img/pod-age.jpg)|The pod's age, typically a 3-day lifespan, is represented by three equal segments of the pod age icon. As the pod ages, the segments are converted to a darker grey color. At 54 hours old, the pod age icon will turn yellow. At 72 hours old, the pod age icon will turn red, the pod will begin the periodic warning beep, and the pod age icon will show a "replace pod" message in the HUD. </br></br>When you reach 80 hours of pod use, the pod will have a sustained audible alarm (the scream) and stops all insulin delivery. Tapping Replace Pod in Loop->Pod->Settings should silence the alarm.|
 
 ## Charts
 
@@ -83,7 +84,7 @@ There are several charts that help you navigate your Loop actions.  Clicking on 
 
 ### Glucose Chart
 
-![img/glucose_graph.jpg](img/glucose_graph.jpg){width="400"}
+![Graph of Blood Glucose showing measured points and predicted dashed line](img/glucose_graph.jpg){width="400"}
 {align="center"}
 
 The glucose chart displays BG values in your preferred units. (If not, quit and restart Loop app on your phone.) The vertical scale of the chart is calculated on the fly by Loop to be as useful as possible while including the highest and lowest readings in the chart.
@@ -104,7 +105,7 @@ If you tap on the Glucose Chart itself, it will open the Predicted Glucose chart
 
 The predicted glucose view is a great way to gain insight into the various components’ importance in Loop’s prediction of eventual BG.
 
-![img/glucose_hidden.svg](img/glucose_hidden.svg){width="400"}
+![Tap Graph of Blood Glucose to reveal separate elements of prediction selectable to demonstrate effects](img/glucose_hidden.svg){width="300"}
 {align="center"}
 
 The graph at the top of this view will match your Glucose Chart. Below this chart you will see a very detailed explanation of all of the variables that Loop takes into account in predicting your future BG value. Each of those effects (including Carbohydrates, Insulin, Glucose Momentum and Retrospective Correction) includes details of the calculation used. You can tap on any of the entries to turn them off and on for visualization. The resulting changes can be viewed by the changes in the dashed lines.
@@ -113,16 +114,16 @@ Note - these elements are not turned on and off in the Loop predictions. They ju
 
 ### Active Insulin Chart
 
-![img/active_insulin.jpg](img/active_insulin.jpg){width="400"}
+![Plot of insulin on board (IOB); active amount above or below basal using insulin model](img/active_insulin.jpg){width="400"}
 {align="center"}
 
-The Active Insulin chart displays the total insulin contribution from both temp basals and boluses.  Active IOB can be either positive and negative IOB.  Negative IOB results from the suspension of normally scheduled basals.  The active insulin displayed in the upper right corner of the chart does NOT include insulin contributions from a recently enacted temp basal or bolus until the (for Medtronic) pump’s reservoir volume is read and confirms a drop in reservoir volume (confirming the insulin has actually been delivered). The opposite is true for OmniPods. If a message is sent from Loop, it assumes the pod got the message and enacted it - even if the acknowledgement is not received.  Later, when communication is restored, if a command was not enacted by the pod, the Event History is updated.
+The Active Insulin chart displays the total insulin contribution from both temp basals and boluses.  Active IOB can be either positive and negative IOB.  Negative IOB results from the suspension of normally scheduled basals.  The active insulin displayed in the upper right corner of the chart does NOT include insulin contributions from a recently enacted temp basal or bolus until the (for Medtronic) pump’s reservoir volume is read and confirms a drop in reservoir volume (confirming the insulin has actually been delivered). The opposite is true for Omnipods. If a message is sent from Loop, it assumes the pod got the message and enacted it - even if the acknowledgement is not received.  Later, when communication is restored, if a command was not enacted by the pod, the Event History is updated.
 
 **Medtronic Only**: So long as you have Event History as the Preferred Data Source in Loop settings, primed insulin deliveries (e.g., cannula fills or manual primes) will not be counted towards IOB.
 
 ### Insulin Delivery Chart
 
-![img/insulin_delivery.jpg](img/insulin_delivery.jpg){width="400"}
+![Plot of insulin delivery shown as bolus triangles and relative temp basal settings](img/insulin_delivery.jpg){width="400"}
 {align="center"}
 
 The Insulin Delivery chart displays a history of the temp basals enacted by Loop.  The display is relative to the scheduled basal rates entered in the Loop settings.  So, a rate displayed in this chart as `+0 units` would indicate no temp basal was set, and Loop defaulted to the scheduled basal rate.  Individual boluses are indicated by an orange triangle on the chart (shown in the graphic above, near the left-most time).  The total insulin delivered since midnight, including all basals and boluses **AND (Medtronic Only) priming insulin**, is given in the upper right corner of the graph.
@@ -131,7 +132,7 @@ Please be patient for a bolus delivery to appear.  There is a lag time from when
 
 ### Reservoir and Event History
 
-![img/insulin_hidden.jpg](img/insulin_hidden.jpg){width="500"}
+![Reservoir and event history shown for Medtronic](img/insulin_hidden.jpg){width="500"}
 {align="center"}
 
 Clicking on either the Active Insulin or Insulin Delivery charts will open your Insulin Delivery history.  The top of the screen will display the current IOB and the total insulin delivered for the day since midnight (or since the time the loop became active if you started Loop after midnight). There are two viewing options; Reservoir or Event History.  
@@ -142,19 +143,19 @@ Clicking on either the Active Insulin or Insulin Delivery charts will open your 
 
 ### Carbohydrate Chart
 
-![img/carb_graph.jpg](img/carb_graph.jpg){width="400"}
+![Active carbohydrate chart showing measured rise and fall based on entries and settings](img/carb_graph.jpg){width="400"}
 {align="center"}
 
 The Carbohydrate chart displays the carbs used by Loop to predict BG changes.  The active COB is displayed in the upper right corner of the chart.  Clicking on the chart will open the Carb Entries history and you can edit/delete any previous entries through that screen.  Please read the [Carb Entry page](../features/carbs.md) for more information about editing carb entries.
 
-![img/carb_edit.png](img/carb_edit.png){width="300"}
+![Editable Carbohydrate History with Insulin Counteraction Effects (ICE) graph](img/carb_edit.png){width="300"}
 {align="center"}
 
 For more information about the Insulin Counteraction Effects information found in the Carb History, please see [here](../features/ice.md).
 
 ## Tool Bar
 
-![img/toolbar.png](img/toolbar.png){width="400"}
+![Loop Toolbar showing meal entry, pre-meal, bolus, override and settings icons](img/toolbar.png){width="400"}
 {align="center"}
 
 The toolbar is where your inputs to the Loop behavior take place.  The individual components of the toolbar are, left to right:
@@ -171,6 +172,6 @@ The toolbar is where your inputs to the Loop behavior take place.  The individua
 
 ## Next Step: RileyLink Menu
 
-You are almost there! One more Loop menu that you need to know about is your RileyLink (or other radio-link) Device. You can access your device menu by tapping on the pump/pod image in Loop settings (or HUD), look for the DEVICES section and tap on a "My Device Name" row that has a green slider. If you don't know what that means, check out the Pump Pairing section for Adding a Pump [Medtronic](mdt-pump.md#pump-pairing) or [OmniPod](omnipod-pump.md#select-rileylink).
+You are almost there! One more Loop menu that you need to know about is your RileyLink (or other radio-link) Device. You can access your device menu by tapping on the pump/pod image in Loop settings (or HUD), look for the DEVICES section and tap on a "My Device Name" row that has a green slider. If you don't know what that means, check out the Pump Pairing section for Adding a Pump [Medtronic](mdt-pump.md#pump-pairing) or [Omnipod](omnipod-pump.md#select-rileylink).
 
 Click [here](rileylink.md) to read more about what to expect to see when you tap on "My Device Name".


### PR DESCRIPTION
Used some html in the markdown tables to register image sizes in the icon : text tables for displays.md. This fixed a problem where icons were not visible on mobile screen. (check out current loopdocs on a mobile device)
Added alt-text for images in included *.md files.
Restored an anchor title to pre-PR216 name in updating.md
Pages updated:
* displays.md
* health.md
* step8.md
* updating.md

Pages are deployed at: https://marionbarker.github.io/loopdocs
