### PR TITLE
Secrets section has been relabeled in Github

### DIFF
--- a/docs/gh-actions/gh-update.md
+++ b/docs/gh-actions/gh-update.md
@@ -121,12 +121,12 @@ Scroll all the way up to the top of the window to see the hamburger menu, click 
 
 Do a horizontal scroll (required on your phone, probably not on a browser) on the row that starts with Code and ends in Settings and tap on Settings. If you don't see Settings (if last item on row is Insights), then you are **not** on your fork or you need to sign in to your GitHub account. You should see `username/LoopWorkspace` with forked from `LoopKit/LoopWorkspace` underneath.
 
-Review the GIF below that shows horizontal scroll to find and tap on Settings, then scroll down on the phone to reach Secrets, open the drop down indicator to see Actions.
+Review the GIF below that shows horizontal scroll to find and tap on Settings, then scroll down on the phone to reach "Secrets and variables", open the drop down indicator to see Actions.
 
 ![phone screens showing the repository settings, secrets and actions](img/phone-with-settings.gif){width="300"}
 {align="center"}
 
-After tapping on Settings -> Secrets -> Actions, keep scrolling on the same screen, past the Action secrets / New repository secret row, until you see your Repository secrets list as shown in the next GIF.
+After tapping on Settings -> Secrets and Variables -> Actions, keep scrolling on the same screen, past the Action secrets / New repository secret row, until you see your Repository secrets list as shown in the next GIF.
 
 ![phone screen showing repository secrets list](img/phone-secret-list.gif){width="300"}
 {align="center"}


### PR DESCRIPTION
When I followed the instructions, it appears that Github has changed the section heading to "Secrets and variables". Updated the docs to reflect this.