### PR TITLE
💄 Configure Mermaid diagrams according to LoopDocs color cheme

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,3 +12,7 @@ article ul ul {
 article ul ul ul {
         list-style-type:  square !important;
 }
+
+.mermaid { 
+   --md-mermaid-node-fg-color:  #18A0A0;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Markdown==3.3.7
 MarkupSafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.4.2
-mkdocs-material==9.0.12
+mkdocs-material==9.0.13
 mkdocs-material-extensions==1.1.1
 packaging==23.0
 Pygments==2.14.0


### PR DESCRIPTION
See #588

The Mermaid (sequence) diagrams do not follow the LoopDocs' color scheme.
They use the accent color `#526cfe` instead of the primary color `#18A0A0` for actors, participants, steps, box borders...
This is mkdocs-material's expected behavior but is not in line with our color scheme and a bit hard on the eyes.

