### PR TITLE
Correct a statement, Turn on automatic publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
 name: publish
 
-# Controls when the action will run. 
-on: 
- workflow_dispatch
-  # Triggers the workflow on push events but only for the main branch
-  #push:
-  #  branches: [ master ]
+# Controls when the action will run.
+on:
+  # Remark: uncomment one section only
+  # Remark: Next 1 line requires manual action, Click on action tab, then publish
+  # workflow_dispatch
+  # Remark: Next 2 lines triggers the workflow on push events but only for the main branch
+  push:
+    branches: [ master ]
 
 jobs:
   deploy:
@@ -17,7 +19,7 @@ jobs:
           python-version: 3.x
       - run: pip install -r requirements.txt
       - run: mkdocs build
-              
+
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           BRANCH: gh-pages

--- a/docs/faqs/branch-faqs.md
+++ b/docs/faqs/branch-faqs.md
@@ -43,7 +43,7 @@ A fix has been made and is available as Loop v2.2.6. This is now the new master,
 
 This is a serious issue, so updating to this release is strongly recommended for anyone currently running v2.2.5. If you tap on Loop Settings and look at the top, and see LOOP V2.2.5, then rebuild ASAP. The time window when you would have built v2.2.5 is from Aug 22 through Sep 6, 2021.
 
-The issue appears to be the result of a failure to write to Apple HealthKit, which may occur if the Health app on your phone is having problems, or if you have turned off Loop's ability to write Insulin data to HealthKit. The fix involves reverting a change made in v2.2.5.  This change was an attempt to reduce overlaps of Reservoir and Pump Event reconciliation, which would over estimate insulin delivery with Medtronic pumps. Instead, that issue will be fixed in the next major release of Loop.
+The issue appears to be the result of a failure to write to Apple HealthKit, which may occur if the Health app on your phone is having problems, or if you have turned off Loop's ability to write Insulin data to HealthKit. The fix involves reverting a change made in v2.2.5.  This change was an attempt to reduce overlaps of Reservoir and Pump Event reconciliation which intermittently over estimate insulin delivery. Instead, that issue will be fixed in the next major release of Loop.
 
 Thanks to all who helped with reporting, digging, and testing this quickly. It's great to have such a strong community of people eager to help.
 


### PR DESCRIPTION
Previously, we have been using the publish.yml to manually publish the pages from github. Convert this to automatic deployment.

Update the branch-faqs.md comment about the double-counting of insulin - it can happen to any type of pump, not just Medtronic.