### PR TITLE
update build-select script address

### DIFF
--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -61,8 +61,11 @@ These instructions show each step needed to build Loop using the Build-Select sc
 There is a copy button located by hovering on the right-hand side of a labeled block of text below.  Click on it, all the words in the block are copied into your paste buffer, and then you can paste those words into the terminal. Then read the instructions and follow them.
 
 ```title="Copy and Paste to start the Build-Select script"
-/bin/bash -c "$(curl -fsSL https://git.io/JImiE)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh)"
 ```
+
+!!! note ""
+    If you've built using the build-select script before and think the command looks a little different, you are correct.  Copy and paste the command as shown.  This uses a more explicit path to the script.
 
 ![paste the script line into terminal](img/build-select-01.png){width="750"}
 {align="center"}

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -122,8 +122,11 @@ There is a copy button located by hovering on the right-hand side of the text bl
 This starts the script, but you will need to read the messages and answer the questions.
 
 ``` title="Run the Build-Select script to Clean Profiles & Derived Data"
-/bin/bash -c "$(curl -fsSL https://git.io/JImiE)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh)"
 ```
+
+!!! note ""
+    If you've used the build-select script before and think the command looks a little different, you are correct.  Copy and paste the command as shown.  This uses a more explicit path to the script.
 
 The expected script responses are shown in the list and graphics below.  Each graphic shows the number you are instructed to type to proceed - the words on this page also tell you what to type.  
 


### PR DESCRIPTION
In response to github announcement that they are removing the use of shortcuts on April 29, 2022, modify the Build-Select script address for pages Build/Step 14 and Buld/Updating.