### PR TITLE
⬆️  Upgrade dependencies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
         # Palette toggle for light mode
         - media: "(prefers-color-scheme: light)"
           scheme: default
+          primary: custom
           toggle:
             icon: material/brightness-7
             name: Switch to dark mode
@@ -27,6 +28,7 @@ theme:
         # Palette toggle for dark mode
         - media: "(prefers-color-scheme: dark)"
           scheme: slate
+          primary: custom
           toggle:
             icon: material/brightness-4
             name: Switch to light mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ jsbeautifier==1.14.7
 Markdown==3.3.7
 MarkupSafe==2.1.2
 mergedeep==1.3.4
-mkdocs==1.4.2
-mkdocs-material==9.0.13
+mkdocs==1.4.3
+mkdocs-material==9.1.13
 mkdocs-material-extensions==1.1.1
 packaging==23.0
 Pygments==2.14.0


### PR DESCRIPTION

- Upgrade mkdocs to 1.4.3 from 1.4.2
- Upgrade mkdocs-material to 9.1.13 from 9.0.13
- From version 9.1.7+ mkdocs-material now requires us to explicitly declare that we are using a custom primary color (see 1st link below) in theme/palette/-media/primary:custom

See:
- https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#custom-colors
- https://github.com/squidfunk/mkdocs-material/releases/tag/9.1.7
- https://github.com/squidfunk/mkdocs-material/issues/5427#issuecomment-1527386636
- https://github.com/squidfunk/mkdocs-material/commit/4006b4f04d83ebb20ff095d39457a9a17ad33cae#diff-412e1a9ed151c45c7342cd0952547d731c2c8e60d15e86de2898eb7be5d11095