### PR TITLE
⚰️ Remove unused mathjax.js include

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,6 @@ markdown_extensions:
         toc_depth: 3
         title: Headers on this Page
 extra_javascript:
-    - javascripts/mathjax.js
     - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 


### PR DESCRIPTION
Suggest removing reference to this non-existent file `docs/javascripts/mathjax.js` as we do not use it nor need it.
This file may prove useful:
- to make an additional configuration (not used, we use the default one)
- with [instant loading](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading) (ie. Single Page Application) that we do not use (yet?).

See:
- https://squidfunk.github.io/mkdocs-material/reference/mathjax/#docsjavascriptsmathjaxjs 
- [Zulip Chat Thread](https://loop.zulipchat.com/#narrow/pm-with/137202,489112,494601-group/near/328308666)