### PR TITLE
Update for Medtronic Region Code

### DIFF
--- a/docs/loop-3/loop-3-overview.md
+++ b/docs/loop-3/loop-3-overview.md
@@ -1,4 +1,4 @@
-# Overview
+# Loop 3 Overview
 
 
 Loop 3.0 will be the next big release. It is being developed and tested under the dev branch (Loop-dev). Loop-dev has significant improvements and looks different (in some ways) from the Loop 2.2.x versions.

--- a/docs/operation/loop-settings/mdt-pump.md
+++ b/docs/operation/loop-settings/mdt-pump.md
@@ -37,7 +37,8 @@ Let’s start by clicking on the Loop Settings button in the tool bar at the bot
 Continue with these steps to connect your Medtronic pump to Loop.  
 
 1. Make sure your RileyLink is turned on and nearby, then you will see a RileyLink listed in this area of the settings.  Actually, you will see a list of any RileyLinks that are in the nearby area. Slide on the toggle for just one RileyLink.
-2. Add your pump's region, color, and serial number.
+2. Add your pump's region, color, and serial number. 
+    * Note that some Canadian pumps use `CM` instead of `CA` for the region code.  Just select `CA` in the dropdown menu.
 3. Click the `Continue` button to finish the addition of your pump.
 <br/><br/>
 


### PR DESCRIPTION
Primary purpose of this PR is to add note about using CA in region dropdown menu for pumps labeled CM.
Also updated a title on a the Loop 3 Overview page.