### PR TITLE
✏️ Fix a Typo in `gh-other-apps` page

### DIFF
--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -27,7 +27,8 @@ Wait until the repository you are interested in adds the capability of GitHub bu
         * Return here and check the table below
         * Use that table to find the link of the repository you will fork
 
-Many graphics on this page show LoopWorkspace, just remember to use the repository for the app you want to build.
+!!! important "Use the repository for the application you are building"
+    Many graphics on this page show `LoopWorkspace`, just remember to use the repository for the app you want to build, that is either `LoopFollow` or `LoopCaregiver`.
 
 ## Fork and Add Secrets
 

--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -97,7 +97,7 @@ The workflows are now displayed: look at the list on the left side similar to th
 
 This step validates most of your six Secrets and provides error messages if it detects an issue with one or more.
 
-1. Click on the "Actions" tab of your LoopWorkspace repository and enable workflows if needed
+1. Click on the "Actions" tab of your `LoopFollow` or `LoopCaregiver`  repository and enable workflows if needed
 1. On the left side, select "1. Validate Secrets".
 1. On the right side, click "Run Workflow", and tap the green `Run workflow` button.
 1. Wait, and within a minute or two you should see a green checkmark indicating the workflow succeeded.


### PR DESCRIPTION
🐛 The [`gh-other-apps` page](https://loopkit.github.io/loopdocs/gh-actions/gh-other-apps/#action-validate-secrets) (section `Action: Validate Secrets`) contains a typo.  
It mentions `LoopWorkspace` instead of `LoopFollow` or `LoopCaregiver`.
That is:
> 1. Click on the "Actions" tab of your **`LoopWorkspace`** repository and enable workflows if needed

should be:

> 1. Click on the "Actions" tab of your **`LoopFollow` or `LoopCaregiver`** repository and enable workflows if needed

✅ This PR fixes it and adds an admonition to make a warning message stand out.