### PR TITLE
Update Home page and Intro pages:

### DIFF
--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -51,7 +51,7 @@ If the build fails again, look through the list below and see if you can match y
 
 STOP!!  Read this section! Important!
 
-Before you post in a [Loop Social Media](../index.md#finding-help) site asking for help with build errors, do your work first. The build errors listed below (and the checks listed above) will fix most of problems you may encounter. ***PLEASE READ THIS PAGE***. The volunteers answering questions online would love to spend more time helping people use Loop and less time answering questions that can be addressed by using this page.
+Before you post in a [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) site asking for help with build errors, do your work first. The build errors listed below (and the checks listed above) will fix most of problems you may encounter. ***PLEASE READ THIS PAGE***. The volunteers answering questions online would love to spend more time helping people use Loop and less time answering questions that can be addressed by using this page.
 
 Therefore, try to resolve your build error yourself. Then, if you need to post for help, please include enough information with the post so the volunteers know where you are in your troubleshooting attempts.
 

--- a/docs/build/code_customization.md
+++ b/docs/build/code_customization.md
@@ -304,7 +304,7 @@ abs(accumulatedRotation)
 
 ### Loop 3 Digital Crown Adjustments
 
-These are new instructions and the user should take care - and please [report back](../index.md#finding-help) if you have problems.
+These are new instructions and the user should take care - and please [report back](../intro/loopdocs-how-to.md#how-to-find-help) if you have problems.
 
 First - try it with no customization. Then make small changes.
 

--- a/docs/build/overview.md
+++ b/docs/build/overview.md
@@ -12,6 +12,20 @@ The build process is straightforward if you follow the step-by-step instructions
 
 After the build, keep following along in the docs as you [Set up](../operation/overview.md) and [Operate](../operation/loop/open-loop.md) the Loop app.
 
+## What do I need to Loop?
+
+Loop has both hardware and software requirements. In general, to use Loop you need to have seven components.
+
+1. [Computer](../build/step1.md#macos) (Mac preferred)
+1. [Compatible iPhone/iPod Touch](../build/step2.md)
+1. Compatible insulin pump: [Medtronic or Omnipod](../build/step3.md)
+1. [Compatible CGM](../build/step4.md)
+1. [RileyLink Compatible Device](../build/step5.md) (not needed for Omnipod DASH)
+1. [Apple Developer Membership](../build/step6.md) (not needed if you rebuild weekly)
+1. [Xcode (a free Apple application)](../build/step8.md)
+
+If building to a [Simulator](../version/simulator.md) first to try things out, the only requirements are a computer and Xcode.
+
 ## Getting Ready to Build
 
 We recommend you start by clicking through the Build Steps from 1 through 14 and read the top three boxes on each page. On a desktop, you can use `n` for next and `p` for previous.
@@ -24,7 +38,7 @@ And yes - we do know how to count, but step 7 is no longer required and we didn'
 
 Next, read the pages completely for Steps 1 through 14 and skim [Oh dear! Build errors?](build_errors.md). Most of the mistakes you can make when building have already been made. The Build Errors page shows how to fix them. You don't need to understand this page - just know that it exists.
 
-When you are ready to proceed, complete the tasks on each page.  You can do one a day, take a week per step or blaze through them quickly.  Just be sure to read carefully and if you are confused - reach out for help: [Finding Help](../index.md#finding-help).
+When you are ready to proceed, complete the tasks on each page.  You can do one a day, take a week per step or blaze through them quickly.  Just be sure to read carefully and if you are confused - reach out for help: [Finding Help](../intro/loopdocs-how-to.md#how-to-find-help).
 
 !!! example "Take it one step at a time..."
 
@@ -42,4 +56,4 @@ Try to:
 
 * Scroll back in the directions and see if you missed a paragraph or step.
 * Compare your screen's display with the graphics in the step. Is something different or does yours have an error message? If you have an error message, does it guide you to the problem and solution?
-* If you are still stumped - reach out for help: [Finding Help](../index.md#finding-help).
+* If you are still stumped - reach out for help: [Finding Help](../intro/loopdocs-how-to.md#how-to-find-help).

--- a/docs/build/step12.md
+++ b/docs/build/step12.md
@@ -1,7 +1,7 @@
 # Step 12: Meet the Community
 
 !!! info "Time Estimate"
-    - Read about your [Social Media Options](../index.md#finding-help): 5 minutes
+    - Read about your [Social Media Options](../intro/loopdocs-how-to.md#how-to-find-help): 5 minutes
     - Join one or more groups: 10 minutes
 
 !!! abstract "Summary"
@@ -15,7 +15,7 @@
 
 ## Online Groups
 
-There's a whole wonderful community of people already Looping who are willing to help you through the process. This link on [Social Media Options](../index.md#finding-help) walks you through those groups and how to join.
+There's a whole wonderful community of people already Looping who are willing to help you through the process. This link on [Social Media Options](../intro/loopdocs-how-to.md#how-to-find-help) walks you through those groups and how to join.
 
 The Loop help found at these sites is provided by volunteers. None of the people are paid to answer questions or spend time troubleshooting. They do it because they want to help others. Please decrease their support burden by doing some simple steps before turning to others for help. Please click the image below to watch this video full of tips to make the most of your online resources.
 

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -18,7 +18,7 @@
     - **What do I do if there is a major release (by Apple) of new iOS?** The short answer is wait a bit:
         * It's a good idea to be prepared to rebuild before updating your phone to the new iOS
         * This is even more important when there has been a major change to iOS or Xcode
-        * Check with the experts - there will be announcements in all the [Loop Social Media](../index.md#finding-help) sites
+        * Check with the experts - there will be announcements in all the [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) sites
     - **How often to I have to rebuild?**
         1. You must build when your app expires (one year paid, one week free)
         1. It is recommended you rebuild more frequently to avoid panic when your app is about to expire as explained in [Updating FAQs](../faqs/update-faqs.md)

--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -111,7 +111,7 @@ The final terminal messages of a successful download are shown in the next graph
 ![the end of LoopWorkspace download](img/build-select-08.png){width="750"}
 {align="center"}
 
-If an error appears in your terminal window, read the error and tap any key other than 1, followed by return to cancel. Try to fix the error and run the script one more time. Still not working? Reach out for help at your favorite [Loop Social Media](../index.md#finding-help) site.
+If an error appears in your terminal window, read the error and tap any key other than 1, followed by return to cancel. Try to fix the error and run the script one more time. Still not working? Reach out for help at your favorite [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) site.
 
 ### Download was Successful
 

--- a/docs/build/step2.md
+++ b/docs/build/step2.md
@@ -106,7 +106,7 @@ We recommend that updates be installed as soon as the All-Clear is given, becaus
 - Google the instructions for your device if you cannot figure it out
     1. Please configure your phone to automatically download the updates
     1. You should choose to perform the installation of the updates manually
-- Check on your favorite [Loop Social Media](../index.md#finding-help) site to see if a newly released iOS is causing an issue with Loop or your CGM before accepting the update from Apple
+- Check on your favorite [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) site to see if a newly released iOS is causing an issue with Loop or your CGM before accepting the update from Apple
 - The "All-Clear" or "WAIT there's a problem" is normally posted within a few days
 
 Apple released iOS 15.4 on March 14, 2022.

--- a/docs/build/step4.md
+++ b/docs/build/step4.md
@@ -13,7 +13,7 @@
 
 !!! question "FAQs"
 
-    - **"What about Libre sensors?"** You will need to seek out a modified version of Loop (search posts and then ask about "forks" that support your CGM in a [Loop Social Media](../index.md#finding-help) site.)
+    - **"What about Libre sensors?"** You will need to seek out a modified version of Loop (search posts and then ask about "forks" that support your CGM in a [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) site.)
     - **"What about Eversense?"** Eversense's application does not integrate with Apple Health nor has the communications protocols for Eversense been reverse engineered for iOS. Therefore, Eversense is not currently compatible with Loop.
 
 ## Continuous Glucose Monitor (CGM)
@@ -34,7 +34,7 @@ Dexcom G5 and G6 CGM data is transmitted directly to the Dexcom app on your iPho
 
 !!! warning "Loop 3.0 will not support G4"
 
-    The plan is the next version of Loop (currently under test in the dev branch.) will drop support of G4 because it is so far out of date. If this is a problem for current Loop users, please post on your favorite [social media site](../index.md#finding-help).
+    The plan is the next version of Loop (currently under test in the dev branch.) will drop support of G4 because it is so far out of date. If this is a problem for current Loop users, please post on your favorite [social media site](../intro/loopdocs-how-to.md#how-to-find-help).
 
 The Dexcom G4 Share system transmits CGM data from the transmitter to a Dexcom G4 Share Receiver. The receiver, in turn, connects to the Dexcom Share2 app on your iPhone via Bluetooth. The Share2 app uploads CGM data to the Dexcom servers from your phone. For Loop to function without an internet connection, you will need the Dexcom app running on the same device as Loop.
 
@@ -55,7 +55,7 @@ Loop is capable of downloading Dexcom Share data for use in modeling BG. However
 
 ## CGMs Not Natively Supported in Loop
 
-There are other CGM, such as Libre (with BluCon or Miao Miao), Eversense and Medtronic Guardian sensors. Loop does not natively support those CGMs.  If you would like to use one of those alternate CGMs and Loop, you will need to look into third-party integrations to allow Loop to access the blood glucose data. First search for previous posts on the topic and then ask questions in a [Loop Social Media](../index.md#finding-help) site. Currently, there are no solutions for Eversense or Guardian CGM to be used with Loop, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/) to Nightscout are available using an Android phone.
+There are other CGM, such as Libre (with BluCon or Miao Miao), Eversense and Medtronic Guardian sensors. Loop does not natively support those CGMs.  If you would like to use one of those alternate CGMs and Loop, you will need to look into third-party integrations to allow Loop to access the blood glucose data. First search for previous posts on the topic and then ask questions in a [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) site. Currently, there are no solutions for Eversense or Guardian CGM to be used with Loop, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/) to Nightscout are available using an Android phone.
 
 ## Next Step: Order a RileyLink Compatible Device
 

--- a/docs/faqs/algorithm-faqs.md
+++ b/docs/faqs/algorithm-faqs.md
@@ -89,7 +89,7 @@ You may also notice that the Dexcom numbers get smoothed out. For example, the D
 
 In Loop 2.2.x, if you set Apple Health app permissions to allow it, Loop will read carbohydrates from the Health app. If you give a third-party app permission to store carbohydrate data in Health, and do not realize that Loop reads that information, you might get unexpected insulin delivery based off those carbs. To avoid that unanticipated behavior, the directions tell you to set permissions to allow Loop to write to carbohydrate storage but not read.
 
-In Loop 3, the option to read from Health carbohydrates is explicitly disabled and can only be enabled by setting up special parameters when you build the app. The insructions for the code customization are not in LoopDocs yet. If it is important to you to use a third-party app to record carbohydrates and have Loop read the information and automatically dose with insulin, [ask for help in zulipchat](../index.md#finding-help).
+In Loop 3, the option to read from Health carbohydrates is explicitly disabled and can only be enabled by setting up special parameters when you build the app. The insructions for the code customization are not in LoopDocs yet. If it is important to you to use a third-party app to record carbohydrates and have Loop read the information and automatically dose with insulin, [ask for help in zulipchat](../intro/loopdocs-how-to.md#how-to-find-help).
 
 ### Insulin and Apple HealthKit
 

--- a/docs/faqs/release-faqs.md
+++ b/docs/faqs/release-faqs.md
@@ -109,7 +109,7 @@ Dexcom Non-US Share:
 
 * Dexcom Share URL for non-US users has been fixed.
 
-For community support, please use one of the [Loop Social Media](../index.md#finding-help) help sites.
+For community support, please use one of the [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) help sites.
 
 
 ### Loop v2.2.4

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ This site takes you step-by-step through the process to build, set up and operat
 
 Loop requires a substantial time commitment.  You need to learn the information on this site and follow the steps carefully. Consider doing this over a period of time and reviewing the materials more than once.
 
-You will need to test and perhaps adjust your settings to be successful with Loop, or any hybrid closed-loop system. In addition to the documentation found on this site, you can find assistance in a support forum: [Finding Help](#finding-help).
+You will need to test and perhaps adjust your settings to be successful with Loop, or any hybrid closed-loop system. In addition to the documentation found on this site, you will find links as you read to a robust support community.
 
 Once you are enjoying all the benefits of Loop, you should regularly follow one or more support forums for important updates on Loop. Spending this time is important for success in building and operating Loop safely.
 
@@ -27,8 +27,6 @@ After building the Loop app:
 * You enter the carbs you eat
 * Loop uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
 * You can choose to have Loop automatically control insulin dosing (closed-loop mode) or have Loop recommend insulin that you can accept or modify (open-loop mode)
-    * Loop requires a [compatible continuous glucose monitor (CGM)](build/step4.md) and a [compatible pump](build/step3.md) for closed-loop operation
-    * If you use a compatible Medtronic pump or Eros pods, you will also need a [small device](build/step5.md) for the iPhone and pump to communicate.
 
 ![Loop main display on phone](img/phone_updated_loop.svg){width="300"}
 ![Loop watch screen on watch](img/watch_updated_loop.svg){width="200"}
@@ -42,8 +40,6 @@ If you have never used Loop, click on links below for an introduction.
     * Special thanks to Tina and Reese Hammer for the terrific video
     * Special thanks to Matthew Fouse for the generous use of his beautiful graphics
 
-
-
 ## Important Disclaimer
 
 Please consult with your health care professional regarding your diabetes management.
@@ -51,21 +47,9 @@ Please consult with your health care professional regarding your diabetes manage
 * The Loop app is an open source project used by many, but it is not approved for therapy by any government organization.
 * **You take full responsibility for building and running this system and do so at your own risk.**
 
-
 ## Volunteer Community
 
-Loop has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to loop because many volunteers have given their personal and family time.  So please add your time by reading this website thoroughly before embarking on your Loop journey.
+Loop has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to loop because many volunteers have given their personal and family time.
 
-### Finding Help
+Please add your time by reading this website thoroughly before embarking on your Loop journey.
 
-Volunteers generously provide support for Loop via online platforms. You have a [number of options](build/step12.md) for joining conversations on loop and asking for help.  Links to the main platforms are listed below.  Non-US Loop users in Italy, Australia, and several other countries have also formed Facebook (FB) groups.
-
-  * The [Looped Group](https://www.facebook.com/groups/TheLoopedGroup) on Facebook. Looped Group is the original FB group for DIY looping systems. There are lot of active members there with an excellent history of helping people.
-  * Loop and Learn is a community that provides Loop-centric information, a T1D Speaker Series covering many topics of general diabetes interest as well as Loop-specific chats, alerts whenever there is an update to iOS and Xcode, Quick Tips and articles written by mentors providing their Loop experience.
-      * [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN)
-      * [LoopandLearn Website](https://www.loopandlearn.org)
-      * [LoopandLearn YouTube Channel](https://youtube.com/loopandlearn)
-* The [LoopTips](https://loopkit.github.io/looptips/) website provides non-build information that is helpful once you are looping, e.g., how to print endo reports, find Loop data, deal with therapy settings changes, etc.
-* Many Loopers use [Nightscout](nightscout/overview.md). Nightscout help can be found in the [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud) Facebook group.
-* For those interested in what is coming next for Loop and those who prefer not to use Facebook, join [Loop Zulipchat](https://loop.zulipchat.com) and be sure to subscribe to all the streams or you'll miss some interesting conversations.
-* Loop has an instagram account @diy.loop where some updates are shared.

--- a/docs/intro/intro-to-loopdocs.md
+++ b/docs/intro/intro-to-loopdocs.md
@@ -2,14 +2,6 @@
 
 It is totally understandable if the thought of building and operating your own Loop app feels intimidating. As you learn the steps explained in LoopDocs, this will start feeling more comfortable.
 
-## What if I'm not sure I want to commit?
-
-You can build Loop and practice with a simulated phone, CGM and  pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
-
-Trying it with a simulator can help you decide if you want to move forward with purchasing the hardware and Apple Developers license each year for Loop.
-
-Note - you will need to have access to a computer as an absolute minimum. Please review [SImulator Build](../version/simulator.md) for more information.
-
 
 ## Building Loop
 
@@ -18,10 +10,19 @@ Building the Loop app is straightforward. There are a lot of steps because they 
 !!! warning "Best Practice: Learn to Build"
     Users are strongly encouraged to build Loop for themselves. 
     
-    * It is not recommended and no links to  providers who build Loop as a service will be found in LoopDocs, but there are such services
-    * If you choose to take advantage of such a service, you still should read all the sections of LoopDocs
-    * You will still need to procure compatible CGM, pump, phone and RileyLink
-        * DASH pods do not require the RileyLink, but that version is not yet released
+    * It is not recommended and no links will be found in LoopDocs to  providers who build Loop as a service
+    * If you choose to take advantage of such a service
+        * You still need to read all the sections of LoopDocs
+        * You still need to procure compatible CGM, pump, phone and RileyLink
+            * DASH pods do not require the RileyLink, but that version is not yet released
+
+## What if I'm not sure I want to commit?
+
+You can build Loop and practice with a simulated phone, CGM and  pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
+
+Trying it with a simulator can help you decide if you want to move forward with purchasing the hardware and Apple Developers license each year for Loop.
+
+Note - you will need to have access to a computer as an absolute minimum. Please review [SImulator Build](../version/simulator.md) for more information.
 
 ## Using Loop
 

--- a/docs/intro/loopdocs-how-to.md
+++ b/docs/intro/loopdocs-how-to.md
@@ -1,10 +1,32 @@
 # LoopDocs How-to
 
-## How to Ask for Help
+## Tooltips
+
+LoopDocs has words that may be unfamiliar. For a definition of any word with a dashed underline, simply hover your mouse over the word, or tap on the word on a mobile device, to view the definition.
+
+Every tootip definition is also found in the [Glossary](../faqs/glossary.md) - so head over there if you have trouble reading the tooltips. 
+
+
+
+## How to Find Help
+
+Volunteers generously provide support for Loop via online platforms. You have a number of options for joining conversations on loop and asking for help.  Links to the main platforms are listed below.  Non-US Loop users in Italy, Australia, and several other countries have also formed Facebook (FB) groups.
+
+  * The [Looped Group](https://www.facebook.com/groups/TheLoopedGroup) on Facebook. Looped Group is the original FB group for DIY looping systems. There are lot of active members there with an excellent history of helping people.
+  * Loop and Learn is a community that provides Loop-centric information, a T1D Speaker Series covering many topics of general diabetes interest as well as Loop-specific chats, alerts whenever there is an update to iOS and Xcode, Quick Tips and articles written by mentors providing their Loop experience.
+      * [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN)
+      * [LoopandLearn Website](https://www.loopandlearn.org)
+      * [LoopandLearn YouTube Channel](https://youtube.com/loopandlearn)
+* The [LoopTips](https://loopkit.github.io/looptips/) website provides non-build information that is helpful once you are looping, e.g., how to print endo reports, find Loop data, deal with therapy settings changes, etc.
+* Many Loopers use a companion app called Nightscout. Nightscout help can be found in the [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud) Facebook group.
+* For those interested in what is coming next for Loop and those who prefer not to use Facebook, join [Loop Zulipchat](https://loop.zulipchat.com) and be sure to subscribe to all the streams or you'll miss some interesting conversations.
+* Loop has an instagram account @diy.loop where some updates are shared.
+
+### How to Ask for Help
 
 If you are having trouble building or using your Loop app, there are some important steps to get responses to your question, while also being considerate of our volunteers' time.
 
-1. Always search in **both** [LoopDocs](overview-intro.md#website-search) and your favorite [support group](../index.md#finding-help). 
+1. Always search in **both** [LoopDocs](#website-search) and your favorite [support group](#how-to-find-help). 
     * Confused on how to search in a Facebook group? [Here is a video](https://www.youtube.com/watch?v=_vSN6C-Uo04) to help.
 2.  If you use Facebook, click on the Announcements section; many posts asking for help are already answered in the pinned announcements.
 3.  Don't post a duplicate question in multiple groups (mentors monitor many groups). Only post to a different group if you have had no responses for several hours.
@@ -13,6 +35,55 @@ If you are having trouble building or using your Loop app, there are some import
     * This helps other Loopers who have the same question
     * This helps mentors know they don't need to respond to help you
 
+## How to use LoopDocs
+
+### Website Short Cuts
+
+One of our awesome Loop volunteers captured the domain names  `loopdocs.org` and `looptips.org`.  So you can find these valuable websites by simply typing loopdocs or looptips followed by .org in your browser. In other words, you don't need to remember or type `https://loopkit.github.io/loopdocs/`.
+
+### Website Navigation
+
+There are a lot of links you can click on this website.
+
+* Some links take you to a different section of the same page
+* Some links take you to a different page in LoopDocs
+* Some links take you to a different website
+
+If you click on the link, you are moved to the new location and must hit the back button on your browser to return.
+
+You can choose to open that link in a new window or new tab.
+
+* If your mouse has a right button, then right click the link
+* On a Mac with no right button, hold down the Control key and click
+* On a mobile device, click and hold the link and choose where to open the link
+
+
+!!! tip "Keyboard Navigation"
+    When viewing the site at a computer, you can use keys as shortcuts:
+    
+    * `n` for next page
+    * `p` for previous page
+    * `s` for search
+
+The website navigation depends on whether you are on a mobile device or a computer (with browser width > 1220 pixels). 
+
+* For the wide-view:
+    * The tabs for the different sections of LoopDocs are visible across the top of the browser
+    * Once a tab is selected:
+        * That tab is highlighted
+        * The list of pages in that tab is displayed on the left side
+        * The Table of Contents for the current page is displayed on the right side
+* For the mobile (or narrow) display:
+    * From the Home page, tap the Hamburger Menu to display the tabs for the different sections of LoopDocs
+    * Once a tab is selected:
+        * The list of pages in that tab is displayed in the Hamburger Menu
+        * To return to the main tab list, tap the back arrow
+        * To see the Table of Contents, use the Hamburger Menu and scroll to the highlighted page (current page) and tap again
+
+### Website Search
+
+It is not uncommon to have a question about Loop. But, it is exceptionally rare to have the question not already answered in LoopDocs, so please **search for answers** by clicking the Search tool (upper right). As you begin to type, suggested completions and links to pages are displayed. Click on the item you think answers your question.
+    <br/><br/>![example of using search](../img/new-look-search-example.png){width="600"}<br/>
 
 ## How to Improve LoopDocs
 

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -2,14 +2,7 @@
 
 The Intro tab of LoopDocs contains information to help a new user get started with the LoopDocs website and with Loop. It also has a quick reference for the website contents.
 
-## Tooltips
-
-LoopDocs has words that may be unfamiliar. For a definition of any word with a dashed underline, simply hover your mouse over the word, or tap on the word on a mobile device, to view the definition.
-
-Every tootip definition is also found in the [Glossary](../faqs/glossary.md) - so head over there if you have trouble reading the tooltips. 
-
-
-## Website Contents
+## Website Quick Reference
 
 The main tabs for LoopDocs are:
 
@@ -19,40 +12,8 @@ The main tabs for LoopDocs are:
 * [Set Up](../operation/overview.md): Instructions to set up your Loop app initially; these pages are also useful for reference while using the app
 * [Operate](../operation/loop/open-loop.md): Many pages on using the Loop app
 * [Troubleshoot](../troubleshooting/overview.md): This is the first place to go if you're having trouble with Loop
-* [Loop 3](../loop-3/loop-3-overview.md): Temporary section. It will move to Set Up when Loop 3 is released. (Loop-dev is close to but not quite ready for release as Loop 3.)
+* [Loop 3](../loop-3/loop-3-overview.md): Temporary section. It will move to Set Up when Loop 3 is released. (A development version is close to but not quite ready for release as Loop 3.)
 * [Version](../version/overview-version.md): Information about Loop versions, code customization and development
-* [Nightscout](../nightscout/overview.md): Loop-specific Nightscout details
-* [FAQs](../faqs/overview-faqs.md): pages with safety tips, frequently asked questions and the Glossary
-
-### Website Short Cuts
-
-One of our awesome Loop volunteers captured the domain names  `loopdocs.org` and `looptips.org`.  So you can find these valuable websites by simply typing loopdocs or looptips followed by .org in your browser. In other words, you don't need to remember or type `https://loopkit.github.io/loopdocs/`.
-
-### Website Navigation
-
-!!! tip "Keyboard Navigation"
-    When viewing the site at a computer, you can use keys as shortcuts:
-    
-    * `n` for next page
-    * `p` for previous page
-    * `s` for search
-
-The website navigation depends on whether you are on a mobile device or a computer (with browser width > 1220 pixels). 
-
-* For the wide-view:
-    * The tabs mentioned in [Website Contents](#website-contents) are visible across the top of the browser
-    * Once a tab is selected:
-        * The list of pages in that tab is displayed on the left side
-        * The Table of Contents on the current page is displayed on the right side
-* For the mobile (or narrow) display:
-    * From the Home page, tap the Hamburger Menu to display the tabs mentioned in [Website Contents](#website-contents)
-    * Once a tab is selected:
-        * The list of pages in that tab is displayed in the Hamburger Menu
-        * To return to the main tab list, tap the back arrow
-        * To see the Table of Contents, use the Hamburger Menu and scroll to the highlighted page (current page) and tap again
-
-### Website Search
-
-It is not uncommon to have a question about Loop. But, it is exceptionally rare to have the question not already answered in LoopDocs, so please **search for answers** by clicking the Search tool (upper right). As you begin to type, suggested completions and links to pages are displayed. Click on the item you think answers your question.
-    <br/><br/>![example of using search](../img/new-look-search-example.png){width="600"}<br/>
+* [Nightscout](../nightscout/overview.md): Loop-specific Nightscout details; Nightscout is a companion application that many Loopers use
+* [FAQs](../faqs/overview-faqs.md): Pages with safety tips, frequently asked questions and the Glossary
 

--- a/docs/loop-3/settings.md
+++ b/docs/loop-3/settings.md
@@ -141,7 +141,7 @@ Tap on the `Issue Report` row, on the graphic above, to create a Loop Report tex
     Be aware:
     
     * Issue (on github) is used to report code problems
-    * `Issue Report` is an action in Loop app to provide information you may need when [Finding Help](../index.md#finding-help)
+    * `Issue Report` is an action in Loop app to provide information you may need when [Finding Help](../intro/loopdocs-how-to.md#how-to-find-help)
 
 It's a good idea to use the `Issue Report` button and save it along with a screen shot if you think you will ask for help.  You can always discard these if you resolve the problem on your own.
 
@@ -157,7 +157,7 @@ In either case, the first action should be to add a term or phrase to the search
 !!! warning "Not for Build or Settings Help"
     Submit Bug Report should be used when you believe there is an error in the code.
 
-    * Use [Finding Help](../index.md#finding-help) instead for these cases:
+    * Use [Finding Help](../intro/loopdocs-how-to.md#how-to-find-help) instead for these cases:
         * Trouble building
         * Trouble pairing a pod
         * Trouble with red loops

--- a/docs/operation/features/bolus.md
+++ b/docs/operation/features/bolus.md
@@ -55,4 +55,4 @@ If an "uncertain" delivery is not resolved:
 * With Omnipod, you can execute a [Read Pod Status](../loop-settings/pump-commands.md#read-pod-status) to ensure communication with the pod is working
 * [Quit the Loop app](https://support.apple.com/en-us/HT201330) and restart it. (Note - this is different from a power cycle of the phone which remembers settings within an app which was running before the power cycle.)
 
-If that does not resolve the issue, please tap on Loop Settings, Issue Report and email it to yourself. Then [post](../../index.md#finding-help) on Facebook or Zulipchat, explain what happened and say you have an Issue Report. Someone should reach out to you.
+If that does not resolve the issue, please tap on Loop Settings, Issue Report and email it to yourself. Then [post](../../intro/loopdocs-how-to.md#how-to-find-help) on Facebook or Zulipchat, explain what happened and say you have an Issue Report. Someone should reach out to you.

--- a/docs/operation/loop-settings/pump-commands.md
+++ b/docs/operation/loop-settings/pump-commands.md
@@ -157,7 +157,7 @@ This command requests the Pod emit a beep pattern. If you hear it, you know the 
 
 #### Read Pulse Log
 
-This command reads the pulse log (diagnostic), displays it on the screen and saves the result in the log file. It takes some time, so keep your gear close until command completes. This can be extracted by sending the pulse log to yourself using the send-to icon at the top right of the screen.  It is also included in the Issue Report. If you are having communication issues, you can provide this report to an expert who may be able to provide assistance. [Post](../../index.md#finding-help) for help in either zulipchat or a Facebook group to request assistance and you'll get information about how to get that log file submitted.
+This command reads the pulse log (diagnostic), displays it on the screen and saves the result in the log file. It takes some time, so keep your gear close until command completes. This can be extracted by sending the pulse log to yourself using the send-to icon at the top right of the screen.  It is also included in the Issue Report. If you are having communication issues, you can provide this report to an expert who may be able to provide assistance. [Post](../../intro/loopdocs-how-to.md#how-to-find-help) for help in either zulipchat or a Facebook group to request assistance and you'll get information about how to get that log file submitted.
 
 #### Test Command
 

--- a/docs/troubleshooting/loop-crashing.md
+++ b/docs/troubleshooting/loop-crashing.md
@@ -42,4 +42,4 @@ Remember that switching from free to paid changes the developer name incorporate
 
 ## Other reasons
 
-If you experience a crash for any other reason, please gather all the information you can about what was happening before the crash and report it to your favorite [Loop Social Media](../index.md#finding-help) help site - you will need to get some personalized help. Please - choose one site for your post and wait for someone to get back to you.  While you are waiting, search on any of the sites and, if on Facebook, read all the announcements.
+If you experience a crash for any other reason, please gather all the information you can about what was happening before the crash and report it to your favorite [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) help site - you will need to get some personalized help. Please - choose one site for your post and wait for someone to get back to you.  While you are waiting, search on any of the sites and, if on Facebook, read all the announcements.

--- a/docs/troubleshooting/yellow-red-loop.md
+++ b/docs/troubleshooting/yellow-red-loop.md
@@ -108,7 +108,7 @@ In July 2019, we started to see a new style of Dexcom G6 transmitters on the mar
 
 Make sure both the Loop app and the Dexcom app have permission to write to Apple Health by checking the [Apple Health Permissions](../build/health.md)
 
-In the early days of iOS 14, there were problems with the Apple HealthKit.  The consequence is that some people's database was corrupted.  If you tap on the Heart Icon on your phone to go to Apple Health and display data and it is very slow to respond - or never responds, you probably need to get rid of a corrupted database and start fresh.  Be sure to go Open Loop if this is needed. Please get help from your favorite [Loop Social Media](../index.md#finding-help) group or from Apple support in this case.
+In the early days of iOS 14, there were problems with the Apple HealthKit.  The consequence is that some people's database was corrupted.  If you tap on the Heart Icon on your phone to go to Apple Health and display data and it is very slow to respond - or never responds, you probably need to get rid of a corrupted database and start fresh.  Be sure to go Open Loop if this is needed. Please get help from your favorite [Loop Social Media](../intro/loopdocs-how-to.md#how-to-find-help) group or from Apple support in this case.
 
 ### Background App Refresh
 


### PR DESCRIPTION
Update Home page and Intro pages:
* This moves the finding-help link to how-to-find-help on a different page
* Modify all the places that use the relocated link