### PR TITLE
PR-234: Algorithm Section: Fix Broken Links, Add Menu for Navigation

### DIFF
--- a/docs/operation/algorithm/bolus.md
+++ b/docs/operation/algorithm/bolus.md
@@ -14,3 +14,10 @@ Finally, Loop checks that the result of the calculations is below the maximum si
 !!! info "Bolusing safety feature"
 
     If the current blood glucose, or any predicted blood glucose, falls below the suspend threshold, Loop will not return a recommended bolus. When the minimum blood glucose rises above the suspend threshold, the bolus tool will provide a recommended bolus.
+
+## Algorithm Section Menu
+
+* [Algorithm Overview](overview.md)
+    * [Bolus Recommendations](bolus.md)
+    * [Blood Glucose Prediction](prediction.md)
+    * [Temp Basal Adjustments](temp-basal.md)

--- a/docs/operation/algorithm/overview.md
+++ b/docs/operation/algorithm/overview.md
@@ -1,8 +1,8 @@
-# Overview
+# Algorithm Overview
 
-Loop’s algorithm for adjusting insulin delivery is oriented around making a blood glucose prediction. Every five minutes, triggered by new blood glucose data, it generates a new prediction. Both [bolus recommendations](bolus) and [temporary basal rates](temp_basal) are set based on this prediction.
+Loop’s algorithm for adjusting insulin delivery is oriented around making a blood glucose prediction. Every five minutes, triggered by new blood glucose data, it generates a new prediction. Both [bolus recommendations](bolus.md) and [temporary basal rate adjustments](temp-basal.md) are set based on this [prediction](prediction.md).
 
-## Terminology
+## Algorithm Terminology
 
 This graph and legend illustrates terms commonly used in discussing Loop's algorithm,
 and shows them in the context of historical and forecasted blood glucose in style similar to the
@@ -24,4 +24,11 @@ status screen of Loop.
 |Suspend Threshold|The suspend threshold is a safety feature of the Loop algorithm. If any predicted blood glucose is below this threshold, the Loop algorithm will issue a temporary basal rate of 0|
 |CGM data|Blood glucose readings made by a continuous glucose monitor.|
 |Insulin sensitivity factor|A configuration value that provides an estimate of how much blood glucose will drop given a unit of insulin.|
-|Active insulin|Active insulin is the remaining amount of insulin activity from boluses and temporary basal rates relative to a user’s scheduled basal rates. More specifically, it is the total amount of insulin activity due to all bolus and basal insulin delivered within the last N hours, where N is determined by the insulin activity duration. The amount of “active” insulin depends upon the insulin activity curve, and also accounts for the insulin withheld via basal suspensions. As such, it is possible that the active insulin can be negative. Negative active insulin will result in an increase in predicted blood glucose. The active insulin displayed in Loop's main display does not reflect the currently enacted temporary basal rate, as that basal rate may be canceled or modified before completion over the next 30 minutes. In others words, Loop doesn't count chickens before the eggs hatch...insulin delivery must be confirmed before being added to the active insulin reporting.|
+|Active insulin|Active insulin, often referred to as Insulin-on-Board (IOB), is the remaining amount of insulin activity from boluses and temporary basal rates relative to a user’s scheduled basal rates. More specifically, it is the total amount of insulin activity due to all bolus and basal insulin delivered within the last N hours, where N is determined by the insulin activity duration. The amount of “active” insulin depends upon the insulin activity curve, and also accounts for the insulin withheld via basal suspensions. As such, it is possible that the active insulin can be negative. Negative active insulin will result in an increase in predicted blood glucose. The active insulin displayed in Loop's main display does not reflect the currently enacted temporary basal rate, as that basal rate may be canceled or modified before completion over the next 30 minutes. In others words, Loop doesn't count chickens before the eggs hatch...insulin delivery must be confirmed before being added to the active insulin reporting.|
+
+## Algorithm Section Menu
+
+* [Algorithm Overview](overview.md)
+    * [Bolus Recommendations](bolus.md)
+    * [Blood Glucose Prediction](prediction.md)
+    * [Temp Basal Adjustments](temp-basal.md)

--- a/docs/operation/algorithm/prediction.md
+++ b/docs/operation/algorithm/prediction.md
@@ -249,3 +249,10 @@ Lastly, the forecast or predicted blood glucose BG at time *t* is the current bl
 Each individual effect along with the combined effects are illustrated in the figure below. As shown, blood glucose is trending slightly upwards at the time of the prediction. Therefore, the blood glucose momentum effect’s contribution is pulling up the overall prediction from the other three effects for a short time. Retrospective correction is having a dampening effect on the prediction, indicating that the recent rise in blood glucose was not as great as had been previously predicted in the recent past.
 
 ![combined effects curve](img/combined_effects.png)
+
+## Algorithm Section Menu
+
+* [Algorithm Overview](overview.md)
+    * [Bolus Recommendations](bolus.md)
+    * [Blood Glucose Prediction](prediction.md)
+    * [Temp Basal Adjustments](temp-basal.md)

--- a/docs/operation/algorithm/temp-basal.md
+++ b/docs/operation/algorithm/temp-basal.md
@@ -1,10 +1,14 @@
-# Basal Adjustments
+# Temp Basal Adjustments
 
 The Loop algorithm takes one of four actions depending upon the eventual blood glucose, predicted glucose, and suspend threshold. Note that all temporary basal rate commands are issued for 30 minutes, however they may be updated (re-issued) every 5 minutes. Said another way, Loop may enact a new temporary basal rate every 5 minutes. But, if communication with the pump is lost, the last issued temporary basal rate will last for at most 30 minutes before the pump reverts to the user’s scheduled basal rates. Note: If a user is operating Loop in open-loop mode, the Loop will only recommend basal dosing actions and will not automatically enact those recommendations.
 
 ## Four Possible Actions
 
-Loop implements one of four possible basal actions: **decrease**, **increase**, **suspend**, or **resume** a scheduled basal rate.
+Loop implements one of four possible temporary basal actions: **decrease**, **increase**, **suspend**, or **resume** a scheduled basal rate.
+
+!!! danger "Note:"
+
+    If you are using an Automatic-Bolus Dosing Strategy in closed Loop mode and Loop predicts you need an **increase** in insulin; this **increase** is provided as a percentage of the recommended bolus instead of an increased temporary basal. The default percentage is 40%.
 
 ### Decrease Basal Rate
 
@@ -97,3 +101,10 @@ Next, calculate the required basal rate:
 ![example rbr](img/rbr_example.png)
 
 Lastly, compare the required basal rate to the maximum temporary basal rate, and find that Loop will enact a temporary basal rate of 5 U/hr for 30 minutes since this temporary basal rate is below the maximum temporary basal rate of 6 U/hr, which was set by the user in Loop app settings.
+
+## Algorithm Section Menu
+
+* [Algorithm Overview](overview.md)
+    * [Bolus Recommendations](bolus.md)
+    * [Blood Glucose Prediction](prediction.md)
+    * [Temp Basal Adjustments](temp-basal.md)


### PR DESCRIPTION
Fix Issue 234: Dead link / 404
* https://github.com/LoopKit/loopdocs/issues/234

Operation Algorithm section
* Fix links in overview.md
* Add a navigation menu at bottom of each algorithm page
* Tweak Menu Titles and Page Titles to be consistent
* Add mention of Automatic-Bolus Dosing Strategy to Temp Basal page

Pages updated:
* docs/operation/algorithm/bolus.md
* docs/operation/algorithm/overview.md
* docs/operation/algorithm/prediction.md
* docs/operation/algorithm/temp-basal.md

Note:
* updates still needed for prediction page (Issue 176)
* not included in this modification
