### PR TITLE
Add Header to Assist Search for Loop is No Longer Available

### DIFF
--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -26,11 +26,15 @@
 
 ## When to Update Loop
 
-The apps built and signed by you in Xcode with a paid developer account will only last for 12 months before they expire and need rebuilding. So, at least once per year you will have to rebuild your app and go through this update process.
+Under ordinary circumstances, you do not *have to* update your Loop app until you are ready to grab new features. However, we encourage regular updates when a new version is released because they often contain bug fixes or improvements which may increase operational stability. Also, if you have updated your phone iOS since the last build, you should download a new copy of the code and you might also need to update the Mac operating system and the version of Xcode to support that phone iOS.
 
-Under ordinary circumstances, you do not *have to* update your Loop app until you are ready to grab new features. However, we encourage regular updates when a new version is released because they often contain bug fixes or improvements which may increase operational stability. Also, if you have updated your phone iOS since the last build, you should download a new copy of the code.
+Refer to [Loop Releases](../faqs/branch-faqs.md#loop-releases) for information about current and previous Loop versions.
 
-The Loop Developers strongly encourage you to update to Loop v2.2.6 (released Sep 6, 2021) as soon as possible. Please check out [Branch FAQs for v2.2.6](../faqs/branch-faqs.md#loop-v226)
+The apps built and signed by you in Xcode with a paid developer account will only last for 12 months before they expire and need rebuilding. So, at least once per year you will have to rebuild your app and go through this update process. If you do not update and the "provisioning profile" on your phone expires, you will see this message:
+
+### "Loop" is No Longer Available
+
+When you see "Loop" is No Longer Available on your phone, the only solution is to rebuild the app.  All of your settings are still present on your phone, but your "provisioning profile" expired and you need to generate a new one. Once you build Loop on your phone, following the instructions on this page, all your settings will be maintained - assuming you build with the same [Apple Developers ID](../faqs/FAQs.md#what-happens-when-i-switch-apple-developer-id) that was used initially.
 
 ## Step 1: Install macOS and Xcode updates
 
@@ -114,6 +118,8 @@ Once you follow the steps in the orange box below, Xcode will have no memory of 
 
     `rm ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision`
     </br></br>You won't see anything special after you enter the command...your Terminal screen should look as boring as shown below when successful.
+
+    Note - you are deleting provisioning profiles on your computer to force Xcode to generate new ones with your next build.  This does not affect the provisioning profiles currently on your phone.
 
     ![Screenshot: terminal after provisioning profile deletion](img/empty-profiles.png){width="650"}
     {align="center"}

--- a/docs/faqs/FAQs.md
+++ b/docs/faqs/FAQs.md
@@ -89,7 +89,9 @@ No. Loop will have the option to move between different pump types from within t
 
 If there is more than one Looper in the family, you only need to have one Apple Developer ID and only one annual payment. The adult who builds can use their Apple Dev ID to put the app on the Looper's phone.  The limit is 99 devices (phone and watch both count).  Unless it's a very large family, you should have no problem supporting everyone in your family. Building Loop on the second phone is much faster than the first one. It's a good idea to let someone else in the family know how to build and have access to your Apple password in case you're out of town. It's also a good idea to build Loop on a backup phone especially for travel. The Apple Developer ID and the Apple ID are two different things. PLEASE read this: [Loopers Need Their Own Apple ID](../../build/step6/#loopers-need-their-own-apple-id).
 
-If you are helping a Looper in your local diabetes group get an update on their phone, make sure you can text each other. They need to realize the Loop app on the phone is different if the build uses a different Apple Developer ID from the one currently on their phone. So they will have to on-board the new app, enter all the settings again and delete the old app. Because of the limit on the number of devices per Developer ID, be sure to limit the number of people you help.
+## What happens when I switch Apple Developer ID?
+
+The Loop app on the phone is different if the build uses a different Apple Developer ID from the one currently on the phone. So if the Apple Developer ID used for a new Loop build is different from the one used for the existing Loop app, there will be two Loop apps on the phone.  The Looper will have to on-board the new app, enter all the settings again and delete the old app. 
 
 ## Can I use someone else's Apple Developer account?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ There are a number of social media options. (Read the directions on each of thes
 ### Search Then Post
 
 !!! danger ""
-    It's really easy to panic if Loop is not working for you, but take the time to do a quick search in your favorite social media group before posting a question. You might get an answer immediately.
+    It's really easy to panic if Loop is not working for you, but take the time to do a quick search in these docs and in your favorite social media group before posting a question. You might get an answer immediately.
 
     Please post your question in only one group on Facebook or under one stream on zulipchat - many mentors monitor more than one place. If you don't hear an answer in 24 hours, then try a different place
 

--- a/docs/operation/features/notifications.md
+++ b/docs/operation/features/notifications.md
@@ -25,7 +25,7 @@ If you want to see the expiration date at any time, tap on Settings, then tap on
 ![Issue report displays Loop App expiration date](img/loop-app-expiration-issue-report.jpeg){width="250"}
 {align="center"}
 
-If you are running Loop v2.2.4 or older, you might be surprised by a ["Loop App Unavailable"](../../troubleshooting/loop-crashing.md#expired-app) display when the app reaches its expiration date.  
+If you are running Loop v2.2.4 or older, you might be surprised by a ["Loop" is No Longer Available](../../troubleshooting/loop-crashing.md#expired-app) display when the app reaches its expiration date.  
 
 * Workaround is to add a notice to your calendar when you build the app initially so you know that the one year app lifetime is nearing the end
 * This is still a good idea even with automated notifications to set your own desired alert window


### PR DESCRIPTION
When searching LoopDocs for phrase displayed when provisioning profile expires, there was no result.

* build/updating.md:
  * Add the phrase "Loop" is No Longer Available as a header
  * Rearrange wording slightly
  * Add clarification about profiles on computer vs phone

* FAQS.md:
  * Add header "What happens when I switch Apple Developer ID?"
  * Revise wording of existing paragraph

* notifications.md:
  * Make message match the (english) version of what is shown on the phone

* index.md:
  * Add search in docs in Search then Post section