### PR TITLE
Improve Navigation

### DIFF
--- a/docs/loop-3/displays_v3.md
+++ b/docs/loop-3/displays_v3.md
@@ -319,25 +319,3 @@ The Status Row is located immediately below the CGM, Loop and Pump Icons and is 
 |If a higher priority message is not displayed in the `Status Row` and an override is active, the override symbol and name, along with the time at which the override expires, is displayed. <br><br>Tapping on the `Status Row` opens the screen for that particular override to enable the user to edit the override. Note that any changes made to that override are applied just to the current session. If you want the override permanently modified, refer to the [Overrides](../operation/features/workout.md) instructions.|
 |<br><br>![Pre-meal Preset message with until time stamp message](img/status-row-pre-meal.svg){width="350"}|
 |If a higher priority message is not displayed in the `Status Row` and the Pre-Meal Range is active in the toolbar, the `Pre-meal Preset, until time stamp` is displayed. Tapping on the status row has no effect for this message.<br><br>**New with Loop 3:** The Pre-Meal Preset can be engaged with an Override. When both are active, the Pre-Meal Range supersedes the range of the active Override, but the other settings for that Override still apply. When both are active, the `Status Row` message reflects the Override with both the PreMeal and Override icons in the toolbar highlighted.|
-
-
-## Loop Widget on Lock Screen
-
-Loop has a widget which can be added to the lock screen. The example graphic below shows the Dexcom G6 widget above the Loop 3 (old-style) widget.
-
-![widget on lock screen, dex above, loop below](img/dex-loop-3-widget.svg){width="300"}
-{align="center"}
-
-!!! info "New to Loop or never added a widget before"
-
-    * There is a difference in behavior between "new-style" Widgets and "old-style" Widgets
-        * New-Style Widgets: always appear at the top of your Today View, can be changed by long-pressing on one and then dragging around, or can be added with the &plus; button in edit mode
-        * Old-Style Widgets, like that available with Loop: use a different method to install
-    * Make sure your phone is unlocked, then swipe from the Home Screen to get to Today View
-        * You can't edit the screen if you start from a locked phone
-    * Start the Edit mode (where all of the icons are shaking), either by long-pressing on one of the new-style widgets, or by scrolling all the way to the bottom of Today View and pressing Edit.
-    * Scroll all the way to the bottom again to find and select the button labeled "Customize"
-    * Now you can configure (add, remove, rearrange) the "old-style" widgets for your screen.
-    * The Loop widget should appear in the list available there.
-
-Experienced Looper who already had a widget should not need to modify anything to see it.

--- a/docs/operation/features/battery.md
+++ b/docs/operation/features/battery.md
@@ -1,4 +1,4 @@
-# Pump Battery
+# Medtronic Pump Battery
 
 One common confusion point for new Loop users is how to interpret their pump's battery levels and whether they need to change their pump batteries based on which pieces of information.
 

--- a/docs/operation/features/widget.md
+++ b/docs/operation/features/widget.md
@@ -1,6 +1,33 @@
 # iPhone Widget
 
-The Loop app will automatically build a widget that will be available on your iPhone.  The widget is available in the Today view of your iPhone.  Swipe right on your iPhone home screen and your widgets will be available.  The Loop widget maybe at the bottom of your widget list.  Scroll down to the bottom of the screen and press the `edit` button.  That opens an "Add Widgets" screen.  If you hold and drag the three horizontal lines on the Loop widget row, you can drag it up to the order you'd like it to appear on your widget list.
+## Loop 3
+
+An updated new-style Loop-dev widget is in process. There are a lot of updates with widgets. With the advent of iOS 16, you can add widgets that show up on the lock screen without need to swipe to view. There is work in progress on this - please be patient.
+
+## Old-Style Loop Widget
+
+Loop 2.2.x and Loop-dev both include an old-style widget.
+
+With older versions of iOS, the widget is available in the Today view of your iPhone.  Swipe right on your iPhone home screen and your widgets will be available.  The Loop widget may be at the bottom of your widget list.  Scroll down to the bottom of the screen and press the `edit` button.  That opens an "Add Widgets" screen.  If you hold and drag the three horizontal lines on the Loop widget row, you can drag it up to the order you'd like it to appear on your widget list.
 
 ![img/widget_bar.png](img/widget_bar.png){width="600"}
 {align="center"}
+
+With newer version of iOS, the old-style widgets cannot be moved to the top of the screen. The example graphic below shows the new-style Dexcom G6 widget above the old-style Loop 3 widget.
+
+![widget on lock screen, dex above, loop below](../../loop-3/img/dex-loop-3-widget.svg){width="300"}
+{align="center"}
+
+!!! info "New to Loop or never added a widget before"
+
+    * There is a difference in behavior between "new-style" Widgets and "old-style" Widgets
+        * New-Style Widgets: always appear at the top of your Today View, can be changed by long-pressing on one and then dragging around, or can be added with the &plus; button in edit mode
+        * Old-Style Widgets, like that available with Loop: use a different method to install
+    * Make sure your phone is unlocked, then swipe from the Home Screen to get to Today View
+        * You can't edit the screen if you start from a locked phone
+    * Start the Edit mode (where all of the icons are shaking), either by long-pressing on one of the new-style widgets, or by scrolling all the way to the bottom of Today View and pressing Edit.
+    * Scroll all the way to the bottom again to find and select the button labeled "Customize"
+    * Now you can configure (add, remove, rearrange) the "old-style" widgets for your screen.
+    * The Loop widget should appear in the list available there.
+
+Experienced Looper who already had a widget should not need to modify anything to see it.

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -12,9 +12,11 @@ After you have been using Loop for a while, there's a potential that you will ru
 
 Loop docs are updated regularly.  If you built your Loop app awhile ago, chances are good that more information has been updated and changed since you last read them.  Please use the search tool - if there's an error message - search for it. Scan the topics in the `Troubleshoot` tab of LoopDocs and look for a page that may be applicable.  The FAQs pages are definitely worth reviewing too.
 
-### Issue Report
+### `Issue Report`
 
-Under the Loop app settings, there is a selection called `Issue Report`.  The Issue Report (a text file) contains important information about your Loop's actions and status that can be very useful for troubleshooters...particularly with unexplained behaviors.  The upper right corner of the Issue Report includes a button so that you can email the Issue Report to yourself (or others).  If you are seeing something unusual in your Loop, capture an Issue Report while it is happening and save it.  A troubleshooter may want to see that information.
+Use the `Issue Report` [Loop 3](../loop-3/settings.md#issue-report) / [Loop 2](../operation/loop-settings/configurations.md#issue-report) command under Loop Settings to generate a Loop Report. This has a lot of detailed information that may help you or a mentor understand your problem.
+
+The Loop Report (a text file) contains important information about actions and status that can be very useful for troubleshooters...particularly with unexplained behaviors.  The upper right corner of the Loop Report includes a button so that you can email the Loop Report to yourself (or others).
 
 ## Check Resources
 
@@ -36,3 +38,5 @@ Search in [Zulipchat]( https://loop.zulipchat.com), [Looped Facebook Group](http
 If you can't find any information in LoopDocs, GitHub Issues, Zulipchat, or Facebook...PLEASE post and ask for help.  GitHub Issues list is an EXCELLENT place to post issues of unexpected Loop behavior (that you believe are errant or need improvement).  However, if you are just seeking clarifications on Loop, but don't necessarily expect that there's a problem with the underlying code, then Facebook and Zulipchat is a better place.  For example, Zulipchat and Facebook are great for asking about bolus strategies or exercise target use...those aren't really code issues.
 
 When you post, provide a description along with any screenshots of the issue you are having and include the version of Loop you are running and the iOS on your device.  (Tap on Loop-Settings and look at the top of the screen to get the Loop version number).  You don't necessarily have to tag any particular person, the community is fairly active in replying to messages.
+
+**Post in only one place - the same volunteers monitor various sites.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,12 +109,10 @@ nav:
     - 'Bolus': 'operation/features/bolus.md'
     - 'Overrides': 'operation/features/workout.md'
     - 'Loop Notifications': 'operation/features/notifications.md'
-    - How to Use Loop App:
-        - 'Pre-meal target': 'operation/features/premeal.md'
-        - 'Using ICE info': 'operation/features/ice.md'
-        - 'Apple Watch': 'operation/features/watch.md'
-        - 'iPhone widget': 'operation/features/widget.md'
-        - 'Pump Battery': 'operation/features/battery.md'
+    - 'Pre-meal target': 'operation/features/premeal.md'
+    - 'Using ICE info': 'operation/features/ice.md'
+    - 'Apple Watch': 'operation/features/watch.md'
+    - 'iPhone widget': 'operation/features/widget.md'
     - Loop Tips: 'operation/loop/looptips.md'
     - Algorithm:
         - 'Algorithm Overview': 'operation/algorithm/overview.md'
@@ -126,9 +124,10 @@ nav:
     - 'Loop App crashes': 'troubleshooting/loop-crashing.md'
     - 'Red Loop': 'troubleshooting/yellow-red-loop.md'
     - 'Pod Pairing Failures': 'troubleshooting/pod-pairing.md'
+    - 'Omnipod Faults': 'troubleshooting/omnipod-faults.md'
     - 'Time Changes': 'troubleshooting/time-change.md'
     - 'MDT Pump Errors': 'troubleshooting/pump-errors.md'
-    - 'Omnipod Faults': 'troubleshooting/omnipod-faults.md'
+    - 'MDT Pump Battery': 'operation/features/battery.md'
 - Loop 3:
     - 'Loop 3 Overview': 'loop-3/loop-3-overview.md'
     - 'Loop 3 Onboarding': 'loop-3/onboarding.md'


### PR DESCRIPTION
Clean up the Operate Tab
* get rid of one extra level
* move MDT Battery to Troubleshooting

Consolidate Loop Widget into a single page

Add links to Issue Report (Loop Report) for Loop 3 and Loop 2 on Troubleshooting Overview page.