### PR TITLE
➕ Add `mkdocs-htmlproofer-plugin` to check broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,11 @@ extra_javascript:
 
 plugins:
     - search
+    - htmlproofer:
+        enabled: !ENV [CHECK_BROKEN_LINKS, False]
+        raise_error_after_finish: true
+
+use_directory_urls: !ENV [CHECK_BROKEN_LINKS, True]
 
 nav:
 - Home: 'index.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Markdown==3.3.7
 MarkupSafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.4.3
+mkdocs-htmlproofer-plugin==0.13.1
 mkdocs-material==9.1.13
 mkdocs-material-extensions==1.1.1
 packaging==23.0


### PR DESCRIPTION
The `mkdocs-htmlproofer-plugin` finds broken links.
See: https://github.com/manuzhang/mkdocs-htmlproofer-plugin

To check for broken links in your local repository:
```shell
CHECK_BROKEN_LINKS=true mkdocs serve
```