### PR TITLE
Fix `Node 16` and `set-output` deprecation warnings when running `publish.yml` Github Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: mkdocs build
 
-      - uses: JamesIves/github-pages-deploy-action@v4.2.5
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          BRANCH: gh-pages
-          FOLDER: site
+          branch: gh-pages
+          folder: site


### PR DESCRIPTION
This PR fixes issue #586 

Running the github action [publish.yml](https://github.com/LoopKit/loopdocs/blob/397b29bc90ddc95b79b4e6b49dc2a5df0d387f60/.github/workflows/publish.yml#L24) generates the following deprecation warnings:

> **Node.js 12 actions are deprecated**. Please **update** the following actions **to** use **Node.js 16**: 
JamesIves/github-pages-deploy-action@v4.2.5. For more information see: 
 https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

> The **`set-output`** command is **deprecated** and will be disabled soon
> deploy
> The `set-output` command is deprecated and will be disabled soon.  Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/