### PR TITLE
💬 Add `Gen 3` as an alternative name for Eros pods

### DIFF
--- a/docs/build/step3.md
+++ b/docs/build/step3.md
@@ -156,8 +156,14 @@ Medtronic will not typically sell pump supplies directly to customers who have n
 
 ### Omnipod Eros
 
-Eros pods were launched in 2013 and continue to be sold by Insulet. Insulet has announced they will stop providing Eros pods in the US in December 2023. As far as we know, there are no timelines announced for the discontinuation of Eros pods for other countries. Insulet doesn't specifically call these "Eros" anymore, they just use the term "omnipod system". For clarity, from [Insulet's webpage](https://www.myomnipod.com/about):
+Eros pods (also known as Gen 3) were launched in 2013 and continue to be sold by Insulet. Insulet has announced they will stop providing Eros pods in the US in December 2023. As far as we know, there are no timelines announced for the discontinuation of Eros pods for other countries. Insulet doesn't specifically call these "Eros" anymore, they just use the term "omnipod system". For clarity, from [Insulet's webpage](https://www.omnipod.com/discontinuation):
 
+!!! info "Alternative Names for Omnipod Eros Pump and Pods"
+
+    **Eros** pump is also known as **Classic**, or **UST400**, or *Omnipod Insulin Management* **System**.  
+
+    Pharmacy sites sometimes may refer to the **Eros pods** as **Gen 3** but they are the same exact pods. 
+    
 Eros system has a big PDM that does not look like a phone.
 
 ![img/eros.png](img/eros.png){width="750"}

--- a/docs/faqs/FAQs.md
+++ b/docs/faqs/FAQs.md
@@ -118,6 +118,12 @@ Check your app version by tapping on Loop settings and reading it from the top o
 * Version 2.2.x or earlier supports Omnipod Eros pumps and some older Medtronic pumps
 * Version 2.3 or later supports Omnipod Eros and DASH pumps and some older Medtronic pumps
 
+!!! info "Alternative Names for Omnipod Eros Pump and Pods"
+
+    **Eros** pump is also known as **Classic**, or **UST400**, or *Omnipod Insulin Management* **System**.  
+
+    Pharmacy sites sometimes may refer to the **Eros pods** as **Gen 3** but they are the same exact pods. 
+
 DASH pumps do not require a RileyLink compatible device.
 
 Omnipod 5 is not supported by any version of Loop.

--- a/docs/faqs/glossary.md
+++ b/docs/faqs/glossary.md
@@ -67,7 +67,7 @@ If you hover your mouse or tap on a mobile device, the phrase associated with ea
 
 **dynos**: used to reboot a Nightscout Site
 
-**EmaLink**: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+**EmaLink**: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 
 **Event History**: record of pump events (bolus or temp basal) reported and used by Loop
 
@@ -135,11 +135,11 @@ If you hover your mouse or tap on a mobile device, the phrase associated with ea
 
 **Onboarding**: familiarize new, and existing, Loop users with settings in Loop 3 and ensure the Therapy Settings are all entered and are within safety guardrails
 
-**Omnipod**: Insulet tubeless insulin pump; Loop supports Eros (with RileyLink) and DASH
+**Omnipod**: Insulet tubeless insulin pump; Loop supports Eros (with RileyLink) and DASH.  Eros is also known as Classic, UST400, and System.
 
 **Open Loop**: Loop will not make automated adjustments of insulin delivery but all prediction and recommendation features are available
 
-**OrangeLink**: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+**OrangeLink**: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 
 **OTP**: one-time password, this is used to enable caregivers to securely execute remote commands to a Looper's phone
 
@@ -163,7 +163,7 @@ If you hover your mouse or tap on a mobile device, the phrase associated with ea
 
 **repository**: contains project files and each file's revision history
 
-**RileyLink**: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+**RileyLink**: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 
 **SAGE**: sensor age on Nightscout site
 

--- a/docs/faqs/omnipod-faqs.md
+++ b/docs/faqs/omnipod-faqs.md
@@ -11,6 +11,12 @@ Check your app version by tapping on Loop settings and reading it from the top o
 * Version 2.3 or newer supports Omnipod Eros and DASH pumps (and some older Medtronic pumps)
 * Version 2.2.x or earlier supports Omnipod Eros pumps (and some older Medtronic pumps)
 
+!!! info "Alternative Names for Omnipod Eros Pump and Pods"
+
+    **Eros** pump is also known as **Classic**, or **UST400**, or *Omnipod Insulin Management* **System**.  
+
+    Pharmacy sites sometimes may refer to the **Eros pods** as **Gen 3** but they are the same exact pods. 
+
 DASH pumps do not require a RileyLink compatible device.
 
 Omnipod 5 is not supported by any version of Loop.

--- a/includes/tooltip-list.txt
+++ b/includes/tooltip-list.txt
@@ -28,7 +28,7 @@
 *[DIY]: Do it yourself, a common acronym for the open-source software community (and the maker community)
 *[Dosing Strategy]: chosen method for increased insulin dosing: (1) High Temp Basal or (2) Automatic Bolus with scheduled basal
 *[dynos]: used to reboot a Nightscout Site
-*[EmaLink]: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+*[EmaLink]: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 *[Event History]: record of pump events (bolus or temp basal) reported and used by Loop
 *[Expiration Date]: your Loop app has a finite life, the app warns you starting 3 weeks before the expiration date
 *[fastlane]: used as part of the github Build Action method that enables building Loop without a Mac computer or Xcode
@@ -62,9 +62,9 @@
 *[Modules]: the Loop code uses a number of modules to handle different components of the entire app
 *[Monterey]: operating system for Mac, macOS 12.x
 *[Onboarding]: familiarize new, and existing, Loop users with settings in Loop 3 and ensure the Therapy Settings are all entered and are within safety guardrails
-*[Omnipod]: Insulet tubeless insulin pump; Loop supports Eros (with RileyLink) and DASH
+*[Omnipod]: Insulet tubeless insulin pump; Loop supports Eros (with RileyLink) and DASH.  Eros is also known as Classic, UST400, and System.
 *[Open Loop]: Loop will not make automated adjustments of insulin delivery but all prediction and recommendation features are available
-*[OrangeLink]: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+*[OrangeLink]: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 *[OTP]: one-time password, this is used to enable caregivers to securely execute remote commands to a Looper's phone
 *[Override]: a modification to Loop settings that can change the correction range, the sensitivity (basal, ISF and CR) or both
 *[Package Dependencies]: packages that must be downloaded by Xcode (once) to build the app after downloading the LoopWorkspace to your computer
@@ -76,7 +76,7 @@
 *[Pull Request]: formal method to request changes to a repository
 *[Quit the Loop App]: quit out of the app - different from closing the app - typically you swipe up in the app switcher
 *[repository]: contains project files and each file's revision history
-*[RileyLink]: radio-frequency device Loop uses to control Eros pods and older Medtronic pumps
+*[RileyLink]: radio-frequency device Loop uses to control Eros pods (aka. Gen 3) and older Medtronic pumps
 *[SAGE]: sensor age on Nightscout site
 *[Secrets]: a method to securely embed personal information into your fork of LoopWorkspace to enable GitHub to have access required to build Loop
 *[SHA-1]: Secure Hash Algorithm 1; used to generate an alphanumeric code for commits in git (github)


### PR DESCRIPTION
As `Eros pods` are sometimes referred to as `Gen 3`, add the alternative names in an info box into the [Compatible pumps](https://loopkit.github.io/loopdocs/build/step3/#omnipod-eros) page, that is:
- Eros **pump** alternative names: Classic, UST400, System
- Eros **pods** alternative names: Gen 3

Sources: 
- [Looped Group](https://www.facebook.com/groups/TheLoopedGroup/permalink/3362652070618102/) where 2nd comment lists Omnipod Generation names
- [Omnipod Eros/Gen 3 discontinuation in US](https://www.omnipod.com/discontinuation) lists alternative names for Omnipod Eros

👍 I appreciate the team research on *Gen 3* and Jack Kouloheris insights.