### PR TITLE
🔧 Render keyboard keys + 📝 add copy-to-clipboard button where missing

### DIFF
--- a/docs/build/build_errors.md
+++ b/docs/build/build_errors.md
@@ -16,8 +16,8 @@ Sometimes, Xcode stops responding. You have to fix this before any of the other 
 
 This can happen sometimes. You just need to force quit Xcode. Sometimes rebooting the Mac may be required, but start with force quit. Then just open up Xcode again and keep going.
 
-* Hold down these 3 keys (Option (or Alt), Command, Esc (Escape)) until the Force Quit menu appears (should be fast)
-* Select Xcode and tap on the Force Quit button
+* Hold down these 3 keys ++option+command+escape++ (or ++alt+command+escape++),  until the `Force Quit` menu appears (should be fast)
+* Select `Xcode` and tap on the `Force Quit` button
 
 ![menu to select application to force quit](img/force-quit.png){width="300"}
 {align="center"}
@@ -25,7 +25,7 @@ This can happen sometimes. You just need to force quit Xcode. Sometimes rebootin
 ## Start with The Obvious Error Causes
 
 !!! info "New Loop Builders"
-    This page contains build error help for people updating their Loop app as well as brand new Loop app builders. Review the "obvious" errors causes first. If that doesn't help, then, skim the page until you reach [Find Your Error Message](build_errors.md#find-your-error-messages) or search the page (Cmd-F) or search LoopDocs for your error. Once you've identified your error message, try to resolve it.  Still stuck? Read [Posting for Help](build_errors.md#posting-for-help)
+    This page contains build error help for people updating their Loop app as well as brand new Loop app builders. Review the "obvious" errors causes first. If that doesn't help, then, skim the page until you reach [Find Your Error Message](build_errors.md#find-your-error-messages) or search the page (++command+"F"++) or search LoopDocs for your error. Once you've identified your error message, try to resolve it.  Still stuck? Read [Posting for Help](build_errors.md#posting-for-help)
 
 Before you start trying to resolve your red errors, start with the most obvious things that can cause a red error message:
 
@@ -122,7 +122,7 @@ Therefore, try to resolve your build error yourself. Then, if you need to post f
 
 ## Screenshots
 
-Please take screenshots of your issue and use them in your posts. On an Apple computer, press `shift-command-4` keys at the same time followed by pressing the space bar and then click on the window of interest. The screenshot will be saved to your desktop with a file name starting with the name "Screen Shot". Use screenshots instead of cell phone images or words whenever possible. Screenshots are higher resolution and easier to read.
+Please take screenshots of your issue and use them in your posts. On an Apple computer, press ++shift+command+"4"++ keys at the same time followed by pressing the space bar ++space++ and then click on the window of interest. The screenshot will be saved to your desktop with a file name starting with the name "Screen Shot". Use screenshots instead of cell phone images or words whenever possible. Screenshots are higher resolution and easier to read.
 
 Use the whole Xcode window screenshot when posting for build help.
 
@@ -515,7 +515,7 @@ You can verify the iOS development certificates are working by clicking on "Mana
 {align="center"}
 
 4. Open your Loop project again in Xcode.
-5. In the main Xcode menu (grey menu bar at the very top of your Apple display area), select `Product` and then select the option for `Clean`. (Keyboard shortcut is shift-command-k)
+5. In the main Xcode menu (grey menu bar at the very top of your Apple display area), select `Product` and then select the option for `Clean`.  (Keyboard shortcut is ++shift+command+"K"++)
 6. Now try rebuilding your Loop app.  If you ever get prompted again to allow Xcode access to Keychain, make sure to click on the option to Always Allow.
 
 ### Unrecognized Arguments

--- a/docs/build/code_customization.md
+++ b/docs/build/code_customization.md
@@ -153,7 +153,7 @@ Depending on your iPhone preferences and model, you may have Face ID or Touch ID
 !!! warning "Loop 3"
     For Loop 3, this controls the authorization requirement to modify Therapy Settings as well as to confirm bolus delivery.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 canEvaluatePolicy(.deviceOwnerAuthentication
 ```
 
@@ -196,7 +196,7 @@ _Code After Modification_
 
 Loop’s default carb absorption times are based on the high, medium, and low glycemic index absorption curves presented in *Think Like A Pancreas* by Gary Scheiner.  With Loop 2.2.x, the lollipop (fast) icon is set for 2 hours, taco (medium) icon for 3 hours, and pizza (slow) icon for 4 hours. This is modified for Loop 3 to 30 minutes, 3 hours and 5 hours respectively.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 defaultCarbAbsorptionTimes: CarbStore.DefaultAbsorptionTimes
 ```
 
@@ -234,7 +234,7 @@ With Loop 2.2.x, the end of the line has a comment `// %`, whereas with Loop 3, 
 
 **Change just the number and double check that the value is less than 1.**
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let bolusPartialApplicationFactor
 ```
 
@@ -275,7 +275,7 @@ Any override more than a factor of 2 from 100% can cause Loop predictions to be 
 
 This example customization changes the lower bound for sensitivity to 50% (factor of 2 smaller than 100%) and provides 5% steps.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let allScaleFactorPercentages
 ```
 
@@ -298,7 +298,7 @@ _Code After Modification to 50% to 200% by steps of 5%_
 
 During the development of Loop 3, a warning screen was added to the carb entry interface when the entered meal is between 100 and 250 grams, inclusive. The variables that control when the warning screen is shown and that limit the overall maximum for carb entries are stored in the LoopConstants file, where they are used by both direct interaction with the Loop phone and by the remote carb entry checking code.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let warningCarbEntryQuantity =
 ```
 
@@ -337,7 +337,7 @@ Users of Loop 2.2.9 and earlier or FreeAPS must use the following method for mod
 Some people want to limit the maximum number of carbs that can be entered in one entry – especially for children or folks who eat lower carb. This helps prevent accidental typos, e.g., entry of 115 g instead of 15 g for a meal.
 
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 maxQuantity =
 ```
 
@@ -369,7 +369,7 @@ Note that Loop does not include the amount of insulin in the prime or insertion 
 
 This code change is found in one location for Eros Pods (called Omnipod throughout the app) and DASH Pods (called Omnipod Dash throughout the app). I tend to change both files, but if you're only using one kind of pod, that is really not necessary.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let cannulaInsertionUnitsExtra
 ```
 
@@ -398,7 +398,7 @@ The [Therapy Setting Guardrails](../loop-3/therapy-settings.md#guardrails-for-se
 If you build Loop 3 over a version of Loop 2.2.x or FreeAPS where the Correction Range is lower than the default value of 87 mg/dL (4.8 mmol/L), your app requires you to satisfy the new guardrail before you can save that Therapy Setting when you onboard.
 
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 Guardrail(absoluteBounds:
 ```
 
@@ -422,7 +422,7 @@ Modify the 67 for suspendThreshold or 87 for correctionRange to the desired valu
 
 Loop 3 limits the future time change allowed to 1 hour.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 cell.datePicker.maximumDate = date.addingTimeInterval
 ```
 
@@ -453,7 +453,7 @@ There are a number of places where you need to make changes (2 for sensitivity a
 ### Loop 2.2.x Sensitivity
 
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let rotationsPerIncrement
 ```
 
@@ -464,7 +464,7 @@ let rotationsPerIncrement
 ![img/sensitivity1.png](img/sensitivity2.png){width="800"}
 {align="center"}
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 let rotationsPerValue
 ```
 
@@ -482,7 +482,7 @@ In order to reduce the amount the user has to spin the watch crown to confirm a 
 For example to change rotation required to 70% of the default, change 1.0 to 0.7 in 3 places on those 2 lines. This `Key_Phrase` returns 3 lines, the second 2 of which are the ones in that file where the change is required:
 
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 abs(accumulatedRotation)
 ```
 
@@ -498,7 +498,7 @@ First - try it with no customization. Then make small changes.
 
 This key phrase will indicate three different files in the same folder as shown in the graphic below - you can adjust each in turn as you desire. When you click on the line, the quantity you change is a few lines below where you find the `Key_Phrase`, except for the CarbAndDateInput file.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 .digitalCrownRotation
 ```
 
@@ -541,11 +541,11 @@ If you prefer a different notification time and frequency, there are two lines y
     * Line 16: modify how long before expiration you get the FIRST notification
     * Line 28: modify how frequently you will be notified
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 expirationAlertWindow: TimeInterval
 ```
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
  minimumTimeBetweenAlerts: TimeInterval
 ```
 
@@ -609,7 +609,7 @@ Please read the nitty-gritty discussion that went into the development of the "e
 
 If you wish to customize these values, please make sure you know what you are doing.  This is not a modification recommended for Loop novices.
 
-``` title="Key_Phrase"
+``` { .txt .copy title="Key_Phrase" }
 MARK: - Model generation
 ```
 

--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -115,16 +115,16 @@ These instructions show each step needed to download Loop using the Build-Select
  
      You do not need to know about these options to build Loop.
 
-Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say Copy to Clipboard when you hover over it). When you click the icon, a message that says “Copied to Clipboard” will appear on your screen.
+Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say `Copy to Clipboard` when you hover over it). When you click the icon, a message that says `Copied to Clipboard` will appear on your screen.
 
 ```title="Copy and Paste to start the BuildLoop.sh script"
 /bin/bash -c "$(curl -fsSL \
   https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh)"
 ```
 
-Paste the line of text into Terminal. Be sure to click anywhere in the terminal before trying to paste. (Ways to paste: CMD-V; or CNTL-click and select from menu or Edit-Paste at top of Mac screen.)
+Paste the line of text into Terminal. Be sure to click anywhere in the terminal before trying to paste. (Ways to paste: ++command+"V"++ ; or ++control++ click and select from menu or `Edit`-`Paste` at top of Mac screen.)
 
-Read the screen (shown below).  Type 1 and return if you understand the warning and agree.
+Read the screen (shown below).  Type `1` and return if you understand the warning and agree.
 
 * Please read what is on the screen as you progress.
 * Adjust font size as directed if you have difficulty seeing the directions.

--- a/docs/build/step14.md
+++ b/docs/build/step14.md
@@ -89,7 +89,7 @@ Go to the Finder app, click on Applications, then open the Utilities folder.  Lo
 
     or more experienced folks may want to just paste this command into their terminal:
 
-    ``` title="Copy and Paste to remove Provisioning Profiles"
+    ``` { .sh .copy title="Copy and Paste to remove Provisioning Profiles" }
     rm ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision
     ```
 
@@ -117,7 +117,7 @@ These instructions show each step needed to download Loop using the Build-Select
 
 Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say `Copy to Clipboard` when you hover over it). When you click the icon, a message that says `Copied to Clipboard` will appear on your screen.
 
-```title="Copy and Paste to start the BuildLoop.sh script"
+``` { .bash .copy title="Copy and Paste to start the BuildLoop.sh script" }
 /bin/bash -c "$(curl -fsSL \
   https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh)"
 ```

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -146,7 +146,7 @@ In order to ensure a full year of use for your Loop app, you need to delete any 
 
     If you are comfortable pasting commands into the terminal, you can delete the provisioning profiles by copying and pasting this command into a terminal window.
 
-    ``` title="Copy and Paste to remove Provisioning Profiles"
+    ``` { .sh .copy title="Copy and Paste to remove Provisioning Profiles" }
     rm ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision
     ```
 
@@ -162,13 +162,13 @@ Go to the Finder app, click on Applications, then open the Utilities folder.  Lo
 
 #### Load the Paste Buffer
 
-Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say Copy to Clipboard when you hover over it). When you click the icon, a message that says “Copied to Clipboard” will appear on your screen.
+Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say `Copy to Clipboard` when you hover over it). When you click the icon, a message that says `Copied to Clipboard` will appear on your screen.
 
-``` title="Run the Build Select script to Clean Profiles & Derived Data"
+``` { .sh .copy title="Run the Build Select script to Clean Profiles & Derived Data" }
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopnlearn/LoopBuildScripts/main/BuildLoop.sh)"
 ```
 
-Paste the line of text into Terminal. Be sure to click anywhere in the terminal before trying to paste. (Ways to paste: CMD-V; or CNTL-click and select from menu or Edit-Paste at top of Mac screen.) Once the line is pasted, hit return to execute the script.
+Paste the line of text into Terminal. Be sure to click anywhere in the terminal before trying to paste. (Ways to paste: ++command+"V"++; or ++control++ click and select from menu or `Edit`-`Paste` at top of Mac screen.) Once the line is pasted, hit return to execute the script.
 
 #### Utilities
 

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -278,8 +278,8 @@ The Keys screen is seen again with the additional content similar to that shown 
 1. The contents of this file will be used for `FASTLANE_KEY`
 
     * Copy the full text, including the "-----BEGIN PRIVATE KEY-----" and "-----END PRIVATE KEY-----" lines
-        * On a Mac, use CMD-A, then CMD-C to copy all the contents
-        * On a PC, use CTL-A, then CTL-C to copy all the contents
+        * On a **Mac**, use ++command+"A"++, then ++command+"C"++  to copy all the contents
+        * On a **PC**, use ++control+"A"++ , then ++control+"C"++ to copy all the contents
     * In the file where you are saving information, paste this with the indication that it is for  `FASTLANE_KEY`
 
     ![img/apns-copy-key.png](../nightscout/img/apns-copy-key.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ markdown_extensions:
           generic: true
     - pymdownx.highlight
     - pymdownx.inlinehilite
+    - pymdownx.keys
     - pymdownx.superfences:
         # make exceptions to highlighting of code:
         custom_fences:


### PR DESCRIPTION
This PR:
- adds copy-to-clipboard buttons where missing
- adds the **rendering** of **keyboard keys** instead of text

## Before
<img width="805" alt="no-keys-2" src="https://user-images.githubusercontent.com/73331/219121132-888f8f3a-4b75-4906-9c37-a1df604e3074.png">

## After 
<img width="791" alt="keys-2" src="https://user-images.githubusercontent.com/73331/219121254-53f9156f-50b9-4cad-8d74-6124a946213c.png">


[Source](https://squidfunk.github.io/mkdocs-material/reference/formatting/#adding-keyboard-keys)