### PR TITLE
Emphasize minimum NS version, 14.2.6, for Remote Commands

### DIFF
--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -961,7 +961,7 @@ Refer to the graphic below for the numbered steps:
     1. You should get several emails
         * one says build succeeded (or failed)
         * one says TestFlight is ready (typically half-hour after build succeeds)
-        * Ignore the one that says you need to fix "issues" in your build. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
+        * Ignore the one that says you need to fix "issues" in your app. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
     1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps).
     1. For each phone/person you would like to support Loop on:
         * Add them in [Users and Access](https://appstoreconnect.apple.com/access/users) on App Store Connect.
@@ -991,7 +991,7 @@ Refer to the graphic below for the first four steps:
 1. You should get several emails
     * one says build succeeded (or failed)
     * one says TestFlight is ready (typically half-hour after build succeeds)
-    * Ignore the one that says you need to fix "issues" in your build. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
+    * Ignore the one that says you need to fix "issues" in your app. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
 1. Your app should eventually appear on [`App Store Connect`](https://appstoreconnect.apple.com/apps).
 
 ## Set Up Users and Access (TestFlight)

--- a/docs/gh-actions/gh-update.md
+++ b/docs/gh-actions/gh-update.md
@@ -99,6 +99,10 @@ If you are using the dev branch, head over to [GitHub Build for dev](#github-bui
 
 Otherwise, head over to [GitHub Errors](gh-errors.md).
 
+#### Apple Email to Ignore
+
+* You can ignore an email from Apple that there are things you must fix in your app - that refers to things to fix before putting that app in the App Store and you will not be doing that
+
 ### Wait for TestFlight
 
 You'll receive an App Store Connect email confirming that the build has completed processing, and a TestFlight email confirming the new app is ready to test.
@@ -109,10 +113,6 @@ You'll receive an App Store Connect email confirming that the build has complete
          * This means Apple did not reply to GitHub as fast as GitHub expected
          * Make sure your developer account is in good standing and that there are no agreements that need to be accepted
         * Repeat the build (previous step)
-
-#### Apple Email to Ignore
-
-* You can ignore an email from Apple that there are things you must fix in your app - that refers to things to fix before putting that app in the App Store and you will not be doing that
 
 The updated Loop app will show up in your TestFlight app on the Looper's phone.
 

--- a/docs/nightscout/remote-overrides.md
+++ b/docs/nightscout/remote-overrides.md
@@ -2,7 +2,7 @@
 
 You can use your *Nightscout* site to remotely set and cancel your override presets in your Loop app. What?! Yes, really...you can set/cancel an override remotely for your child's *Loop*.
 
-If you are using &nbsp;<span translate="no">Loop 3</span>, then you can also send remote commands to add carbs and command a bolus.
+If you are using &nbsp;<span translate="no">Loop 3</span>, then you can also send remote commands to add carbs and command a bolus. **Remote commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Nightscout version does not meet that minimum requirement, remote commands **might** be accepted but if they are, the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the looper's phone.
 
 !!! warning "Remote Nightscout Interface Caveats"
     * Requires **`Apple Push Notifications service (APNs)`** - not available with a Free account
@@ -202,6 +202,9 @@ Don't forget to read [Loopdocs: Overrides](../operation/features/workout.md). Fo
    **Answer**: No. When you set a remote override in *Nightscout*, it starts immediately and lasts for the duration programmed for that override in the *Loop* app. You can only set an override in advance using the *Loop* app.
 
 ## Warnings for Remote Commands
+
+!!! important "Minimum Versions: &nbsp;<span translate="no">Loop 3</span> and &nbsp;<span translate="no">**Nightscout 14.2.6**</span>"
+    If your Nightscout version does not meet that minimum requirement, remote commands **might** be accepted but if they are, the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the looper's phone.
 
 !!! danger "**Duplicate Delivery Risk**"
     We want to highlight a very important risk before you get started.


### PR DESCRIPTION
make it more obvious on page that 14.2.6 is required and what happens if not in use.
Pick up a commit that wasn't pushed before last merge (email that can be ignored with GitHub browser build.)