### PR TITLE
🔧 Disable copy-to-clipboard button by default + 📝  enable it on specific code blocks

### DIFF
--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -259,9 +259,9 @@ Text in error:
 
 No need to quit Xcode. If your build script terminal is still open, use it. Otherwise, open a new terminal window.
 
-Copy the lines below that start with `ls -l` by hovering the mouse near the right side of the text and clicking the copy icon (should say Copy to Clipboard when you hover over it). When you click the icon, a message that says “Copied to Clipboard” will appear on your screen.
+Copy the lines below that start with `ls -l` by hovering the mouse near the right side of the text and clicking the copy icon (should say `Copy to Clipboard` when you hover over it). When you click the icon, a message that says `Copied to Clipboard` will appear on your screen.
 
-```title="Copy and Paste to add read permissions to xcconfig file"
+``` { .sh .copy title="Copy and Paste to add read permissions to xcconfig file" }
 ls -l ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig
 chmod +r ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig
 ls -l ~/Downloads/BuildLoop/LoopConfigOverride.xcconfig

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -509,7 +509,7 @@ MATCH_PASSWORD
 Once all six secrets have been added to your LoopWorkspace, you are done with Settings. Your screen should look similar to the graphic below.
 
 * Take a moment to be sure all of your secrets are spelled correctly
-* If you notice a mistake, just delete the one that is not spelled correctly and add a `New respository secret` with the correct name
+* If you notice a mistake, just delete the one that is not spelled correctly and add a `New repository secret` with the correct name
 
 ![all secrets entered](img/gh-done-adding-secrets.png){width="700"}
 {align="center"}
@@ -641,7 +641,7 @@ If you modified settings for the Loop identifier, the Save button at the top rig
 
 If you did not need to make changes, the Save button will not be active.
 
-* Tap on the `< All Indentifiers` button at top left
+* Tap on the `< All Identifiers` button at top left
 
 The full list of Identifiers should be displayed again.
 
@@ -675,7 +675,7 @@ If you had to modify a given identifier, the Save button at the top right will b
 
 If you did not need to make changes, the Save button will not be active.
 
-* Tap on the `< All Indentifiers` button at top left
+* Tap on the `< All Identifiers` button at top left
 
 The full list of Identifiers should be displayed again.
 

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -483,22 +483,22 @@ Take a calming breath. This next part requires care.
     * If it is not, all will appear fine until you try to Build Loop and then you will get failures
 
 For each of the following secrets, follow the directions below - this list is configured with a copy button when you hover to the right of each word - this helps avoid spelling errors.
-```
+``` { .text .copy }
 TEAMID
 ```
-```
+``` { .text .copy }
 FASTLANE_ISSUER_ID
 ```
-```
+``` { .text .copy }
 FASTLANE_KEY_ID
 ```
-```
+``` { .text .copy }
 FASTLANE_KEY
 ```
-```
+``` { .text .copy }
 GH_PAT
 ```
-```
+``` { .text .copy }
 MATCH_PASSWORD
 ```
 

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -353,7 +353,7 @@ You must be logged into your GitHub account before starting this step. If you ar
 
 ### Create Match-Secrets
 
-Open your github.com URL (this is `https://github.com/username`) where you replace username with the name you chose above.
+Open your github.com URL (this is `https://github.com/username`) where you replace `username` with the name you chose above.
 
 Create a new private repository - you can either click on the link below, or follow the instructions with the first graphic:
 
@@ -368,9 +368,9 @@ or
 
 This shows you a screen similar to the following graphic which has 3 regions highlighted:
 
-* In Repository name, type Match-Secrets (use a hyphen between Match and Secrets)
+* In `Repository name`, type `Match-Secrets` (use a hyphen between Match and Secrets)
 * Be sure to check the box (red circle) to make the repository **private**
-* **Please confirm you selected Match-Secrets repository as private.**
+* **Please confirm you selected `Match-Secrets` repository as private.**
 * Scroll to the bottom of the pages and tap on "Create Repository"
 
 ![first screen for new repository](img/01-gh-create-match-secrets.png){width="600"}
@@ -502,8 +502,8 @@ GH_PAT
 MATCH_PASSWORD
 ```
 
-* For the FASTLANE_KEY value, copy the entire contents from<br>-----BEGIN PRIVATE KEY-----<br> through<br>-----END PRIVATE KEY-----<br>
-* For MATCH_PASSWORD value - make up a password for this and save it for later use
+* For the `FASTLANE_KEY` value, copy the entire contents from<br>-----BEGIN PRIVATE KEY-----<br> through<br>-----END PRIVATE KEY-----<br>
+* For `MATCH_PASSWORD` value - make up a password for this and save it for later use
     * The MATCH_PASSWORD must be the same for any repository using this method ([Other Apps](gh-other-apps.md))
 
 Once all six secrets have been added to your LoopWorkspace, you are done with Settings. Your screen should look similar to the graphic below.

--- a/docs/nightscout/remote-overrides.md
+++ b/docs/nightscout/remote-overrides.md
@@ -257,7 +257,7 @@ A build script is available to assist in building LoopCaregiver. This should be 
 
 Open a terminal window. Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say Copy to Clipboard when you hover over it). When you click the icon, a message that says “Copied to Clipboard” will appear on your screen.
 
-```title="Copy and Paste to start the BuildLoopCaregiver.sh script"
+``` { .bash .copy  title="Copy and Paste to start the BuildLoopCaregiver.sh script" }
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoopCaregiver.sh)"
 ```
 

--- a/docs/operation/features/notifications.md
+++ b/docs/operation/features/notifications.md
@@ -20,7 +20,7 @@ The expiration notification pattern is the same as for the Paid Loop App. You ma
 
 ## Loop App Expiration Date
 
-If you want to see the expiration date at any time, tap on Settings, then tap on Issue Report.  The expiration date is near the top of the report (to the right of ```profileExpiration```).  If you don't see that, time to rebuild to get that feature. Once you've viewed the expiration date, tap Settings to back out of the Issue Report display. The time is in GMT, so adjust to your own time zone if you procrastinated until the last minute.
+If you want to see the expiration date at any time, tap on Settings, then tap on Issue Report.  The expiration date is near the top of the report (to the right of `profileExpiration`).  If you don't see that, time to rebuild to get that feature. Once you've viewed the expiration date, tap Settings to back out of the Issue Report display. The time is in GMT, so adjust to your own time zone if you procrastinated until the last minute.
 
 ![Issue report displays Loop App expiration date](img/loop-app-expiration-issue-report.jpeg){width="250"}
 {align="center"}

--- a/docs/version/loopworkspace.md
+++ b/docs/version/loopworkspace.md
@@ -95,7 +95,7 @@ Now...look carefully and notice two things...that command is getting (1) the ver
 
 So, you will need to edit that "branch-name" before using the command so that you are getting started with the branch you want. If you want to clone from a different fork, the LoopKit will be replaced with the name of the github site for the fork. For example, to test dev (which is under development and has some cool new architecture and features), you would copy/paste:
 
-```
+``` { .bash .copy }
 git clone --branch=dev --recurse-submodules https://github.com/LoopKit/LoopWorkspace
 ```
 
@@ -104,7 +104,7 @@ git clone --branch=dev --recurse-submodules https://github.com/LoopKit/LoopWorks
 
 If you want to start the build from the command line, enter the following 2 lines into the terminal and skip ahead to [Building LoopWorkspace](#building-loopworkspace)
 
-```
+``` { .bash .copy }
 cd LoopWorkspace
 xed .
 ```
@@ -155,15 +155,15 @@ When it's time to update the copy of LoopWorkspace on your computer - you have c
 Be sure your terminal is in the correct location using [Open a Terminal in LoopWorkspace Folder](../build/code_customization.md#open-a-terminal-in-loopworkspace-folder)
 
 1. Make sure you are in the correct branch using this git command:
-    ```
+    ``` { .bash .copy }
     git branch
     ```
 1. If you are not in the correct branch, for example `dev`, then issue this git command (suitably modified for the desired branch)
-    ```
+    ``` { .bash .copy }
     git checkout dev
     ```
 1. Use the following git commands in the LoopWorkspace folder of your terminal:
-    ```
+    ``` { .bash .copy }
     git fetch
     git pull --recurse
     ```
@@ -182,15 +182,15 @@ For example, suppose you want to checkout LoopWorkspace commit bde44b5, but noth
 Be sure your terminal is in the correct location using [Open a Terminal in LoopWorkspace Folder](../build/code_customization.md#open-a-terminal-in-loopworkspace-folder). First you have to bring down all the latest dev commits. Then you will back up to the one you want.
 
 1. Make sure you are in the correct branch using this git command:
-    ```
+    ``` { .bash .copy }
     git branch
     ```
 1. If you are not in the correct branch, for example `dev`, then issue this git command (suitably modified for the desired branch)
-    ```
+    ``` { .bash .copy }
     git checkout dev
     ```
 1. Use the following git commands to bring down all the newer commits to your copy:
-    ```
+    ``` { .bash .copy }
     git fetch
     git pull --recurse
     ```
@@ -215,7 +215,7 @@ This command deletes derived data stored across all workspaces and projects by X
 
 Copy and paste this command into a terminal window.
 
-``` title="Copy and Paste to Delete Derived Data"
+``` { .bash .copy title="Copy and Paste to Delete Derived Data" }
 rm -rf ~/Library/Developer/Xcode/DerivedData
 ```
 
@@ -312,7 +312,7 @@ The easiest fix is to type commands similar to the following, where you modify L
 ```
 
 After stashing and updating with no errors, you can try to restore your changes:
-```
+```  { .bash .copy }
   cd Loop; git stash pop; cd ..
 ```
 

--- a/docs/version/loopworkspace.md
+++ b/docs/version/loopworkspace.md
@@ -295,7 +295,7 @@ If you got a error message the # you requested `did not match any file(s) known 
 
 If you have modified anything in a submodule folder on your computer, it might be in conflict with the latest commit.
 
-If you get a messages such as this:
+If you get a message such as this:
 
 ```
   error: Your local changes to the following files would be overwritten by checkout:
@@ -336,7 +336,7 @@ There are 2 main ways to do this.
 
 !!! info "Average Loopers can skip this whole section...it's for Developers mostly"
 
-    This whole section about non-LoopKit workspace clones is something almost every Looper can totally skip over. I'm only writing up this section for people who are interested in dabbling in code collaborations/customizations that they would want to maintain separate from LoopKit proper.
+    This whole section about non-LoopKit workspace clones is something almost every Looper can totally skip over. I'm only writing up this section for people who are interested in dabbling in code collaborations/customizations that they would want to maintain separately from LoopKit proper.
 
 Scenario: You have a friend named DeveloperBob who has his own version of LoopWorkspace that he's customized. DeveloperBob wants you to look at his code customizations and collaborate with him. You need to change the "git clone" command to get DeveloperBob's version, not LoopKit's version. And, you'd want to make sure you specify the branch that the new feature is on, too. DeveloperBob should usually include the branch name when he posts/shares. So, the command line might be edited to something like:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,6 @@ theme:
         - search.suggest
         - search.highlight
         - content.code.annotate
-        - content.code.copy
         - content.tooltips
     logo: loop-logo.png
     favicon: loop-logo.png


### PR DESCRIPTION
PR #578 enabled **copy-to-clipboard** button **globally** on all code blocks.
<img width="813" alt="copy-to-clipboard_button" src="https://user-images.githubusercontent.com/73331/218842358-a4fba186-7b04-4ffd-a2b1-5bedd2d11fe2.png">


But, as @marionbarker suggested [here](https://github.com/LoopKit/loopdocs/pull/578#issuecomment-1428059311), showing this button only makes sense for specific ones instead.

> It may be worth setting up all the places where we do want the copy button with the new syntax as explained at this link and, after that is in place, then turn the global copy button enable off again.

This PR does exactly that:
- ① Disable globally showing the copy-to-clipboard button. It will no longer be displayed by default unless explicitly required.
- ② Display this button on a case-by-case basis for a chosen set of code blocks, in the Markdown like so:
  ````
  ``` { .sh .copy title="Optional Title here" }
  Content of code block here...
  ```
  ````
  where:
    - `.sh` denotes the language used within the code block is shell whatever its variant. We could have used `.bash` here to be more restrictive.
    - `.copy` specify that we want the copy-to-clipboard button to be  displayed
    - `title="..."` is the title (optional)
  Do note that there is space between the first triple backticks (denoting the beginning of the code block) and the opening curly brace `{ `