### PR TITLE
Remove carthage from build instructions

### DIFF
--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -50,7 +50,7 @@ In you haven't built in a while, but have been using Loop for a long time:
     Everyone else - head to Step 14 to [Build the Loop App](step14.md).
 
     * Be sure to clone into a new directory that does not already have a folder called LoopWorkspace in it.
-    * Loop-dev is the only workspace build that still requires carthage and it requires a specific version - don't worry - instructions are provided below
+    * As of June 24, 2022, a fresh download (or pull) of Loop-dev no longer requires carthage
 
 Yes - this section is "out-of-place", but the Step 14 Build Loop App page is already very long and complicated. If you can build Loop-dev, you can find this section.
 
@@ -62,22 +62,18 @@ Please read [What's going on in the dev branch?](../faqs/branch-faqs.md#whats-go
 
 - Note, the dev branch requires a minimum of iOS 14 on your device
 - Once you install the dev branch on a device, you must delete the app to return to master, which means all settings will need to be entered in master and a new pod started
-- The dev branch user interface is different, i.e., the documentation in LoopDocs does not always match the screens you will see when you use the Loop app built from the dev branch
-- Please read the [Loop dev Preview](../faqs/dev-menus.md) page
+- The dev branch Loop user interface is updated - as an experienced Looper - you will notice the difference
+- Updated documentation is a work-in-progress located under the [Loop 3](../loop-3/loop-3-overview.md) tab of LoopDocs
 
-### Carthage and Downloading
-
-The dev branch requires installation of carthage 0.36.0 on your Mac.
-
-* [Check carthage Status](#check-carthage-status) to ensure you have carthage 0.36.0 installed
+### Downloading
 
 * Review the instructions here: [LoopWorkspace README](https://github.com/LoopKit/LoopWorkspace#readme) 
 
 * Use finder to create a new folder, typically in Downloads
     - Navigate to Downloads
-    - Hold down the control key and click on the folder to open a menu
+    - Best practice - create a new folder called Loop-dev_YYMMDD where you replace YYMMDD with today's date.
+    - Hold down the control key and click on that folder to open a menu
     - Select (near the bottom) New Terminal at Folder
-    - You can choose to use an existing folder, but it cannot already have a folder in it called LoopWorkspace
 
 * Copy and paste the lines below into that terminal window
 
@@ -129,14 +125,14 @@ Note - if you know your Personal Team ID, you can enter it as directed in [Signi
     * **Watch App Extension Target:** Siri
 1. Add the keyword `SIRI_DISABLED` to the LoopConfigOverride.xcconfig file
     * Examine the file and find the line that starts with `SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited)`
-    * Insert the new keyword (separated by a space) any where after `$(inherited)` and before the slashes near the end of the line
+    * Insert the new keyword (separated by a space) anywhere after `$(inherited)` and before the slashes near the end of the line
 
 
 ### Build Loop-dev
 
 * There are some package dependencies (new for Loop-dev) that are resolved first and then the indexing takes place
 * If you notice a red x in Xcode (indicating an error) while it is resolving packages and indexing - please follow the steps for [Couldn't Get Revision for Package Dependency](build_errors.md#couldnt-get-revision-for-package-dependency)
-* Once the packages are resolved and the indexing has started, you can build the app following the directions in the "Build Loop" section on the next page: [Step 14: Build Loop App #Build Loop](step14.md#build-loop).
+* Once the packages are resolved and the indexing has started, you can build the app following the directions in the "Build Loop" section on the next page: [Step 14: Build Loop App: Build Loop](step14.md#build-loop).
 
 We suggest reading the tips below on keeping Loop-dev updated. Checking for updates every week is a good idea.  Also - subscribe to all the streams on [Loop Zulipchat](https://loop.zulipchat.com) to make sure you don't miss critical information.
 
@@ -151,7 +147,7 @@ While Loop-dev is under active test, you will want to update frequently.
 
 ### Check carthage Status
 
-The steps required to install the correct version of carthage depend on whether carthage is already installed.
+You no longer need carthage, and can uninstall it from your system if you don't use it for any other reason (most people do not need carthage installed)
 
 First copy and paste this phrase into the terminal and hit return:
 
@@ -159,11 +155,13 @@ First copy and paste this phrase into the terminal and hit return:
 carthage version
 ```
 
-* If the response includes "0.36.0", you can build the Loop-dev branch. Ignore the instructions to "Please update to the latest Carthage version: . . ." You want to stick with 0.36.0.
+* If the response gives you a version number, then carthage is installed - you can uninstall it if you choose
 
-* If the response is, "-bash: carthage: command not found", then skip ahead to the [Install carthage 0.36.0 step](#install-carthage-0360).
+* If the response is, "-bash: carthage: command not found", you are done - it is no longer needed to build Loop-dev
 
-* Any other response requires you to delete the current version of carthage first.
+### Remove carthage
+
+If carthage is on your system, you can choose to remove it.
 
 Copy and paste the following line into the terminal window and hit return.  
 
@@ -178,14 +176,3 @@ sudo rm -rf /Library/Frameworks/CarthageKit.framework
 ```
 
 You will be prompted for a password when you hit enter on the second line.   It is the same password you use in order to log into the computer.   It will not echo to the screen.
-
-
-### Install carthage 0.36.0
-
-Go to this link: [Carthage.pkg](https://github.com/Carthage/Carthage/releases/tag/0.36.0) to download the carthage 0.36.0 package. After following the preceding link, ignore the warning message, scroll down to the Assets section and click on Carthage.pkg to start the download.
-
-Once the download has completed, you need to take extra steps to install it - **do not double click to open it**.
-
-Go to the Finder app, click on Downloads, locate Carthage.pkg. Hold down the Control Key on the keyboard and single click on Carthage.pkg. This will bring up a menu of choices, select Open from the menu and then Open (greyed out) again from the pop up box.  Then run through the install process.  You will need to enter your password. **The password is your computer's password.** Once installation completes, you can discard the Carthage.pkg when prompted.
-
-If you need more help with this, this external link to the [Loop and Learn website](https://www.loopandlearn.org/carthage-0-36-0/#carthage-install) has some graphics to assist in this step.

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -148,7 +148,7 @@ While Loop-dev is under active test, you will want to update frequently.
 * Some are comfortable with the command line git commands described on [here](loopworkspace.md#updating-loop-using-loopworkspace).
 
 
-#### Check carthage Status
+### Remove carthage
 
 You no longer need carthage, and can uninstall it from your system if you don't use it for any other reason (most people do not need carthage installed)
 
@@ -160,9 +160,7 @@ carthage version
 
 * If the response gives you a version number, then carthage is installed - you can uninstall it if you choose
 
-* If the response indicate, "carthage: command not found", you are done - it is no longer needed to build Loop-dev
-
-### Remove carthage
+* If the response indicates, "carthage: command not found", you are done - it is no longer needed to build Loop-dev
 
 If carthage is on your system, you can choose to remove it.
 

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -43,29 +43,31 @@ In you haven't built in a while, but have been using Loop for a long time:
 
 ## Advanced Users Only
 
-!!! abstract "Advanced Users Reminders"
+!!! abstract "About this Section"
 
-    If you are an advanced user who wants to build the dev branch - this section is for you.
+    If you are an advanced user who wants to build the development branch - this section is for you.
 
-    Everyone else - head to Step 14 to [Build the Loop App](step14.md).
+    Everyone else - head to Step 14 to [Build](step14.md) the released version of the Loop App.
 
-    * Be sure to clone into a new directory that does not already have a folder called LoopWorkspace in it.
+!!! warning "Important"
+
+    * When you clone a fresh copy, you must use a directory that does not already have a folder called LoopWorkspace in it.
     * As of June 24, 2022, a fresh download (or pull) of Loop-dev no longer requires carthage
 
 Yes - this section is "out-of-place", but the Step 14 Build Loop App page is already very long and complicated. If you can build Loop-dev, you can find this section.
 
 **Only build the dev branch if you're a developer/experienced user**
 
-### Before Downloading
+### About Loop-dev
 
 Please read [What's going on in the dev branch?](../faqs/branch-faqs.md#whats-going-on-in-the-dev-branch) before deciding to test the dev branch.
 
 - Note, the dev branch requires a minimum of iOS 14 on your device
-- Once you install the dev branch on a device, you must delete the app to return to master, which means all settings will need to be entered in master and a new pod started
-- The dev branch Loop user interface is updated - as an experienced Looper - you will notice the difference
+- Once you install the dev branch on a device, you must delete the app to return to master (the released version), which means all settings will need to be entered in master and a new pod started
+- The dev branch Loop user interface is updated - as an experienced Looper, you will notice the difference
 - Updated documentation is a work-in-progress located under the [Loop 3](../loop-3/loop-3-overview.md) tab of LoopDocs
 
-### Downloading
+### Downloading Loop-dev
 
 * Review the instructions here: [LoopWorkspace README](https://github.com/LoopKit/LoopWorkspace#readme) 
 
@@ -76,6 +78,7 @@ Please read [What's going on in the dev branch?](../faqs/branch-faqs.md#whats-go
     - Select (near the bottom) New Terminal at Folder
 
 * Copy and paste the lines below into that terminal window
+* There cannot already be a folder called LoopWorkspace at this location - see best practice in list above
 
 ```
 git clone --branch=dev --recurse-submodules https://github.com/LoopKit/LoopWorkspace
@@ -85,7 +88,7 @@ xed .
 
 These three lines will download the code and open Xcode. Be sure to select LoopWorkspace and your phone.
 
-### Signing Targets
+### Signing Loop-dev
 
 If you choose to sign manually instead of using the new capability (next paragraph), you must sign 6 targets (add these 2 to the usual 4)
 
@@ -145,7 +148,7 @@ While Loop-dev is under active test, you will want to update frequently.
 * Some are comfortable with the command line git commands described on [here](loopworkspace.md#updating-loop-using-loopworkspace).
 
 
-### Check carthage Status
+#### Check carthage Status
 
 You no longer need carthage, and can uninstall it from your system if you don't use it for any other reason (most people do not need carthage installed)
 
@@ -157,7 +160,7 @@ carthage version
 
 * If the response gives you a version number, then carthage is installed - you can uninstall it if you choose
 
-* If the response is, "-bash: carthage: command not found", you are done - it is no longer needed to build Loop-dev
+* If the response indicate, "carthage: command not found", you are done - it is no longer needed to build Loop-dev
 
 ### Remove carthage
 

--- a/docs/faqs/dev-menus.md
+++ b/docs/faqs/dev-menus.md
@@ -1,8 +1,0 @@
-# Loop dev Preview
-
-Loop users are directed to select a released version of Loop to download during the build process. The next version of Loop is developed under the dev branch and, when ready for testing, the developers ask for volunteers to assist in testing the new code. Please read [What's going on in the dev branch?](branch-faqs.md#whats-going-on-in-the-dev-branch) before deciding to test the dev branch. If you decide to build the dev branch, instructions are found the [Advanced Users Only](../build/step13.md#advanced-users-only) section of Build Step 13.
-
-The Loop dev branch is in a state where there is active testing going on by experienced Loopers.  To assist those Loopers, preliminary documentation has been prepared and is provided in a new tab called [Loop 3](../loop-3/loop-3-overview.md).  This is because, when released, Loop-dev will be released as Loop 3.0. 
-
-With Loop dev branch, the app screens have an updated appearance and organization.  People familiar with the layout of features in Loop v2.2.x may need to reorient slightly to find particular settings; but for the most part, the layout will be natural to experienced Loop users.
-

--- a/includes/tooltip-list.txt
+++ b/includes/tooltip-list.txt
@@ -4,7 +4,7 @@
 *[BLE]: Bluetooth low energy, used for communication by phones, CGM and some pumps
 *[branch]: version of code within a single repository or workspace repository
 *[CAGE]: cannula (or pump site) age on Nightscout site
-*[carthage]: a method to connect several repositories, currently used only by Loop-dev
+*[carthage]: a program that used to be required to build Loop - no longer needed
 *[Catalina]: older version for operating system for Mac, macOS 10.x
 *[Certificate]: Apple certificate is used to sign your iOS or Mac apps - tied to but different from your permanent Developer ID
 *[CGM]: continuous glucose monitor, wearable medical device that measures and reports glucose in interstitial fluid

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,7 +147,6 @@ nav:
     - 'Omnipod FAQs': 'faqs/omnipod-faqs.md'
     - 'Loop Releases': 'faqs/release-faqs.md'
     - 'Loop Development': 'faqs/branch-faqs.md'
-    - 'Loop dev Preview': 'faqs/dev-menus.md'
     - 'Update/Rebuild Loop FAQs': 'faqs/update-faqs.md'
     - 'RileyLink FAQs': 'faqs/rileylink-faqs.md'
     - 'Algorithm FAQs': 'faqs/algorithm-faqs.md'


### PR DESCRIPTION
Modify docs now carthage is not needed
Update links to point to Loop 3 tab
Remove dev preview faqs page

Updated files:
```
M       docs/build/step13.md
D       docs/faqs/dev-menus.md
M       includes/tooltip-list.txt
M       mkdocs.yml
```