### PR TITLE
📝 ➕ Switch dexcom sensors and transmitters diagrams

### DIFF
--- a/docs/faqs/cgm-faqs.md
+++ b/docs/faqs/cgm-faqs.md
@@ -29,7 +29,7 @@ When you change transmitters (prior to Dexcom G7), you will need to update the t
 * In Loop, select the `Delete CGM` button at the very bottom of the CGM info page
     * You cannot just edit the line with your old transmitter ID
 * It's a good idea to go into your phone Bluetooth settings and delete the old Dexcom transmitter
-    * The transmitter starts with Dexcom and ends with the last 2 characters of your transmitter ID
+    * The transmitter starts with Dexcom and ends with the last 2 characters of your old transmitter ID
     * Tap on the (i) next to `Not Connected` and select `Forget This Device`
 * Follow the Dexcom instructions for pairing the new transmitter
 * After pairing completes with Dexcom:
@@ -42,6 +42,35 @@ When you change transmitters (prior to Dexcom G7), you will need to update the t
 If you don't update your transmitter ID when you change active transmitters, and you included your Dexcom share credentials, then Loop uses your Dexcom Share server to get your CGM data and will not work without cell or wifi connection. When Loop is using data from Dexcom Share servers, a small cloud will appear above the BG reading in Loop and should tip you off that maybe you forgot to update your transmitter ID. It's best not to enter Share Credentials. This makes it really obvious that you need to update the CGM settings in Loop at transmitter change time.
 
 With G7, Loop automatically picks up the active sensor/transmitter pair from the Dexcom G7 app on the phone.
+
+The below diagram illustrates **how to switch transmitters on Dexcom G5, G6, and ONE** (not G7).
+
+```mermaid
+sequenceDiagram
+    actor       user     as User
+    participant dexcom   as Dexcom App
+    participant loop_app as Loop App
+
+    autonumber
+    user     ->>  loop_app: Delete CGM
+    user     ->>  dexcom:   Stop old Sensor
+    activate      dexcom
+    Note over     dexcom:   Switching sensors and transmitters... ⏱️
+    user     -->> user:     Remove old Sensor and old Transmitter
+    user     ->>  dexcom:   Enter new Transmitter Serial Number
+    user     ->>  dexcom:   Enter new Sensor Code
+    user     -->> user:     Insert new Sensor then attach new transmitter
+    user     ->>  dexcom:   Pair then Start new Sensor
+    deactivate    dexcom
+    dexcom   -->> user:     New Sensor warming up... 
+    activate      dexcom
+    Note over     dexcom:   New sensor warmup... ⏱️
+    user     ->>  loop_app: Add CGM
+    user     ->>  loop_app: Enter new Transmitter Serial Number
+    dexcom   -->> user:     New Sensor operational
+    deactivate dexcom
+```
+
 
 ## Can I use Libre sensors with a reader like Miao Miao?
 

--- a/docs/faqs/cgm-faqs.md
+++ b/docs/faqs/cgm-faqs.md
@@ -58,7 +58,7 @@ sequenceDiagram
     Note over     dexcom:   Switching sensors and transmitters... ⏱️
     user     -->> user:     Remove old Sensor and old Transmitter
     user     ->>  dexcom:   Enter new Transmitter Serial Number
-    user     ->>  dexcom:   Enter new Sensor Code
+    user     ->>  dexcom:   Enter/Scan new Sensor Code
     user     -->> user:     Insert new Sensor then attach new transmitter
     user     ->>  dexcom:   Pair then Start new Sensor
     deactivate    dexcom

--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -155,7 +155,7 @@ sequenceDiagram
     activate      dexcom
     Note over     dexcom:   Switching sensors... ⏱️
     user     -->> user:     Remove old Sensor
-    user     ->>  dexcom:   Enter new Sensor Code
+    user     ->>  dexcom:   Enter/Scan new Sensor Code
     user     -->> user:     Insert new Sensor
     user     ->>  dexcom:   Pair then Start new Sensor
     deactivate    dexcom

--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -1,6 +1,6 @@
 ## CGM Choices
 
-A CGM can be added from the Heads-Up-Display ([HUD](displays_v3.md#heads-up-display)) or from the [Loop Settings](settings.md) screen.
+A CGM can be added from the Heads-Up-Display ([HUD](displays_v3.md#heads-up-display)) or from the [Loop Settings](settings.md) screen ⚙️.
 
 The HUD will look like the graphic below if no CGM or Pump is connected with Loop:
 
@@ -24,7 +24,7 @@ Loop can be connected to the following CGMs:
 
 ## Add CGM
 
-To add a CGM, go to the Settings screen, tap on add CGM and tap on your CGM.
+To add a CGM, go to the Settings screen ⚙️, tap on `Add CGM`, and tap on your CGM.
 
 ![graphic showing some of the CGMs available with Loop 3](img/loop-3-setting-add-cgm.svg){width="500"}
 {align="center"}
@@ -33,13 +33,13 @@ To add a CGM, go to the Settings screen, tap on add CGM and tap on your CGM.
 
 To use the Dexcom G5, G6 or ONE:
 
-* Select Dexcom model, use G6 for either G6 or ONE
+* Select Dexcom model, use `Dexcom G6` for either  G6 or ONE
 * Dexcom app must be running on the Loop iPhone and paired to an active transmitter
 * User must enter that active transmitter ID in the location indicated by the red rectangle in the graphic below
-* Do not enter your Share Credentials
+* Do **not** enter your `Share Credentials`
     * The graphic below shows `Tap to set`
     * Do not tap, leave it alone
-* Only add the transmitter ID to Loop after it is paired with the Dexcom app on your phone
+* Only add the **transmitter ID** to Loop **after** it is paired with the *Dexcom app* on your phone
 
 ![interface to add transmitter ID for Dexcom](img/loop-3-setting-add-dexcom.svg){width="300"}
 {align="center"}
@@ -53,6 +53,7 @@ To use the Dexcom G5, G6 or ONE:
     Follow the instructions here: [What do I do when I switch Dexcom transmitters?](../faqs/cgm-faqs.md#what-do-i-do-when-i-switch-dexcom-transmitters).
 
     The Dexcom G7 is handled differently - Loop automatically detects when a new sensor/transmitter pair is added to the Dexcom G7 app.
+
 
 #### About Dexcom Share credentials
 
@@ -123,15 +124,53 @@ The user must enter both the URL and API_SECRET for their site to ensure the sec
 ![Nightscout Remote CGM entry screen](img/nightscout-cgm-entry.svg){width="350"}
 {align="center"}
 
-When using Nightscout Remote CGM, if the user needs to change credentials or switch to a different CGM, the user must go through the Loop->Settings->CGM menu.
+When using Nightscout Remote CGM, if the user needs to change credentials or switch to a different CGM, the user must go through the Loop->Settings ⚙️->CGM menu.
 
 
 ## Change CGM
 
 To change CGMs, delete your existing CGM and then add a new CGM.
 
-* For Dexcom G5, G6, ONE or Share, access `Delete CGM` by tapping on the CGM Icon in the HUD or by tapping on Loop Settings and selecting CGM and scrolling down.
+### Change a Dexcom G5, G6, ONE CGM
 
-* For Nightscout Remote CGM, the Nightscout URL is opened when tapping on the CGM icon in the HUD, while the credential sections with the `Delete CGM` row is shown when tapping on Loop Settings and selecting CGM.
+For **Dexcom G5, Dexcom G6, Dexcom ONE, or Share**:
 
-After deleting a CGM, the [Head-Up-Display](#cgm-choices) at the top of the Loop main screen will show the add CGM icon.
+1. In the **Loop App**, access `Delete CGM` by tapping on the CGM Icon in the HUD or by tapping on Loop Settings ⚙️, selecting your CGM, and scrolling all the way down the page.
+2. Open the **Dexcom App**:
+	- Stop the old sensor
+	- Start the new one
+3. Back in the **Loop App**, `Add a CGM` as  [described here](#add-cgm).
+
+The below diagram illustrates **how to switch sensors on Dexcom G5, G6, and ONE**.
+
+```mermaid
+sequenceDiagram
+    actor       user     as User
+    participant dexcom   as Dexcom App
+    participant loop_app as Loop App
+
+    autonumber
+    user     ->>  loop_app: Delete CGM
+    user     ->>  dexcom:   Stop old Sensor
+    activate      dexcom
+    Note over     dexcom:   Switching sensors... ⏱️
+    user     -->> user:     Remove old Sensor
+    user     ->>  dexcom:   Enter new Sensor Code
+    user     -->> user:     Insert new Sensor
+    user     ->>  dexcom:   Pair then Start new Sensor
+    deactivate    dexcom
+    dexcom   -->> user:     New Sensor warming up...
+    activate      dexcom
+    Note over     dexcom:   New sensor warmup... ⏱️
+    user     ->>  loop_app: Add CGM
+    user     ->>  loop_app: Enter current Transmitter Serial Number
+    dexcom   -->> user:     New Sensor operational
+    deactivate dexcom
+```
+
+
+### Change a Nightscout Remote CGM
+
+For **Nightscout Remote CGM**, the Nightscout URL is opened when tapping on the CGM icon in the HUD, while the credential sections with the `Delete CGM` row are shown when tapping on Loop `Settings` ⚙️, and selecting CGM.
+
+After deleting a CGM, the [Head-Up-Display](#cgm-choices) at the top of the Loop main screen will show the `Add CGM` icon.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,6 @@ extra_css:
     - stylesheets/extra.css
     - stylesheets/primary-color.css
 
-
 markdown_extensions:
     - meta
     - abbr
@@ -51,7 +50,12 @@ markdown_extensions:
           generic: true
     - pymdownx.highlight
     - pymdownx.inlinehilite
-    - pymdownx.superfences
+    - pymdownx.superfences:
+        # make exceptions to highlighting of code:
+        custom_fences:
+          - name:  mermaid
+            class: mermaid
+            format: !!python/name:mermaid2.fence_mermaid
     - pymdownx.snippets:
         auto_append:
             - includes/tooltip-list.txt
@@ -63,11 +67,12 @@ markdown_extensions:
 extra_javascript:
     - javascripts/mathjax.js
     - https://polyfill.io/v3/polyfill.min.js?features=es6
+    - https://unpkg.com/mermaid/dist/mermaid.min.js
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:
     - search
-
+    - mermaid2
 nav:
 - Home: 'index.md'
 - Intro:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,29 @@
-# python installation requirements for loopdocs
-# install by running: pip install -r requirements.txt
-
+beautifulsoup4==4.11.2
+certifi==2022.12.7
+charset-normalizer==3.0.1
+click==8.1.3
+EditorConfig==0.12.3
+ghp-import==2.1.0
+idna==3.4
+importlib-metadata==6.0.0
+Jinja2==3.1.2
+jsbeautifier==1.14.7
+Markdown==3.4.1
+MarkupSafe==2.1.2
+mergedeep==1.3.4
 mkdocs==1.3.0
 mkdocs-material==7.3.6
+mkdocs-material-extensions==1.1.1
+mkdocs-mermaid2-plugin==0.6.0
+packaging==23.0
+Pygments==2.14.0
+pymdown-extensions==9.9.2
+python-dateutil==2.8.2
+PyYAML==6.0
+pyyaml_env_tag==0.1
+requests==2.28.2
+six==1.16.0
+soupsieve==2.3.2.post1
+urllib3==1.26.14
+watchdog==2.2.1
+zipp==3.12.0


### PR DESCRIPTION
This PR: 
- ➕ Add dependencies
    - add a plugin to create diagrams in Markdown
- 📝 Update Documentation
    - add 2 sequence diagrams to depict how to switch sensors and/or transmitters and in which order (what to do when in which App).
    - 📝 add a header for `Change a Dexcom G5, G6, ONE CGM`.
      I'm not familiar with `ONE` or `Share` so I would like you to review what I added to make sure it applies to them.
    - 📝 Add a cog (⚙️) after `Loop Settings`. 
      I am not sure if this also applies to Loop version `2.x` as I use version 3.

## Sequence Diagrams

The sequence diagrams use [mermaid.js](https://mermaid.js.org/syntax/sequenceDiagram.html), a Markdown extension that provides a way to give a textual description (in Markdown) of what a diagram should look like.  
MkDocs does not support mermaid.js natively, but via the [mkdocs-mermaid2-plugin](https://mermaid.js.org/misc/integrations.html#document-generation).
This is why I added this plugin to `requirements.txt` along with all the packages it requires.
I also [configured mkdocs-mermaid2-plugin]() in `mkdocs.yml`:
- https://github.com/fralau/mkdocs-mermaid2-plugin#basic-configuration
- https://github.com/fralau/mkdocs-mermaid2-plugin#using-mermaid-and-code-highlighting-at-the-same-time

Here is what the diagrams look like once rendered via `mkdocs serve` locally.

<img width="652" alt="dexcom-5_6_one-switch_sensors-diagram" src="https://user-images.githubusercontent.com/73331/216671816-16eefeba-ef1d-4195-873e-1ccdba6de319.png">


<img width="690" alt="dexcom-5_6_one-switch_transmitters-diagram" src="https://user-images.githubusercontent.com/73331/216671855-827ba0a7-1ce8-4295-b826-009304fcef4c.png">

## How I "updated" the project's required dependencies

I'm not familiar with `pip` and really learned how to use it for this PR. 
❗️So, another pair of eyes is welcome to double-check if I did things correctly (package dependencies and diagrams).

```shell
cd loopdocs
  
# Creates a virtual environment for the project in the venv folder, using Python 3
python3 -m venv venv 
  
# Activate the virtual environment  
source venv/bin/activate

# Install project's required packages/dependencies
python -m pip install -r requirements.txt 

# Instal the plugin to be able to use Mermaid diagrams in Markdown files
python -m pip install mkdocs-mermaid2-plugin 

# Recreate the file containing the project's required packages/dependencies 
pyhon -m pip freeze > requirements.txt 

```