### PR TITLE
Add dark/light/automatic mode options

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,26 @@ theme:
         - content.tooltips
     logo: loop-logo.png
     favicon: loop-logo.png
+    palette:
+        # Palette toggle for automatic mode
+        - media: "(prefers-color-scheme)"
+          toggle:
+            icon: material/brightness-auto
+            name: Switch to light mode
+
+        # Palette toggle for light mode
+        - media: "(prefers-color-scheme: light)"
+          scheme: default 
+          toggle:
+            icon: material/brightness-7
+            name: Switch to dark mode
+
+        # Palette toggle for dark mode
+        - media: "(prefers-color-scheme: dark)"
+          scheme: slate
+          toggle:
+            icon: material/brightness-4
+            name: Switch to system preference
 
 # repo_url: https://github.com/LoopKit/Loop
 


### PR DESCRIPTION
Update mkdoc.yml to add an icon (upper right of toolbar) to select Light, Dark or Automatic theme for website.