### PR TITLE
➕ Add mkdocs-unused-files plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,15 @@ plugins:
     - htmlproofer:
         enabled: !ENV [CHECK_BROKEN_LINKS, False]
         raise_error_after_finish: true
+    - unused_files:
+        enabled: !ENV [CHECK_UNUSED_FILES, False]
+        excluded_files:
+            - stylesheets/extra.css
+            - stylesheets/primary-color.css
+            - .DS_Store
+            - gh-actions/.DS_Store
+            - gh-actions/img/.DS_Store
+            - build/.DS_Store            
 
 use_directory_urls: !ENV [CHECK_BROKEN_LINKS, True]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
 certifi==2022.12.7
 charset-normalizer==3.0.1
 click==8.1.3
@@ -16,6 +16,7 @@ mkdocs==1.4.3
 mkdocs-htmlproofer-plugin==0.13.1
 mkdocs-material==9.1.13
 mkdocs-material-extensions==1.1.1
+mkdocs-unused-files==0.1.7
 packaging==23.0
 Pygments==2.14.0
 pymdown-extensions==10.0.1


### PR DESCRIPTION
This PR adds and configure the `mkdocs-unused-files` plugin.  
See https://github.com/wilhelmer/mkdocs-unused-files

> Find unused (orphaned) files in your project.
> 
> This is useful, e.g., if your project contains a lot of image files and you lost track of which images are still in use.


## Usage

```shell
CHECK_UNUSED_FILE=true mkdocs build
```