### PR TITLE
Fix broken link, shorten build overview

### DIFF
--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -51,7 +51,7 @@ If the build fails again, look through the list below and see if you can match y
 
 STOP!!  Read this section! Important!
 
-Before you post in a [Loop Social Media](../index.md#stay-in-the-loop) site asking for help with build errors, do your work first. The build errors listed below (and the checks listed above) will fix most of problems you may encounter. ***PLEASE READ THIS PAGE***. The volunteers answering questions online would love to spend more time helping people use Loop and less time answering questions that can be addressed by using this page.
+Before you post in a [Loop Social Media](../index.md#finding-help) site asking for help with build errors, do your work first. The build errors listed below (and the checks listed above) will fix most of problems you may encounter. ***PLEASE READ THIS PAGE***. The volunteers answering questions online would love to spend more time helping people use Loop and less time answering questions that can be addressed by using this page.
 
 Therefore, try to resolve your build error yourself. Then, if you need to post for help, please include enough information with the post so the volunteers know where you are in your troubleshooting attempts.
 

--- a/docs/build/overview.md
+++ b/docs/build/overview.md
@@ -1,53 +1,46 @@
 # Overview of Build Process
 
-The overall build process is straightforward if you follow the step-by-step instructions.
+The build process is straightforward if you follow the step-by-step instructions.
 
-The steps in the Build menu will help you through the following tasks:
+!!! info "The Build Steps show how to:"
 
-* Check that you have or can obtain the compatible gear needed to Loop
-* Prepare your computer
-* Download the Loop code to your computer
-* Build the Loop app on your phone
+    * Check that you have a phone, pump and CGM that works with Loop
+    * Tell you about the RileyLink compatible device and how to get one
+    * Prepare your computer
+    * Download the Loop code to your computer
+    * Build the Loop app on your phone
 
-After the build, be sure to follow steps to [Set up](../operation/overview.md) and [Operate](../operation/features/carbs.md) the Loop app
+After the build, follow steps to [Set up](../operation/overview.md) and [Operate](../operation/features/carbs.md) the Loop app
 
-This may appear intimidating at first, but it is quite doable by the average computer user.
-
-To orient yourself, consider clicking through the Build Steps from Step 1 through Step 14 and read just the top three boxes on each page. If you're on a desktop, use `n` for next and `p` for previous.
+We recommend you start by clicking through the Build Steps from 1 through 14 and read the top three boxes on each page. On a desktop, you can use `n` for next and `p` for previous.
 
 !!! info "Time Estimate"
 !!! abstract "Summary"
 !!! question "FAQs"
 
-Once you've completed this quick overview of the build steps, return and read the pages completely for Steps 1 through 14. It's good idea to skim [Oh dear! Build errors?](build_errors.md) at this point. The most important take-away from that page is that most of the mistakes have already been made and there are correction steps to follow to get your build back on track. If that doesn't help, there are [mentors](../index.md#stay-in-the-loop) ready and willing to assist.
+And yes - we do know how to count, but step 7 is no longer required and we didn't want to rename the pages.
 
-The next stage is to work through the steps and complete the tasks on each page.  You can do one a day or blaze through them all.  Just be sure to read carefully and if you are confused - reach out for help.
+Next, read the pages completely for Steps 1 through 14 and skim [Oh dear! Build errors?](build_errors.md). Most of the mistakes you can make when building have already been made. The Build Errors page shows how to fix them. If those steps do not help, there are [mentors](../index.md#finding-help) ready and willing to assist.
 
-Yes - if you were paying attention, the suggestion is to go from this page through Build Steps 1 through 14 three times:
+When you are ready to proceed, complete the tasks on each page.  You can do one a day, take a week per step or blaze through them quickly.  Just be sure to read carefully and if you are confused - reach out for help.
 
-1. Read just the highlights (top three boxes)
-1. Skim each page
-1. Do the work
+!!! example "Take it one step at a time..."
+
+    If you have limited time, you can stop at one of the steps and come back later. The end of each step is a nice stopping point but you can stop at any time and return later.
+
+To summarize:
+
+1. Read just the highlights (top three boxes) for Steps 1 - 14
+1. Read each page for Steps 1 - 14 and skim Build Errors
+1. Complete the tasks on each page
 
 ## Introduction to Loop Video
 
 If you have never used Loop, click on links below for an introduction.
 
-!!! warning "Classic Video"
-    * This "classic" Katie DiSimone video [Introduction to Loop Video](https://youtu.be/qw_u1lqboCs) was created before the Omnipod version of Loop was released in April 2019 - so yes you can definitely use Omnipod Eros pumps
-    * The menus have been rearranged slightly but the overall concept of how to use Loop is demonstrated in this video
-    * The workout target shown in the video has been completely reworked as Overrides
-
-!!! success "New Video"
-    * This newer [What is Loop](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the Loop and Learn Team
+!!! success "Loop Video"
+    * This [What is Loop](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the Loop and Learn Team
     * Special thanks to Tina and Reese Hammer for the terrific video
     * Special thanks to Matthew Fouse for the generous use of his beautiful graphics
 
-!!! example "Take it one step at a time..."
 
-    If you are worried about how long this will take, you can always stop at one of the steps and come back later. The steps are meant to be nice stopping points to take breaks if needed.
-
-
-## First Step: Compatible Computer
-
-Now you are ready to start the [Build Steps](step1.md).

--- a/docs/build/step12.md
+++ b/docs/build/step12.md
@@ -1,7 +1,7 @@
 # Step 12: Meet the Community
 
 !!! info "Time Estimate"
-    - Read about your [Social Media Options](../index.md#stay-in-the-loop): 5 minutes
+    - Read about your [Social Media Options](../index.md#finding-help): 5 minutes
     - Join one or more groups: 10 minutes
 
 !!! abstract "Summary"
@@ -15,7 +15,7 @@
 
 ## Online Groups
 
-There's a whole wonderful community of people already Looping who are willing to help you through the process. This link on [Social Media Options](../index.md#stay-in-the-loop) walks you through those groups and how to join.
+There's a whole wonderful community of people already Looping who are willing to help you through the process. This link on [Social Media Options](../index.md#finding-help) walks you through those groups and how to join.
 
 The Loop help found at these sites is provided by volunteers. None of the people are paid to answer questions or spend time troubleshooting. They do it because they want to help others. Please decrease their support burden by doing some simple steps before turning to others for help. Please click the image below to watch this video full of tips to make the most of your online resources.
 

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -18,7 +18,7 @@
     - **What do I do if there is a major release (by Apple) of new iOS?** The short answer is wait a bit:
         * It's a good idea to be prepared to rebuild before updating your phone to the new iOS
         * This is even more important when there has been a major change to iOS or Xcode
-        * Check with the experts - there will be announcements in all the [Loop Social Media](../index.md#stay-in-the-loop) sites
+        * Check with the experts - there will be announcements in all the [Loop Social Media](../index.md#finding-help) sites
     - **How often to I have to rebuild?**
         1. You must build when your app expires (one year paid, one week free)
         1. It is recommended you rebuild more frequently to avoid panic when your app is about to expire as explained in [Updating FAQs](../faqs/update-faqs.md)

--- a/docs/build/step2.md
+++ b/docs/build/step2.md
@@ -106,7 +106,7 @@ We recommend that updates be installed as soon as the All-Clear is given, becaus
 - Google the instructions for your device if you cannot figure it out
     1. Please configure your phone to automatically download the updates
     1. You should choose to perform the installation of the updates manually
-- Check on your favorite [Loop Social Media](../index.md#stay-in-the-loop) site to see if a newly released iOS is causing an issue with Loop or your CGM before accepting the update from Apple
+- Check on your favorite [Loop Social Media](../index.md#finding-help) site to see if a newly released iOS is causing an issue with Loop or your CGM before accepting the update from Apple
 - The "All-Clear" or "WAIT there's a problem" is normally posted within a few days
 
 Apple released iOS 15.4 on March 14, 2022.

--- a/docs/build/step4.md
+++ b/docs/build/step4.md
@@ -13,7 +13,7 @@
 
 !!! question "FAQs"
 
-    - **"What about Libre sensors?"** You will need to seek out a modified version of Loop (search posts and then ask about "forks" that support your CGM in a [Loop Social Media](../index.md#stay-in-the-loop) site.)
+    - **"What about Libre sensors?"** You will need to seek out a modified version of Loop (search posts and then ask about "forks" that support your CGM in a [Loop Social Media](../index.md#finding-help) site.)
     - **"What about Eversense?"** Eversense's application does not integrate with Apple Health nor has the communications protocols for Eversense been reverse engineered for iOS. Therefore, Eversense is not currently compatible with Loop.
 
 ## Continuous Glucose Monitor (CGM)
@@ -55,7 +55,7 @@ Loop is capable of downloading Dexcom Share data for use in modeling BG. However
 
 ## CGMs Not Natively Supported in Loop
 
-There are other CGM, such as Libre (with BluCon or Miao Miao), Eversense and Medtronic Guardian sensors. Loop does not natively support those CGMs.  If you would like to use one of those alternate CGMs and Loop, you will need to look into third-party integrations to allow Loop to access the blood glucose data. First search for previous posts on the topic and then ask questions in a [Loop Social Media](../index.md#stay-in-the-loop) site. Currently, there are no solutions for Eversense or Guardian CGM to be used with Loop, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/) to Nightscout are available using an Android phone.
+There are other CGM, such as Libre (with BluCon or Miao Miao), Eversense and Medtronic Guardian sensors. Loop does not natively support those CGMs.  If you would like to use one of those alternate CGMs and Loop, you will need to look into third-party integrations to allow Loop to access the blood glucose data. First search for previous posts on the topic and then ask questions in a [Loop Social Media](../index.md#finding-help) site. Currently, there are no solutions for Eversense or Guardian CGM to be used with Loop, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/) to Nightscout are available using an Android phone.
 
 ## Next Step: Order a RileyLink Compatible Device
 

--- a/docs/faqs/release-faqs.md
+++ b/docs/faqs/release-faqs.md
@@ -109,7 +109,7 @@ Dexcom Non-US Share:
 
 * Dexcom Share URL for non-US users has been fixed.
 
-For community support, please use one of the [Loop Social Media](../index.md#stay-in-the-loop) help sites.
+For community support, please use one of the [Loop Social Media](../index.md#finding-help) help sites.
 
 
 ### Loop v2.2.4

--- a/docs/operation/features/bolus.md
+++ b/docs/operation/features/bolus.md
@@ -55,4 +55,4 @@ If an "uncertain" delivery is not resolved:
 * With Omnipod, you can execute a [Read Pod Status](../loop-settings/pump-commands.md#read-pod-status) to ensure communication with the pod is working
 * [Quit the Loop app](https://support.apple.com/en-us/HT201330) and restart it. (Note - this is different from a power cycle of the phone which remembers settings within an app which was running before the power cycle.)
 
-If that does not resolve the issue, please tap on Loop Settings, Issue Report and email it to yourself. Then [post](../../index.md#stay-in-the-loop) on Facebook or Zulipchat, explain what happened and say you have an Issue Report. Someone should reach out to you.
+If that does not resolve the issue, please tap on Loop Settings, Issue Report and email it to yourself. Then [post](../../index.md#finding-help) on Facebook or Zulipchat, explain what happened and say you have an Issue Report. Someone should reach out to you.

--- a/docs/operation/loop-settings/pump-commands.md
+++ b/docs/operation/loop-settings/pump-commands.md
@@ -157,7 +157,7 @@ This command requests the Pod emit a beep pattern. If you hear it, you know the 
 
 #### Read Pulse Log
 
-This command reads the pulse log (diagnostic), displays it on the screen and saves the result in the log file. It takes some time, so keep your gear close until command completes. This can be extracted by sending the pulse log to yourself using the send-to icon at the top right of the screen.  It is also included in the Issue Report. If you are having communication issues, you can provide this report to an expert who may be able to provide assistance. [Post](../../index.md#stay-in-the-loop) for help in either zulipchat or a Facebook group to request assistance and you'll get information about how to get that log file submitted.
+This command reads the pulse log (diagnostic), displays it on the screen and saves the result in the log file. It takes some time, so keep your gear close until command completes. This can be extracted by sending the pulse log to yourself using the send-to icon at the top right of the screen.  It is also included in the Issue Report. If you are having communication issues, you can provide this report to an expert who may be able to provide assistance. [Post](../../index.md#finding-help) for help in either zulipchat or a Facebook group to request assistance and you'll get information about how to get that log file submitted.
 
 #### Test Command
 

--- a/docs/troubleshooting/loop-crashing.md
+++ b/docs/troubleshooting/loop-crashing.md
@@ -42,4 +42,4 @@ Remember that switching from free to paid changes the developer name incorporate
 
 ## Other reasons
 
-If you experience a crash for any other reason, please gather all the information you can about what was happening before the crash and report it to your favorite [Loop Social Media](../index.md#stay-in-the-loop) help site - you will need to get some personalized help. Please - choose one site for your post and wait for someone to get back to you.  While you are waiting, search on any of the sites and, if on Facebook, read all the announcements.
+If you experience a crash for any other reason, please gather all the information you can about what was happening before the crash and report it to your favorite [Loop Social Media](../index.md#finding-help) help site - you will need to get some personalized help. Please - choose one site for your post and wait for someone to get back to you.  While you are waiting, search on any of the sites and, if on Facebook, read all the announcements.

--- a/docs/troubleshooting/yellow-red-loop.md
+++ b/docs/troubleshooting/yellow-red-loop.md
@@ -108,7 +108,7 @@ In July 2019, we started to see a new style of Dexcom G6 transmitters on the mar
 
 Make sure both the Loop app and the Dexcom app have permission to write to Apple Health by checking the [Apple Health Permissions](../build/health.md)
 
-In the early days of iOS 14, there were problems with the Apple HealthKit.  The consequence is that some people's database was corrupted.  If you tap on the Heart Icon on your phone to go to Apple Health and display data and it is very slow to respond - or never responds, you probably need to get rid of a corrupted database and start fresh.  Be sure to go Open Loop if this is needed. Please get help from your favorite [Loop Social Media](../index.md#stay-in-the-loop) group or from Apple support in this case.
+In the early days of iOS 14, there were problems with the Apple HealthKit.  The consequence is that some people's database was corrupted.  If you tap on the Heart Icon on your phone to go to Apple Health and display data and it is very slow to respond - or never responds, you probably need to get rid of a corrupted database and start fresh.  Be sure to go Open Loop if this is needed. Please get help from your favorite [Loop Social Media](../index.md#finding-help) group or from Apple support in this case.
 
 ### Background App Refresh
 


### PR DESCRIPTION
I was working on shortening the Build overview page when I discovered a broken link.
The old header name was Stay in the Loop and that was changed to Finding Help.
