### PR TITLE
🐛 Fix/mermaid diagram not rendered correctly in auto light dark mode

### DIFF
--- a/docs/javascripts/refresh_on_toggle_dark_light.js
+++ b/docs/javascripts/refresh_on_toggle_dark_light.js
@@ -1,0 +1,10 @@
+var paletteSwitcher1 = document.getElementById("__palette_1");
+var paletteSwitcher2 = document.getElementById("__palette_2");
+
+paletteSwitcher1.addEventListener("change", function () {
+  location.reload();
+});
+
+paletteSwitcher2.addEventListener("change", function () {
+  location.reload();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,12 +15,6 @@ theme:
     logo: loop-logo.png
     favicon: loop-logo.png
     palette:
-        # Palette toggle for automatic mode
-        - media: "(prefers-color-scheme)"
-          toggle:
-            icon: material/brightness-auto
-            name: Switch to light mode
-
         # Palette toggle for light mode
         - media: "(prefers-color-scheme: light)"
           scheme: default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ theme:
           scheme: slate
           toggle:
             icon: material/brightness-4
-            name: Switch to system preference
+            name: Switch to light mode
 
 # repo_url: https://github.com/LoopKit/Loop
 
@@ -63,10 +63,16 @@ extra_javascript:
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://unpkg.com/mermaid/dist/mermaid.min.js
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+    - javascripts/refresh_on_toggle_dark_light.js
 
 plugins:
     - search
-    - mermaid2
+    - mermaid2:
+        arguments:
+          # for mkdocs-material <8.0.0
+          theme: |
+            ^(JSON.parse(window.localStorage.getItem(__prefix('__palette'))).index == 1) ? 'dark' : 'light'
+
 nav:
 - Home: 'index.md'
 - Intro:


### PR DESCRIPTION
## Issue

The Mermaid diagram on the [FAQ page](https://loopkit.github.io/loopdocs/faqs/cgm-faqs/#dexcom-g5-g6-and-one), is messed up when clicking the auto/dark/light theme toggle button (next to the search field) to go dark mode, [as mentioned here](https://loop.zulipchat.com/#narrow/stream/270362-documentation/topic/.28no.20topic.29/near/326903950).

<img width="1351" alt="theme_toggle_button" src="https://user-images.githubusercontent.com/73331/218189414-9b0a3f72-4dfb-4ab8-8ae3-9210d7f27047.png">

![In dark mode, Mermaid Diagram arrow lines are hidden](https://user-images.githubusercontent.com/73331/218182734-9540feed-251d-4c66-b55f-07b51cf2dc24.png)



## Why?

We use [here](https://github.com/LoopKit/loopdocs/blob/42b9ce474ee922ddadf0483285d9debf65235299/mkdocs.yml#L19-L22) a feature called [automatic light/dark mode](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode) only available to `mkdocs-material` **sponsors** in most recent versions. This is probably why `automatic` mode it does not work as expected when clicking the toggle button twice to switch the theme from `automatic` to `light` and then `dark`.

The fix removes the `automatic` theme from the configuration and adds some configuration to refresh the page for the theme change to be taken into account.
Then we have a functional dark mode.


<img width="952" alt="mermaid_diagram-dark_mode" src="https://user-images.githubusercontent.com/73331/218190298-f8711664-42bc-4803-875c-99e472403a7c.png">

