### PR TITLE
Updates: Time Change Warning, misc

### DIFF
--- a/docs/build/step11.md
+++ b/docs/build/step11.md
@@ -38,7 +38,7 @@ Take some time to familiarize yourself with these data options and choose your p
         * Loop 3 allows remote commands for carbs, bolus or overrides
         * The [LoopCaregiver](../nightscout/remote-overrides.md#loopcaregiver) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
 
-Nightscout options include free or nominal cost sites you build yourself was well as a few paid Nightscout as a Service providers who provide turn-key sites. Links to the options are found in the [Nightscout: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
+Nightscout options include free or nominal cost sites you build yourself or there are several Nightscout as a Service vendors who provide turn-key sites for a monthly fee. Links to the options are found in the [Nightscout: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
 
 Nightscout is the most useful day-to-day for some of its capabilities such as plotting IOB and providing a secure, real-time Dashboard of Loop status visible to anyone with access codes and the internet.
 

--- a/docs/build/step11.md
+++ b/docs/build/step11.md
@@ -19,6 +19,8 @@
 
 ## Data Options
 
+Take some time to familiarize yourself with these data options and choose your preferred system(s). Many Loopers use all three for various aspects.
+
 * [Apple Health app](../faqs/apple-health-faqs.md#healthkit-plots)
     * Great resource to view on the Loop phone
     * Not so great for showing your endo
@@ -27,12 +29,16 @@
     * Many users of the mobile app like the note taking ability
         * The mobile app also uploads Apple HealthKit data to Tidepool
 * Nightscout:
-    * [Nightscout](../nightscout/overview.md) link in LoopDocs
-    * [Nightscout](https://loopkit.github.io/looptips/data/nightscout/) link to LoopTips
+    * [LoopDocs: Nightscout](../nightscout/overview.md) section of LoopDocs, has Loop-centric information about Nightscout
+    * [LoopTips: Nightscout](https://loopkit.github.io/looptips/data/nightscout/) link to LoopTips page on Nightscout
+    * [Nightscout: Documentation](https://nightscout.github.io/) official Nightscout site with lots of information about building and using Nightscout
     * Nightscout has a lot of useful alarms and alerts, provides a care portal and detailed reports
-    * Some versions of Loop and Nightscout together allow for remote interface between caregiver and looper
+    * For those who assist someone who is Looping, Nightscout enables the caregiver to provide remote commands to the Looper's phone
+        * Loop 2 allows overrides to be enabled or disabled remotely
+        * Loop 3 allows remote commands for carbs, bolus or overrides
+        * The [LoopCaregiver](../nightscout/remote-overrides.md#loopcaregiver) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
 
-All of the options are free and straightforward to setup. (There are paid options for configuring Nightscout; links to those providers are found along with the DIY steps in the Nightscout docs.) Take some time to familiarize yourself with these options and setup your preferred system(s). Many Loopers use all three for various aspects. 
+Nightscout options include free or nominal cost sites you build yourself was well as a few paid Nightscout as a Service providers who provide turn-key sites. Links to the options are found in the [Nightscout: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
 
 Nightscout is the most useful day-to-day for some of its capabilities such as plotting IOB and providing a secure, real-time Dashboard of Loop status visible to anyone with access codes and the internet.
 

--- a/docs/build/step2.md
+++ b/docs/build/step2.md
@@ -67,10 +67,10 @@ Do not use any of the beta iOS versions. (Don't worry...if you don't know what t
 
 With iOS 16 and watchOS 9, Apple added a feature. If you want to know more, click on this [Apple Link about Developer Mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device).
 
-When you build (or run) Loop on your phone running iOS 16, and watch paired to your phone running watchOS 9, you need to have Developer Mode enabled. You will be told to enable it in the [Build Loop App: Prepare your Phone and Watch](step14.md#prepare-your-phone-and-watch) instructions.
+When you build Loop on your phone from Xcode directly and then transition to or start with iOS 16, you need to have Developer Mode enabled. This is also a requirement to use the Loop app on a watch paired to your phone running watchOS 9. You will be told to enable it in the [Build Loop App: Prepare your Phone and Watch](step14.md#prepare-your-phone-and-watch) instructions.
 
 !!! info "Developer Mode with iOS 16, watchOS 9"
-    If you already have Loop on your phone/watch when you update to iOS 16/watchOS 9, you will be told that Loop requires Developer Mode to run.
+    If you already have Loop, built with Xcode on a Mac, on your phone/watch when you update to iOS 16/watchOS 9, you will be told that Loop requires Developer Mode to run.
     
     You will not be able to run Loop on your phone (or watch) until you have enabled Developer Mode on the device(s).
 

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -1,5 +1,9 @@
 After you have been using Loop for a while, there's a potential that you will run across a behavior or issue that you wonder if it is normal or intended.  When that happens, there are a few things that we'd recommend doing to resolve the issue.
 
+## Use Automatic Time on Loop Phone
+
+If you have modified the Loop time (not changed time zone, but turned off automatic time and manually changed the time), please read: [Loop Phone Must be on Automatic Time](../troubleshooting/time-change.md#loop-phone-must-be-on-automatic-time).
+
 ## Gather information
 
 ### Screenshots

--- a/docs/troubleshooting/time-change.md
+++ b/docs/troubleshooting/time-change.md
@@ -1,15 +1,23 @@
 ## Loop Phone Must be on Automatic Time
 
 !!! danger "Loop Phone is a Medical Device"
-    There have been several instance where a Looper disabled automatic time on their Loop phone.
+    There have been several instances where a Looper disabled automatic time to change the time on their Loop phone.
 
     One scenario should be enough to convince you not to do this:
 
     * Glucose is 180 mg/dL (10 mmol/L) when you set time one day ahead (for a game)
     * Later you return time to automatic and think nothing of it
-    * Next day, Loop keeps trying to bring down that glucose that was recorded in the future, when in fact your glucose is 90 mg/dL (5 mmol/L)
+    * As soon as automatic time is restored, Loop thinks your eventual glucose will be the future value (in this example 180 mg/dL) and attempts to bring you to your correction range
+    * Because that future value is "stuck", Loop keeps providing more insulin
 
-    Loop 3 is very aggressive at warning you if you make this mistake.
+### Remove Future Glucose
+
+* You **MUST** go into Apple Health and remove any glucose values in the future. At the current time, Loop 2.2.x and Loop-dev will use those future readings.
+    * If you want to know more, check out this link: [Request: Detect Future Glucose](https://github.com/LoopKit/Loop/issues/1890)
+* If you also use Nightscout **and** have the upload CGM readings enabled in Loop, those future glucose values will appear in Nightscout
+    * To fix this problem (after you fix Apple Health), use the [Admin Tools in Nightscout](https://nightscout.github.io/nightscout/admin_tools/) to remove future treatments and future entries
+
+One added improvement with Loop 3 is it very aggressive at warning you if you make this mistake. you will get a notification - even when you are in a different app. The graphic below shows the alert when you next open Loop after turning off automatic time and changing the time. Even if you respond right away, you may have at least one glucose reading in the future when you see this alert. Please [Remove Future Glucose](#remove-future-glucose).
 
 ![notification displayed when automatic time is disabled on Loop phone](../loop-3/img/loop-3-omnipod-time-change.svg){width="350"}
 {align="center"}


### PR DESCRIPTION
* Improve warning and instructions if Looper does change time manually on phone.
* Clarify that Developer Mode is only needed with Mac / Xcode build (not required with GitHub Build Actions / TestFlight)
* Clean up the Nightscout section on Loop Data page