### PR TITLE
🐛Fix Regression: Copy-to-clipboard button no longer available

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
         - search.suggest
         - search.highlight
         - content.code.annotate
+        - content.code.copy
         - content.tooltips
     logo: loop-logo.png
     favicon: loop-logo.png


### PR DESCRIPTION
The **copy-to-clipboard button** is now opt-in since `mkdocs-material` 9+ and we need to declare it explicitly. This is why it disappeared since we upgraded to `mkdocs-material`.
This PR adds it back.

See: https://squidfunk.github.io/mkdocs-material/upgrade/?h=upgrade#contentcodecopy
Fixes #577