### PR TITLE
G7, Emphasize dev nature with scripts

### DIFF
--- a/docs/build/build-select-dev.md
+++ b/docs/build/build-select-dev.md
@@ -18,8 +18,15 @@ The script, BuildLoopFixedDev.sh, assists in building the development branch for
 If you have not previously built the released version of the app using the Build-Select (BuildLoop.sh) script as documented on the [Build the Loop App](step14.md) page, review that page first and then return.
 
 * The BuildLoopFixedDev.sh script downloads the development branch and then selects a specific commit that has been lightly tested
+* When you use this script, you accept that this is not released code
+* The developer may need to make changes that require you to delete your app and start over
+* The advantage of the script is experienced testers have gone before you to test new changes
+* You are still testing a development version of the app and you are expected to:
+    * Pay attention
+    * Monitor for reports of problems other people are having
+    * Report any issue you experience.
 
-Remember, this code is under active development, so please pay attention to your app and report any unexpected behavior on [Loop Zulipchat](https://loop.zulipchat.com).
+**Remember, this code is under active development, so please pay attention to your app and report any unexpected behavior on [Loop Zulipchat](https://loop.zulipchat.com).**
 
 The lightly tested commit is identified by a 7-digit alphanumeric code. That code is appended to the folder name of the downloaded code under Downloads/BuildLoop. You can use finder to view the folder name after the script completes.
 

--- a/docs/build/code_customization.md
+++ b/docs/build/code_customization.md
@@ -592,7 +592,13 @@ Refer to the graphic below.  The Downloads folder in Finder is highlighted on th
 * Hold down the CTRL key and click (or right-click) LoopWorkspace
 * A menu appears - select `New Terminal at Folder` (near the bottom of the list)
 
-This new terminal window is now in the LoopWorkspace folder needed to type commands to apply patches.
+This new terminal window is ready to accept commands as needed when the instructions say to start a terminal in the LoopWorkspace folder.
+
+To confirm you are in the correct location, type `pwd` and return in the terminal. The response must end in LoopWorkspace. For example, using the graphic below, the response to `pwd` should be similar to:
+
+`
+/Users/marion/Downloads/BuildLoop/Loop-20220803-1145/LoopWorkspace
+`
 
 ![how to use finder to find the correct download and open xcode](img/finding-loopworkspace.svg){width="750"}
 {align="center"}

--- a/docs/build/loopworkspace.md
+++ b/docs/build/loopworkspace.md
@@ -124,6 +124,8 @@ Once Xcode is opened for the LoopWorkspace, everything is pretty similar to buil
 
 When it's time to update the copy of LoopWorkspace on your computer - you have choices. You can use the method below or redo the whole cloning process.
 
+Be sure your terminal is in the correct location using [Open a Terminal in LoopWorkspace Folder](code_customization.md#open-a-terminal-in-loopworkspace-folder)
+
 1. Make sure you are in the correct branch using this git command:
     ```
     git branch
@@ -142,6 +144,34 @@ If you are testing the LoopKit dev branch, you need to be on [zulipchat](https:/
 
 ![there has been an update in three submodules](img/zulipchat-github.svg){width="600"}
 {align="center"}
+
+### Updating Loop to a Specific LoopWorkspace commit
+
+Sometimes, you know a feature you want was added at a specific commit number, but the [Loop Dev Script](build-select-dev.md) does not include that commit. However, you know there are other changes later than that commit which you do not want to test. There is a solution.
+
+For example, suppose you want to checkout LoopWorkspace commit bde44b5, but nothing later.
+
+Be sure your terminal is in the correct location using [Open a Terminal in LoopWorkspace Folder](code_customization.md#open-a-terminal-in-loopworkspace-folder). First you have to bring down all the latest dev commits. Then you will back up to the one you want.
+
+1. Make sure you are in the correct branch using this git command:
+    ```
+    git branch
+    ```
+1. If you are not in the correct branch, for example `dev`, then issue this git command (suitably modified for the desired branch)
+    ```
+    git checkout dev
+    ```
+1. Use the following git commands to bring down all the newer commits to your copy:
+    ```
+    git fetch
+    git pull --recurse
+    ```
+1. Now you want to "backup" to the desired commit:
+    ```
+    git checkout bde44b5
+    git submodule update
+    ```
+1. Assuming there were no errors, see [Local Modifications Conflict](#local-modifications-conflict), in the process above, you can now build that commit.
 
 ### Build Following Update
 
@@ -247,12 +277,19 @@ If you get a messages such as this:
   Aborting
 ```
 
-The easiest fix is to type:
+The easiest fix is to type, where you can modify Loop to be whichever folder had the conflict:
 
 ```
   cd Loop; git stash; cd ..
   git pull --recurse
 ```
+
+If there were no errors, and you want to restore your changes, you can try:
+```
+  cd Loop; git stash pop; cd ..
+```
+
+If you see errors indicating you cannot use `pop`, that means you need to manually add your customizations back.
 
 
 ## Checking out different branches within a LoopWorkspace

--- a/docs/build/step13.md
+++ b/docs/build/step13.md
@@ -1,10 +1,14 @@
 # Advanced Users Only
 
-**Typically, the dev branch is tested by developers and experienced users. When the dev branch gets more mature, adventurous Loopers want to try out the new features and are not waiting for the release. Please pay extra attention if you proceed with Loop-dev.**
+**Typically, the dev branch is tested by developers and very experienced users. When the dev branch gets more mature, adventurous Loopers want to try out the new features and are not waiting for the release. Please pay extra attention if you proceed with Loop-dev.**
 
 ## About Loop-dev
 
-Normally, people are discouraged from building a development branch, see [What's going on in the dev branch?](../faqs/branch-faqs.md#whats-going-on-in-the-dev-branch). However, the dev branch is approaching the time when it will be released. It is currently being used by a lot of regular users. But keep paying attention and report any issues you may have with Loop dev. (You will see a lot of documentation that refers to Loop 3 - this is for the convenience of preparing updates to LoopDocs to be ready for that release.)
+Please read [What's going on in the dev branch?](../faqs/branch-faqs.md#whats-going-on-in-the-dev-branch) and [New with Loop 3](../loop-3/loop-3-overview.md#new-with-loop-3).
+
+The dev branch is being used by a number of people, has improved features and provides DASH support. Many newer Loopers are switching to dev, but they need to be aware that this is NOT released code and if the developer needs to make a change, they will.
+
+If you use this page and script to build Loop-dev, keep paying attention and report any issues you may have. (You will see a lot of documentation that refers to Loop 3 - this is for the convenience of preparing updates to LoopDocs to be ready for that release.)
 
 !!! question "When will Loop dev be released as Loop 3?"
     There is no set time for the release. However, the BuildLoopFixedDev script described on this page allows you to use a lightly tested version of the dev branch. The link below lets you view what has been fixed and what is on the list to be updated.
@@ -13,11 +17,10 @@ Normally, people are discouraged from building a development branch, see [What's
         * [https://github.com/LoopKit/Loop/projects/4](https://github.com/LoopKit/Loop/projects/4)
 
 - Note, the dev branch requires a minimum of iOS 14 on your device
-- Once you install the dev branch on a device, you must delete the app to return to master (the released version), which means all settings will need to be entered in master and a new pod started
-- The dev branch Loop user interface is updated - as an experienced Looper, you will notice the difference
+- Once you install the dev branch on a device, if you then decide to return to the released version, you must delete the app off your phone, which means all settings will need to be entered in master and a new pod started
 - Updated documentation is a work-in-progress located under the [Loop 3](../loop-3/loop-3-overview.md) tab of LoopDocs
 
-The development branch supports Omnipod DASH and many less experienced users want that capability. To assist these individuals, a special script (similar to the Build Select script) is provided. The name of the script: BuildLoopFixedDev refers to the fact that the scripts build a version (commit) of the dev branch that has been lightly tested. The developers continue to make changes to dev, and after testing, the script is updated to the next lightly tested commit.
+To assist users who are willing to test dev but do not feel comfortable with using git, a special script (similar to the Build Select script) is provided. The name of the script: BuildLoopFixedDev refers to the fact that the script builds a version of the dev branch with a fixed commit number that has been lightly tested. The developers continue to make changes to dev, and after testing, the script is updated to the next lightly tested commit.
 
 !!! danger "Returning to Older Version"
     If you decide to return to Loop v2.2.x (or FreeAPS) after building Loop-dev on your phone, you will have to delete the Loop app and all other apps with the shared app group ID. This list includes Loop, FreeAPS, FreeAPS X, xDrip4iOS, Glucose-Direct, and the g5 Transmitter Reset app.
@@ -30,9 +33,17 @@ The development branch supports Omnipod DASH and many less experienced users wan
 
 This page documents using the BuildLoopFixedDev script to download the development branch of the app for Loop or FreeAPS.
 
-* The BuildLoopFixedDev script downloads the development branch and then selects a specific commit that has been lightly tested
+* The BuildLoopFixedDev.sh script downloads the development branch and then selects a specific commit that has been lightly tested
+* When you use this script, you accept that this is not released code
+* The developer may need to make changes that require you to delete your app and start over
+* One advantage of the script is experienced testers have gone before you to test new changes
+* You are still testing a development version of the app and you are expected to:
+    * Pay attention
+    * Monitor for reports of problems other people are having
+    * Report any issue you experience.
 
-This is still code under development, so please pay attention to your app and report any unexpected behavior on [Loop Zulipchat](https://loop.zulipchat.com).
+**Remember, this code is under active development, so please pay attention to your app and report any unexpected behavior on [Loop Zulipchat](https://loop.zulipchat.com).**
+
 
 !!! warning "iOS 16: Developer Mode Required"
     If your phone is running iOS 16, please click on this [Developer Mode](step14.md#developer-mode) link, follow the directions on that page and then return to this page.  (If you continue on the page with the Developer Mode link, you will be building the released code, not the dev code.)

--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -14,6 +14,10 @@ Loop can be connected to the following CGMs:
 * CGMs that reside on the same phone (internet not required)
     * [Dexcom G5](#dexcom-g5-g6-one)
     * [Dexcom G6](#dexcom-g5-g6-one) (use this for Dexcom ONE)
+    * [Dexcom G7](#dexcom-g7) **(Loop-dev only)**
+        * only available with Loop dev (commit bde44b5, 26 Nov 2022, or later)
+        * NOT INCLUDED in [Build Loop-dev script](../build/build-select-dev.md), see [Updating Loop to a Specific LoopWorkspace commit](../build/loopworkspace.md#updating-loop-to-a-specific-loopworkspace-commit)
+        * REQUIRES Xcode 14
     * [Minimed Enlite CGM](#medtronic-enlite-cgm)
         * Medtronic Pump only
         * **You must [add pump](add-pump.md) first**
@@ -54,6 +58,14 @@ To use the Dexcom G5, G6 or ONE:
 #### About Dexcom Share credentials
 
 You do **NOT** need your Share account info listed in Loop settings if you are using a G5 or G6 system. The transmitter ID is sufficient. In fact, you should leave your Share credentials blank so that you don't accidentally become internet-dependent for CGM data if you forget to update your transmitter ID when you start a new transmitter.
+
+### Dexcom G7
+
+This is only available on Loop dev and requires special build instructions (as noted above).
+
+You must have the G7 app on the same phone as Loop.
+
+Minimal documentation is provided and this is an in-process implementation. Please join zulipchat and click on the [Development G7 Integration link](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/G7.20Integration) to read the conversation.
 
 ### Medtronic Enlite CGM
 

--- a/docs/loop-3/displays_v3.md
+++ b/docs/loop-3/displays_v3.md
@@ -166,9 +166,10 @@ The Heads-Up-Display, visible in portrait mode, shows the Glucose Status on the 
 
 * The Glucose is displayed in the same units as the selected CGM
     * If units are incorrect, quit Loop, allow your CGM app to update and then restart Loop
+    * You can override the display units, later, by selecting the [units in Apple Health](../faqs/apple-health-faqs.md#how-do-i-change-glucose-units)
 * The green Loop icon indicates that within the last 5 minutes Loop completed a [cycle](#loop-cycle)
 * The Pump Status indicates the scheduled basal rate is running
-    * The 0.0 U display means the basal currently running is 0 U/hr different from the scheduled basal
+    * The +0.0 U display means the basal currently running is 0 U/hr different from the scheduled basal
 
 ### Loop Status Icon
 
@@ -235,7 +236,7 @@ The nominal pump icon displays high-level status information for the pump with t
 * The basal delivery status displays the enacted temp basal change relative to the scheduled basal.  For example, for a scheduled basal of 0.45 U/hr
     * If Loop sets a temp basal rate of 0.2 U/hr, the icon displays -0.25 U
     * If Loop sets a temp basal rate of 1.5 U/hr, the icon displays +1.05 U
-    * When scheduled basal is running, the icon displays 0.0 U
+    * When scheduled basal is running, the icon displays +0.0 U
 * But what about [Overrides](../operation/features/workout.md)?
     * Using scheduled basal of 0.45 U/hr with override set to 70%, the "override basal rate" is 0.315 U/hr
         * That is a value that cannot be set in the pump, but Loop uses it for IOB calculations

--- a/docs/loop-3/loop-3-overview.md
+++ b/docs/loop-3/loop-3-overview.md
@@ -30,7 +30,8 @@ Here are some highlights:
 * Omnipod Dash compatibility
 * Fingerstick blood glucose prompts when data is stale
 * Non-pump insulin entry within the app
-* Remote Carb/Bolus capability
+* [Remote Carb/Bolus capability](features.md#remote-carb-bolus)
+* [Manual Temp Bolus capability for Omnipod](omnipod.md#manual-temp-basal)
 
 
 ## Building Loop 3


### PR DESCRIPTION
Build/step13 and Build/build-select-dev
* Emphasize that code built with Loop-dev build scripts are still dev

Loop-3/add-cgm
* Add G7 information

Build/LoopWorkspace
* Add how to build to a specific commit
* Add git stash pop information

Misc improvements in language and typo fixes
