### PR TITLE
Add tooltips to LoopDocs

### DIFF
--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,15 @@
+*[HTML]: Hyper Text Markup Language
+*[W3C]: World Wide Web Consortium
+*[URL]: Uniform Resource Locator
+*[API_SECRET]: password needed to access Nightscout Site
+*[modal]: message appearing in app that must be acknowledged
+*[dynos]: used to reboot a Nightscout Site
+*[Config Vars]: configuration parameters for a Nightscout Site
+*[Monterey]: operating system for Mac, macOS 12.x
+*[Xcode]: program used to build an app
+*[Terminal]: interface for entering commands to the computer
+*[Workspace]: a grouping of several programs into a complete package
+*[git]: a tool for version control
+*[repository]: contains project files and each file's revision history
+*[pull request]: formal request to modify a project
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
         - search.suggest
         - search.highlight
         - content.code.annotate
+        - content.tooltips
     logo: loop-logo.png
     favicon: loop-logo.png
 
@@ -23,12 +24,15 @@ extra_css:
 
 markdown_extensions:
     - meta
+    - abbr
     - admonition
     - attr_list
     - pymdownx.highlight
     - pymdownx.inlinehilite
     - pymdownx.superfences
-    - pymdownx.snippets
+    - pymdownx.snippets:
+        auto_append:
+            - includes/abbreviations.md
     - toc:
         permalink: true
         permalink_title: Anchor link to this Header on this Page


### PR DESCRIPTION
The mkdocs.yml file was updated to support tooltips and auto append includes/abbreviations.md
A few items were added to the abbreviations.md file to ensure this works as expected.
