### PR TITLE
Add anchor links for xcode warning sections

### DIFF
--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -82,14 +82,20 @@ Next you are asked which version of Loop you would like to build. Type 1 and hit
 ![choose which Loop to build](img/build-select-06.png){width="750"}
 {align="center"}
 
-!!! warning "If you see errors like these . . ."
+#### XCode Errors with Build-Select
+
+!!! warning "WARNINGS"
+
+    If you see errors like these . . .
 
     * `xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun`
     * `xcode-select: Failed to locate 'git', requesting installation of command line developer tools`
     * `xcode-select: error: tool 'xed' requires Xcode`
-    * You missed one of these steps:
-        * [Build Step 8: Install Xcode](step8.md)
-        * [Build Step 9: Xcode command line tools](step9.md)
+
+    You missed one of these steps:
+
+    * [Build Step 8: Install Xcode](step8.md)
+    * [Build Step 9: Xcode command line tools](step9.md)
 
 
 This download can take from 3 minutes to 30 minutes depending on your download speed.  You can leave the room and return later to check on progress. You do not need to understand the definitions for enumeration or submodule or cloning.  You only need to review the display to look for any errors after the download is finished. The download starts out with the enumeration of all the submodules that will be downloaded. This is followed by a cloning step for each submodule. The cloning for the first module is included in the first graphic.

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -72,7 +72,9 @@ Now that you have updated your macOS, you should have the ability to see the mos
 
 If you are finding installation of Xcode from the App Store incredibly slow, try the alternate method of [Direct Download of Xcode](#direct-download-of-xcode). Note that once you have used direct download, Xcode will not show up in the App Store for download or updates - read the information at the link. If you find those instructions confusing, perhaps you should set up the download/update from the App Store a day early and let your computer work in the background.
 
-!!! warning "Missing Xcode or Command Line Tools"
+#### Missing Xcode or Command Line Tools
+
+!!! warning "WARNING"
 
     If you fail to have [Xcode](step8.md) or [Xcode Command Line Tools](step9.md) installed, you will get one of these error when you attempt to run the build-select script (or something similar):
 


### PR DESCRIPTION
Add anchor links for xcode warning sections to make it easier for mentors to reference.
* Build / Step 14
* Build / Updating