### PR TITLE
Add variable required for remote installations

### DIFF
--- a/docs/nightscout/remote-overrides.md
+++ b/docs/nightscout/remote-overrides.md
@@ -78,6 +78,7 @@ Scroll down the bottom of the Config Vars lines until you find the last blank on
 |LOOP_APNS_KEY|enter ENTIRE contents of the downloaded .p8 file including the BEGIN and END lines. Here's where you can use the `command-a` and `command-c` to hightlight and copy all the text in that file so you can paste it into Heroku here for this new variable you are creating. ![img/apns-copy-key2.png](img/apns-copy-key2.png)|
 |LOOP_APNS_KEY_ID|string of characters on the .p8 download file immediately following the underscore (  _  ) and not including the file extension ( .p8 ), or you can get it from your saved key in your developer account as shown next step, too ![img/apns-open2.png](img/apns-open2.png)
 |LOOP_DEVELOPER_TEAM_ID|get this value from Loop app signing or in your developer account's top right corner under your name ![img/apns-vars.png](img/apns-vars.png)|
+|LOOP_PUSH_SERVER_ENVIRONMENT| (optional) Set this to production if you installed Loop remotely such as with TestFlight, Diawi, AppCenter, or an IPA. If you built directly to your phone in XCode with your phone plugged into to your computer, do not include this variable.|
 
 When executed properly, you should have something that looks like this for your three new variables that you added:
 


### PR DESCRIPTION
Added LOOP_PUSH_SERVER_ENVIRONMENT to list of config vars, which is required for remote overrides to work if you installed Loop remotely.