### PR TITLE
Rework some translation tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ There are still some **issues**, where text is translated whereas it should not,
 
 To improve the automatic translation quality, please follow these rules when writing or updating the documentation. This will provide *Google Translate* with more context and enhance translation accuracy.
 
-#### Rules
+#### Suggestions
 
-Updates to Eric's comments (from Marion)
+Updates to Eric's suggestions (from Marion)
 
 Really - just saying the same thing in different words.
 
@@ -193,12 +193,20 @@ This is in the middle of a sentence that includes&nbsp;<span translate="no">Word
 ```
 If the word is at the end of a line or has other punctuation, the `&nbsp;` can be skipped:
 
-### All about&nbsp;<span translate="no">Word or Phrase</span>
+### All about&nbsp;<span translate="no">Word</span>
 
-This ability to build &nbsp;<span translate="no">Loop</span>, from both a browser and with Mac-Xcode, is wonderful.
+This ability to build&nbsp;<span translate="no">Loop</span>, from both a browser and with Mac-Xcode, is wonderful.
 ```
 
-These words / phrases **do not need** no-translate tags, however, they are typically rendered in italics anyway:
+Be warned that if `&nbsp;` is part of the text in a header, the automatic link doesn't acknowledge the space. The link above would be `#all-aboutword`, not `#all-about-word`.
+
+If you want italic font with `span`, I choose to use underscore instead of asterick to make the word show up as italic font because I think that helps with clarity (opinion only):
+```
+This ability to build&nbsp;_<span translate="no">Loop</span>_, from both a browser and with Mac-Xcode, is wonderful.
+```
+
+
+These words / phrases **do not need** no-translate tags, however, they are typically rendered in italics (use astericks on either side):
 
 * Xcode
 * Mac-Xcode
@@ -209,6 +217,12 @@ These words **do need** no-translate tags (most of the time):
 * Apple
 * Loop
 * LoopKit/Loop
+
+Look out for Loop showing up as buckle, at least in French and Spanish, in translations. That indicates `span` must be used, with the `&nbsp;` required if there is no punctuation mark. Once again, using underscore instead of asterisk in concert with `span` is a preference:
+
+```
+&nbsp;_<span translate="no">Loop</span>_&nbsp;
+```
 
 Common words like `Secrets` that will show up on `GitHub` for Building with Browser should be enclosed in `code` so tooltips will work and the word will be highlighted as important.
 

--- a/docs/build/build-app.md
+++ b/docs/build/build-app.md
@@ -24,7 +24,7 @@ If you do watch this video, please note that you no longer are required to delet
 
 ## Build with Browser
 
-If you previously used [Build with Browser](../gh-actions/gh-overview.md) to install Loop on this phone, you must [Disable Automatic Install from&nbsp;<span translate="no">TestFlight</span>](../gh-actions/gh-deploy.md#disable-automatic-install-fromtestflight) or you will not be able to install on that phone with Xcode.
+If you previously used [Build with Browser](../gh-actions/gh-overview.md) to install Loop on this phone, you must [Disable Automatic Install from *TestFlight*](../gh-actions/gh-deploy.md#disable-automatic-install-from-testflight) or you will not be able to install on that phone with Xcode.
 
 ## Developer Mode
 

--- a/docs/build/code-customization.md
+++ b/docs/build/code-customization.md
@@ -170,7 +170,7 @@ You can customize chart display settings if you want. The original lines of code
 
 The instructions on this page were originally prepared for the Mac-Xcode method. 
 
-The Build with Browser method instructions are similar, but each one is used edit a file using a browser in your&nbsp;<span translate="no">GitHub</span>&nbsp;account as instructed on the [Customize with Browser](../gh-actions/gh-customize.md) page.
+The Build with Browser method instructions are similar, but each one is used edit a file using a browser in your *GitHub* account as instructed on the [Customize with Browser](../gh-actions/gh-customize.md) page.
 
 For each customization, you will be given landmarks to find the correct location in the code. You can choose to search using the `Key_Phrase` or navigate to the file in the folder structure and look for ( ++cmd+l++ # ) the line number. 
 

--- a/docs/build/computer.md
+++ b/docs/build/computer.md
@@ -14,7 +14,7 @@
 
     - You need a paid ($99/year)&nbsp;[<span translate="no">Apple Developer Account</span>](apple-developer.md)
     - You need an account (free) with&nbsp;[<span translate="no">GitHub</span>](https://github.com)
-    - You need a [compatible phone](phone.md) to install the app from&nbsp;<span translate="no">TestFlight</span>
+    - You need a [compatible phone](phone.md) to install the app from *TestFlight*
     - You need a [compatible Pump](pump.md) and [CGM](cgm.md) if you want to actually use the app (and not just explore the app)
 
 !!! abstract "Summary"
@@ -38,7 +38,7 @@ If you have access to a computer with MacOS 13.5 or newer, you can skip ahead to
 
 ## Compatible Versions
 
-The current development version and the next release of&nbsp;<span translate="no">Loop</span>&nbsp;will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
+The current development version and the next release of *Loop* will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
 
 When this page was last updated, macOS 14.0 and Xcode 15.0 were tested to successfully build the app for phones with iOS 15 through iOS 17.0.2.
 

--- a/docs/build/computer.md
+++ b/docs/build/computer.md
@@ -38,7 +38,7 @@ If you have access to a computer with MacOS 13.5 or newer, you can skip ahead to
 
 ## Compatible Versions
 
-The current development version and the next release of *Loop* will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
+The current development version and the next release of&nbsp;_<span translate="no">Loop</span>_&nbsp;will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
 
 When this page was last updated, macOS 14.0 and Xcode 15.0 were tested to successfully build the app for phones with iOS 15 through iOS 17.0.2.
 

--- a/docs/build/loop-data.md
+++ b/docs/build/loop-data.md
@@ -36,7 +36,7 @@ Take some time to familiarize yourself with these data options and choose your p
     * For those who assist someone who is Looping, Nightscout enables the caregiver to provide remote commands to the Looper's phone
         * Loop 2 allows overrides to be enabled or disabled remotely
         * Loop 3 allows remote commands for carbs, bolus or overrides
-        * The &nbsp;[*Loop Caregiver*](../nightscout/loop-caregiver.md) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
+        * The [*Loop Caregiver*](../nightscout/loop-caregiver.md) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
 
 Nightscout options include free or nominal cost sites you build yourself or there are several Nightscout as a Service vendors who provide turn-key sites for a monthly fee. Links to the options are found in the [Nightscout: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
 

--- a/docs/build/loop-data.md
+++ b/docs/build/loop-data.md
@@ -36,7 +36,7 @@ Take some time to familiarize yourself with these data options and choose your p
     * For those who assist someone who is Looping, Nightscout enables the caregiver to provide remote commands to the Looper's phone
         * Loop 2 allows overrides to be enabled or disabled remotely
         * Loop 3 allows remote commands for carbs, bolus or overrides
-        * The &nbsp;[<span translate="no">Loop Caregiver</span>](../nightscout/loop-caregiver.md) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
+        * The &nbsp;[*Loop Caregiver*](../nightscout/loop-caregiver.md) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
 
 Nightscout options include free or nominal cost sites you build yourself or there are several Nightscout as a Service vendors who provide turn-key sites for a monthly fee. Links to the options are found in the [Nightscout: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
 

--- a/docs/build/xcode-version.md
+++ b/docs/build/xcode-version.md
@@ -77,7 +77,7 @@ After any update of [macOS](computer.md#check-your-macos-version) or Xcode, it i
 
 ### Compatible Versions#
 
-The current development version and the next release of&nbsp;<span translate="no">Loop</span>&nbsp;will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
+The current development version and the next release of *Loop* will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
 
 When this page was last updated, macOS 14.0 and Xcode 15.0 were tested to successfully build the app for phones with iOS 15 through iOS 17.0.2.
 

--- a/docs/build/xcode-version.md
+++ b/docs/build/xcode-version.md
@@ -77,7 +77,7 @@ After any update of [macOS](computer.md#check-your-macos-version) or Xcode, it i
 
 ### Compatible Versions#
 
-The current development version and the next release of *Loop* will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
+The current development version and the next release of&nbsp;_<span translate="no">Loop</span>_&nbsp;will require Xcode version 15 regardless of the iOS on the phone. This requires macOS 13.5 or higher. As an alternative, use [Build with Browser](../gh-actions/gh-overview.md), which supports iOS 15, 16, and 17.
 
 When this page was last updated, macOS 14.0 and Xcode 15.0 were tested to successfully build the app for phones with iOS 15 through iOS 17.0.2.
 

--- a/docs/faqs/algorithm-faqs.md
+++ b/docs/faqs/algorithm-faqs.md
@@ -46,7 +46,7 @@ IOB is plotted on the [Active Insulin Chart](../loop-3/displays-v3.md#active-ins
 
 ## How do Delivery Limits Affect Automatic Dosing?
 
-With each cycle, <span translate="no">Loop</span>&nbsp;generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
+With each cycle, *Loop* generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
 
 * The nearest 3 hours has more influence on the recommendation than the later 3 hours, but the entire 6 hours is considered
 * The automated response to a negative recommended dose is to reduce basal rate, typically to zero

--- a/docs/faqs/algorithm-faqs.md
+++ b/docs/faqs/algorithm-faqs.md
@@ -46,7 +46,7 @@ IOB is plotted on the [Active Insulin Chart](../loop-3/displays-v3.md#active-ins
 
 ## How do Delivery Limits Affect Automatic Dosing?
 
-With each cycle, *Loop* generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
+With each cycle, _<span translate="no">Loop</span>_&nbsp;generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
 
 * The nearest 3 hours has more influence on the recommendation than the later 3 hours, but the entire 6 hours is considered
 * The automated response to a negative recommended dose is to reduce basal rate, typically to zero

--- a/docs/faqs/new-phone.md
+++ b/docs/faqs/new-phone.md
@@ -1,8 +1,8 @@
 ## Overview
 
-Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the *Loop* icon will appear, but the app will not open until you install *Loop* from either [*TestFlight*](../gh-actions/gh-deploy.md#install-app-with-testflight) or [*Mac-Xcode*](../build/build-app.md).
+Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the&nbsp;_<span translate="no">Loop</span>_&nbsp;icon will appear, but the app will not open until you install *Loop* from either [*TestFlight*](../gh-actions/gh-deploy.md#install-app-with-testflight) or [*Mac-Xcode*](../build/build-app.md).
 
-Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and Medtronic pumps can be controlled on the pump itself. Use your backup plan until you can get *Loop* running on a new phone.
+Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and *Medtronic* pumps can be controlled on the pump itself. Use your backup plan until you can get&nbsp;_<span translate="no">Loop</span>_&nbsp;running on a new phone.
 
 ### Forced iOS Update
 
@@ -18,23 +18,23 @@ If you still have your old phone, you can prepare before switching to the new ph
 
 If you don't have your old phone, hopefully you have an iCloud backup and can use that to transfer your information to your new phone.
 
-!!! tip "Keep the Old Phone Until *Loop* is Working on the New One"
+!!! tip "Keep the Old Phone Until the *Loop* app is Working on the New One"
     Even if you plan to turn your old phone in for a rebate, you can ask to keep the old one for a week or two. Most vendors will agree to this.
 
 Update your old phone to the latest iOS the hardware supports - this simplifies the automatic transfer process *Apple* provides to move all your data and apps from your old phone to your new phone.
 
-!!! abstract "New Phone Checklist for *Browser Build*"
+!!! abstract "New Phone Checklist for Build with Browser"
     * The *Loop* app will install from *TestFlight* onto the most recent iOS
-    * If a new version of *Loop* is available, we recommend updating and building to the latest [Update with Browser](../gh-actions/gh-update.md)
+    * If a new version is available, we recommend updating and building to the latest [Update with Browser](../gh-actions/gh-update.md)
 
-!!! abstract "New Phone Checklist for <span translate="no">*Mac-Xcode*</span>&nbsp;Build"
+!!! abstract "New Phone Checklist for *Mac-Xcode* Build"
     * Are your [Mac and Xcode versions](../build/xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other) compatible with the latest iOS version?
-    * If not, you should configure and build the app with [Browser Build](../gh-actions/gh-overview.md)
+    * If not, you should configure and build the app with [Build with Browser](../gh-actions/gh-overview.md)
 
 ### Different Developer ID
 
 !!! important "Different Developer ID"
-    If you need to build *Loop* with a different developer ID on the new phone, the settings and pump information will **not** transfer.
+    If you need to build the *Loop* app with a different developer ID on the new phone, the settings and pump information will **not** transfer.
 
     * The new app that you build with the new Developer ID will open and you can [Onboard](../loop-3/onboarding.md)
     * The old app will still be on the phone: find it and delete it to avoid confusion
@@ -48,27 +48,27 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
     * Use an [iCloud back-up](https://support.apple.com/en-us/HT210217) for the transfer
     * Use both devices with [Quick Start](https://support.apple.com/en-us/HT210216) to transfer from the old to the new phone
 
-### *Loop* with the Old Phone
+### Use the Old Phone until Ready
 
-If you cannot keep the old phone, or it is not available, then skip ahead to the [*Loop* with the New Phone](#loopwith-the-new-phone).
+If you cannot keep the old phone, or it is not available, then skip ahead to the [Use the New Phone](#use-the-new-phone).
 
-* You can use the old phone to *Loop* until you are ready to switch
+* You can use the old phone to&nbsp;_<span translate="no">Loop</span>_&nbsp;until you are ready to switch
 * Use WiFi with the old phone and use your new phone as a cellular hot-spot as needed
 * Keep the CGM on the old phone
     * If using Dexcom, use the Dexcom app on the old phone
-    * If using&nbsp;<span translate="no">Libre</span>;, the&nbsp;<span translate="no">Libre</span>&nbsp;is connected to *Loop* on the old phone
+    * If using *Libre*, the *Libre CGM* is connected to the old phone
 
-## *Loop* with the New Phone
+## Use the New Phone
 
-### Install *Loop*
+### Install the *Loop* App
 
-It is easier if you transfer information from the old phone to the new phone before you install and open *Loop* on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new *Loop* app.
+It is easier if you transfer information from the old phone to the new phone before you install and open&nbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new *Loop* app.
 
 1. When you transfer information from your old phone to your new phone, all the *Loop* settings files get copied to the new device including information about the pod
     * If the timing works, you can keep the pod if you switch to using the new phone for *Loop* after the information transfer and before changing pods with the old phone
     * If this is not possible, you will need to start a new pod with the new phone
-    * Medtronic users will have all their information transferred but will only have one phone connected to the RileyLink
-1. Install *Loop* on the new phone (all your settings should be there)
+    * *Medtronic* users will have all their information transferred but will only have one phone connected to the *RileyLink*
+1. Installnbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone (all your settings should be there)
     * [Install from *TestFlight*](#install-from-testflight)<br>or
     * [Build using *Mac-Xcode*](#build-using-mac-xcode)
 1.  As soon as you install the *Loop* app on the new phone, go ahead and disable <code>Closed Loop</code>.
@@ -86,14 +86,14 @@ It is easier if you transfer information from the old phone to the new phone bef
 * Plug in the new phone to the computer (trust phone/computer) and hit build
 * Build the app on the new phone
 
-### Prepare to Change *Loop* Phones
+### Prepare to Change Phones
 
 On old phone (if available):
 
-1. *Loop* app, turn off the slider for the *RileyLink* if using *Medtronic* or *Eros Pods*
+1. _<span translate="no">Loop</span>_&nbsp;app, turn off the slider for the *RileyLink* if using *Medtronic* or *Eros Pods*
     * Do not delete the pump; if using pods, this cannot be reversed
 1. Phone Settings, *Bluetooth*
-    * Forget the connections to the CGM (Dexcom or&nbsp;<span translate="no">Libre</span>)
+    * Forget the connections to the CGM (*Dexcom* or *Libre*)
     * Do not forget anything that says *TWI_BOARD or *NXP_BLE*(this is your *DASH* pod)
 1. Phone Settings, *Bluetooth*: Disable *Bluetooth*
 
@@ -119,7 +119,7 @@ It is now time to transfer the CGM to the new phone.
 The Dexcom app might have transferred successfully, but it’s not a bad idea to install that fresh from the App Store on the new phone. Doing so may be required.
 
 * You need your Dexcom Transmitter ID or 4-digit code (for G7)
-* On the new phone, in *Loop*, delete Dexcom as your CGM so you can pair the new phone to the Dexcom app
+* On the new phone, in&nbsp;_<span translate="no">Loop</span>_, delete Dexcom as your CGM so you can pair the new phone to the Dexcom app
 * On the new phone, open the Dexcom app and pair to the transmitter (G5, G6 or One) or enter the four-digit code for G7
     * You can keep using your current sensor session
     * You indicate you are starting a new sensor (it’s not really new)
@@ -140,7 +140,7 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
 * On the new phone, in *Loop*, add&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
 * Wait for&nbsp;<span translate="no">Libre</span>&nbsp;to connect
 
-### Ready to *Loop*
+### Check out the Transfer
 
 1. Keep closed loop disabled until you complete the full transfer and checkout.
 
@@ -156,18 +156,18 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
 
 1. Check COB and IOB
 
-    !!! important "<span translate="no">Apple Health</span>&nbsp;History"
+    !!! important "_<span translate="no">Apple Health</span>_&nbsp;History"
         Your COB and IOB may not carry over to your new phone.
 
-        *Loop* reads from&nbsp;<span translate="no">Apple Health</span>&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
+        *Loop* reads from&nbsp;_<span translate="no">Apple Health</span>_&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
 
         If your COB and IOB show up as blank, you can go open loop for 3 to 6 hours.
         
         If you are impatient, you can try this but be cautious:
         
-        * Add back your insulin via&nbsp;<span translate="no">Apple Health</span>&nbsp;(on your new phone) to the time that the boluses and positive temp basals were recorded on your old phone:&nbsp;<span translate="no">Apple Health</span>&nbsp;, Insulin Delivery, Add Data.
-        * Wait about 5 minutes for that insulin to show up in *Loop* as Active Insulin
-        * Finally, add the Carbohydrates to *Loop* by entering them in your Add Carb Entry screen and rolling back the Date/Time wheel to the time of the original entry(ies)
+        * Add back your insulin via *Apple Health* (on your new phone) to the time that the boluses and positive temp basals were recorded on your old phone: *Apple Health*, Insulin Delivery, Add Data.
+        * Wait about 5 minutes for that insulin to show up in the *Loop* app as Active Insulin
+        * Finally, add the Carbohydrates by entering them in your Add Carb Entry screen and rolling back the Date/Time wheel to the time of the original entry(ies)
 
 1. Once you are happy with the configuration of *Loop* on your new phone, go ahead and enable closed loop mode again.
 

--- a/docs/faqs/new-phone.md
+++ b/docs/faqs/new-phone.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the *Loop* icon will appear, but the app will not open until you install *Loop* from either *TestFlight* (*GitHub* Build) or&nbsp;<span translate="no">Xcode</span>&nbsp;(<span translate="no">Mac-Xcode</span>&nbsp;Build).
+Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the *Loop* icon will appear, but the app will not open until you install *Loop* from either [*TestFlight*](../gh-actions/gh-deploy.md#install-app-with-testflight) or [*Mac-Xcode*](../build/build-app.md).
 
 Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and Medtronic pumps can be controlled on the pump itself. Use your backup plan until you can get *Loop* running on a new phone.
 
@@ -27,7 +27,7 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
     * The *Loop* app will install from *TestFlight* onto the most recent iOS
     * If a new version of *Loop* is available, we recommend updating and building to the latest [Update with Browser](../gh-actions/gh-update.md)
 
-!!! abstract "New Phone Checklist for <span translate="no">Mac-Xcode</span>&nbsp;Build"
+!!! abstract "New Phone Checklist for <span translate="no">*Mac-Xcode*</span>&nbsp;Build"
     * Are your [Mac and Xcode versions](../build/xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other) compatible with the latest iOS version?
     * If not, you should configure and build the app with [Browser Build](../gh-actions/gh-overview.md)
 
@@ -69,35 +69,37 @@ It is easier if you transfer information from the old phone to the new phone bef
     * If this is not possible, you will need to start a new pod with the new phone
     * Medtronic users will have all their information transferred but will only have one phone connected to the RileyLink
 1. Install *Loop* on the new phone (all your settings should be there)
-    * Install from&nbsp;[<span translate="no">TestFlight</span>](#install-from-testflight)&nbsp;for *GitHub*  Build or from Xcode for&nbsp;[<span translate="no">Mac-Xcode</span>&nbsp;Build](#build-using-mac-xcode)
-1.  As soon as you install *Loop* on the new phone, go ahead and disable Closed Loop.
-    * Keep closed loop disabled until you complete the full transfer and checkout.
+    * [Install from *TestFlight*](#install-from-testflight)<br>or
+    * [Build using *Mac-Xcode*](#build-using-mac-xcode)
+1.  As soon as you install the *Loop* app on the new phone, go ahead and disable <code>Closed Loop</code>.
+    * Keep <code>Closed Loop</code> disabled until you complete the full transfer and checkout.
 
 #### Install from *TestFlight*
 
 * Open *TestFlight* app on new phone
-* Install *Loop* on your new phone from *TestFlight*
+* Install the app on your new phone from *TestFlight*
+* If necessary, review [*TestFlight* for a Child](../gh-actions/gh-deploy.md#testflight-for-a-child)
 
-#### Build using Mac-Xcode
+#### Build using **Mac-Xcode**
 
-* Open Xcode – use the same build as you used for the old phone
+* Open *Xcode* – use the same build as you used for the old phone
 * Plug in the new phone to the computer (trust phone/computer) and hit build
-* Build *Loop* on the new phone
+* Build the app on the new phone
 
 ### Prepare to Change *Loop* Phones
 
 On old phone (if available):
 
-1. *Loop* app, turn off the slider for the RileyLink if using Medtronic or Eros Pods
+1. *Loop* app, turn off the slider for the *RileyLink* if using *Medtronic* or *Eros Pods*
     * Do not delete the pump; if using pods, this cannot be reversed
-1. Phone Settings, Bluetooth
+1. Phone Settings, *Bluetooth*
     * Forget the connections to the CGM (Dexcom or&nbsp;<span translate="no">Libre</span>)
-    * Do not forget anything that says&nbsp;<span translate="no">TWI_BOARD</span>&nbsp;or&nbsp;<span translate="no">NXP_BLE</span>&nbsp;(this is your&nbsp;<span translate="no">DASH</span>&nbsp;pod)
-1. Phone Settings, Bluetooth: Disable Bluetooth
+    * Do not forget anything that says *TWI_BOARD or *NXP_BLE*(this is your *DASH* pod)
+1. Phone Settings, *Bluetooth*: Disable *Bluetooth*
 
 ### Transfer Pump
 
-Bluetooth must be off on the old phone.
+*Bluetooth* must be off on the old phone.
 
 * On the new phone, examine the pump status
     * If everything transfered, your new phone should be communicating with your pump
@@ -175,8 +177,8 @@ Once you are using *Loop* on your new phone, you can delete the pump from the ol
 
 * On the old phone, in the *Loop* app:
     * Delete the pump
-* If using DASH pods with direct Bluetooth connection to your phone
-    * Go into the old phone Settings -> Bluetooth and turn it back on
+* If using DASH pods with direct *Bluetooth* connection to your phone
+    * Go into the old phone Settings -> *Bluetooth* and turn it back on
     * Forget the pod; it will show up as TWI_BOARD or NXP_BLE
 
 You can either keep the Old Phone as a backup, reset it and turn it in for credit or give it to some deserving individual.

--- a/docs/faqs/new-phone.md
+++ b/docs/faqs/new-phone.md
@@ -1,12 +1,12 @@
 ## Overview
 
-Changing phones means you have to rebuild the&nbsp;<span translate="no">Loop</span>&nbsp;app onto the new phone. When you transfer information from your old phone to your new one, all your&nbsp;<span translate="no">Loop</span>&nbsp;information is included and the&nbsp;<span translate="no">Loop</span>&nbsp;icon will appear, but the app will not open until you install&nbsp;<span translate="no">Loop</span>&nbsp;from either&nbsp;<span translate="no">TestFlight</span>&nbsp;(<span translate="no">GitHub</span>&nbsp;Build) or&nbsp;<span translate="no">Xcode</span>&nbsp;(<span translate="no">Mac-Xcode</span>&nbsp;Build).
+Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the *Loop* icon will appear, but the app will not open until you install *Loop* from either *TestFlight* (*GitHub* Build) or&nbsp;<span translate="no">Xcode</span>&nbsp;(<span translate="no">Mac-Xcode</span>&nbsp;Build).
 
-Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and Medtronic pumps can be controlled on the pump itself. Use your backup plan until you can get&nbsp;<span translate="no">Loop</span>&nbsp;running on a new phone.
+Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and Medtronic pumps can be controlled on the pump itself. Use your backup plan until you can get *Loop* running on a new phone.
 
 ### Forced iOS Update
 
-When you change phones,&nbsp;<span translate="no">Apple</span>&nbsp;will force you to the latest iOS version available for your new phone.
+When you change phones, *Apple* will force you to the latest iOS version available for your new phone.
 
 ### Prepare Before Upgrade
 
@@ -14,18 +14,18 @@ If you are using Dexcom G7, make sure you keep the 4-digit code for your current
 
 If you still have your old phone, you can prepare before switching to the new phone.
 
-* Be sure to record your&nbsp;<span translate="no">Loop</span>&nbsp;Settings (screenshots work well)
+* Be sure to record your *Loop* Settings (screenshots work well)
 
 If you don't have your old phone, hopefully you have an iCloud backup and can use that to transfer your information to your new phone.
 
-!!! tip "Keep the Old Phone Until&nbsp;<span translate="no">Loop</span>&nbsp;is Working on the New One"
+!!! tip "Keep the Old Phone Until *Loop* is Working on the New One"
     Even if you plan to turn your old phone in for a rebate, you can ask to keep the old one for a week or two. Most vendors will agree to this.
 
-Update your old phone to the latest iOS the hardware supports - this simplifies the automatic transfer process&nbsp;<span translate="no">Apple</span>&nbsp;provides to move all your data and apps from your old phone to your new phone.
+Update your old phone to the latest iOS the hardware supports - this simplifies the automatic transfer process *Apple* provides to move all your data and apps from your old phone to your new phone.
 
 !!! abstract "New Phone Checklist for *Browser Build*"
-    * The&nbsp;<span translate="no">Loop</span>&nbsp;app will install from&nbsp;<span translate="no">TestFlight</span>&nbsp;onto the most recent iOS
-    * If a new version of&nbsp;<span translate="no">Loop</span>&nbsp;is available, we recommend updating and building to the latest [Update with Browser](../gh-actions/gh-update.md)
+    * The *Loop* app will install from *TestFlight* onto the most recent iOS
+    * If a new version of *Loop* is available, we recommend updating and building to the latest [Update with Browser](../gh-actions/gh-update.md)
 
 !!! abstract "New Phone Checklist for <span translate="no">Mac-Xcode</span>&nbsp;Build"
     * Are your [Mac and Xcode versions](../build/xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other) compatible with the latest iOS version?
@@ -34,7 +34,7 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
 ### Different Developer ID
 
 !!! important "Different Developer ID"
-    If you need to build&nbsp;<span translate="no">Loop</span>&nbsp;with a different developer ID on the new phone, the settings and pump information will **not** transfer.
+    If you need to build *Loop* with a different developer ID on the new phone, the settings and pump information will **not** transfer.
 
     * The new app that you build with the new Developer ID will open and you can [Onboard](../loop-3/onboarding.md)
     * The old app will still be on the phone: find it and delete it to avoid confusion
@@ -42,53 +42,53 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
 ## Procure a New Phone
 
 1. Procure the new phone and keep the old one (if possible)
-    * [<span translate="no">Loop</span>&nbsp;with the old phone](#loopwith-the-old-phone) until it is convenient to switch to the new phone
+    * [*Loop* with the old phone](#loopwith-the-old-phone) until it is convenient to switch to the new phone
 1. Transfer your information to your new phone
     * Let the new phone vendor help you
     * Use an [iCloud back-up](https://support.apple.com/en-us/HT210217) for the transfer
     * Use both devices with [Quick Start](https://support.apple.com/en-us/HT210216) to transfer from the old to the new phone
 
-### <span translate="no">Loop</span>&nbsp;with the Old Phone
+### *Loop* with the Old Phone
 
-If you cannot keep the old phone, or it is not available, then skip ahead to the [<span translate="no">Loop</span>&nbsp;with the New Phone](#loopwith-the-new-phone).
+If you cannot keep the old phone, or it is not available, then skip ahead to the [*Loop* with the New Phone](#loopwith-the-new-phone).
 
-* You can use the old phone to&nbsp;<span translate="no">Loop</span>&nbsp;until you are ready to switch
+* You can use the old phone to *Loop* until you are ready to switch
 * Use WiFi with the old phone and use your new phone as a cellular hot-spot as needed
 * Keep the CGM on the old phone
     * If using Dexcom, use the Dexcom app on the old phone
-    * If using&nbsp;<span translate="no">Libre</span>;, the&nbsp;<span translate="no">Libre</span>&nbsp;is connected to&nbsp;<span translate="no">Loop</span>&nbsp;on the old phone
+    * If using&nbsp;<span translate="no">Libre</span>;, the&nbsp;<span translate="no">Libre</span>&nbsp;is connected to *Loop* on the old phone
 
-## <span translate="no">Loop</span>&nbsp;with the New Phone
+## *Loop* with the New Phone
 
-### Install&nbsp;<span translate="no">Loop</span>
+### Install *Loop*
 
-It is easier if you transfer information from the old phone to the new phone before you install and open&nbsp;<span translate="no">Loop</span>&nbsp;on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new&nbsp;<span translate="no">Loop</span>&nbsp;app.
+It is easier if you transfer information from the old phone to the new phone before you install and open *Loop* on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new *Loop* app.
 
-1. When you transfer information from your old phone to your new phone, all the&nbsp;<span translate="no">Loop</span>&nbsp;settings files get copied to the new device including information about the pod
-    * If the timing works, you can keep the pod if you switch to using the new phone for&nbsp;<span translate="no">Loop</span>&nbsp;after the information transfer and before changing pods with the old phone
+1. When you transfer information from your old phone to your new phone, all the *Loop* settings files get copied to the new device including information about the pod
+    * If the timing works, you can keep the pod if you switch to using the new phone for *Loop* after the information transfer and before changing pods with the old phone
     * If this is not possible, you will need to start a new pod with the new phone
     * Medtronic users will have all their information transferred but will only have one phone connected to the RileyLink
-1. Install&nbsp;<span translate="no">Loop</span>&nbsp;on the new phone (all your settings should be there)
-    * Install from&nbsp;[<span translate="no">TestFlight</span>](#install-fromtestflight)&nbsp;for&nbsp;<span translate="no">GitHub</span>&nbsp; Build or from Xcode for&nbsp;[<span translate="no">Mac-Xcode</span>&nbsp;Build](#build-using-mac-xcode)
-1.  As soon as you install&nbsp;<span translate="no">Loop</span>&nbsp;on the new phone, go ahead and disable Closed Loop.
+1. Install *Loop* on the new phone (all your settings should be there)
+    * Install from&nbsp;[<span translate="no">TestFlight</span>](#install-from-testflight)&nbsp;for *GitHub*  Build or from Xcode for&nbsp;[<span translate="no">Mac-Xcode</span>&nbsp;Build](#build-using-mac-xcode)
+1.  As soon as you install *Loop* on the new phone, go ahead and disable Closed Loop.
     * Keep closed loop disabled until you complete the full transfer and checkout.
 
-#### Install from&nbsp;<span translate="no">TestFlight</span>
+#### Install from *TestFlight*
 
-* Open&nbsp;<span translate="no">TestFlight</span>&nbsp;app on new phone
-* Install&nbsp;<span translate="no">Loop</span>&nbsp;on your new phone from&nbsp;<span translate="no">TestFlight</span>
+* Open *TestFlight* app on new phone
+* Install *Loop* on your new phone from *TestFlight*
 
 #### Build using Mac-Xcode
 
 * Open Xcode – use the same build as you used for the old phone
 * Plug in the new phone to the computer (trust phone/computer) and hit build
-* Build&nbsp;<span translate="no">Loop</span>&nbsp;on the new phone
+* Build *Loop* on the new phone
 
-### Prepare to Change&nbsp;<span translate="no">Loop</span>&nbsp;Phones
+### Prepare to Change *Loop* Phones
 
 On old phone (if available):
 
-1. <span translate="no">Loop</span>&nbsp;app, turn off the slider for the RileyLink if using Medtronic or Eros Pods
+1. *Loop* app, turn off the slider for the RileyLink if using Medtronic or Eros Pods
     * Do not delete the pump; if using pods, this cannot be reversed
 1. Phone Settings, Bluetooth
     * Forget the connections to the CGM (Dexcom or&nbsp;<span translate="no">Libre</span>)
@@ -117,7 +117,7 @@ It is now time to transfer the CGM to the new phone.
 The Dexcom app might have transferred successfully, but it’s not a bad idea to install that fresh from the App Store on the new phone. Doing so may be required.
 
 * You need your Dexcom Transmitter ID or 4-digit code (for G7)
-* On the new phone, in&nbsp;<span translate="no">Loop</span>, delete Dexcom as your CGM so you can pair the new phone to the Dexcom app
+* On the new phone, in *Loop*, delete Dexcom as your CGM so you can pair the new phone to the Dexcom app
 * On the new phone, open the Dexcom app and pair to the transmitter (G5, G6 or One) or enter the four-digit code for G7
     * You can keep using your current sensor session
     * You indicate you are starting a new sensor (it’s not really new)
@@ -128,17 +128,17 @@ The Dexcom app might have transferred successfully, but it’s not a bad idea to
     * Within 5 to 10 minutes, Dexcom app should read the current session and keep going
 
 * Wait for Dexcom to connect
-* On new phone, add the CGM to&nbsp;<span translate="no">Loop</span>
+* On new phone, add the CGM to *Loop*
 
 #### <span translate="no">Libre</span>&nbsp;CGM
 
 Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Suggested procedures from the community are encouraged.
 
-* On the new phone, in&nbsp;<span translate="no">Loop</span>, delete&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
-* On the new phone, in&nbsp;<span translate="no">Loop</span>, add&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
+* On the new phone, in *Loop*, delete&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
+* On the new phone, in *Loop*, add&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
 * Wait for&nbsp;<span translate="no">Libre</span>&nbsp;to connect
 
-### Ready to&nbsp;<span translate="no">Loop</span>
+### Ready to *Loop*
 
 1. Keep closed loop disabled until you complete the full transfer and checkout.
 
@@ -146,9 +146,9 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
         * Make sure all the basal, ISF, CR, Insulin Selection and ranges are correct
         * Check Dosing Strategy selection
         * Check permissions and notification settings
-        * Check Focus mode settings - make sure&nbsp;<span translate="no">Loop</span>&nbsp;and CGM apps have permission for all Focus modes
+        * Check Focus mode settings - make sure *Loop* and CGM apps have permission for all Focus modes
 
-1. Do a manual bolus of the smallest possible amount to make sure&nbsp;<span translate="no">Loop</span>&nbsp;and pump are working.
+1. Do a manual bolus of the smallest possible amount to make sure *Loop* and pump are working.
 
 1. Monitor CGM values to ensure new readings are coming in.
 
@@ -157,23 +157,23 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
     !!! important "<span translate="no">Apple Health</span>&nbsp;History"
         Your COB and IOB may not carry over to your new phone.
 
-        <span translate="no">Loop</span>&nbsp;reads from&nbsp;<span translate="no">Apple Health</span>&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
+        *Loop* reads from&nbsp;<span translate="no">Apple Health</span>&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
 
         If your COB and IOB show up as blank, you can go open loop for 3 to 6 hours.
         
         If you are impatient, you can try this but be cautious:
         
         * Add back your insulin via&nbsp;<span translate="no">Apple Health</span>&nbsp;(on your new phone) to the time that the boluses and positive temp basals were recorded on your old phone:&nbsp;<span translate="no">Apple Health</span>&nbsp;, Insulin Delivery, Add Data.
-        * Wait about 5 minutes for that insulin to show up in&nbsp;<span translate="no">Loop</span>&nbsp;as Active Insulin
-        * Finally, add the Carbohydrates to&nbsp;<span translate="no">Loop</span>&nbsp;by entering them in your Add Carb Entry screen and rolling back the Date/Time wheel to the time of the original entry(ies)
+        * Wait about 5 minutes for that insulin to show up in *Loop* as Active Insulin
+        * Finally, add the Carbohydrates to *Loop* by entering them in your Add Carb Entry screen and rolling back the Date/Time wheel to the time of the original entry(ies)
 
-1. Once you are happy with the configuration of&nbsp;<span translate="no">Loop</span>&nbsp;on your new phone, go ahead and enable closed loop mode again.
+1. Once you are happy with the configuration of *Loop* on your new phone, go ahead and enable closed loop mode again.
 
 ### Old Phone
 
-Once you are using&nbsp;<span translate="no">Loop</span>&nbsp;on your new phone, you can delete the pump from the old phone.
+Once you are using *Loop* on your new phone, you can delete the pump from the old phone.
 
-* On the old phone, in the&nbsp;<span translate="no">Loop</span>&nbsp;app:
+* On the old phone, in the *Loop* app:
     * Delete the pump
 * If using DASH pods with direct Bluetooth connection to your phone
     * Go into the old phone Settings -> Bluetooth and turn it back on

--- a/docs/faqs/new-phone.md
+++ b/docs/faqs/new-phone.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your *Loop* information is included and the&nbsp;_<span translate="no">Loop</span>_&nbsp;icon will appear, but the app will not open until you install *Loop* from either [*TestFlight*](../gh-actions/gh-deploy.md#install-app-with-testflight) or [*Mac-Xcode*](../build/build-app.md).
+Changing phones means you have to rebuild the *Loop* app onto the new phone. When you transfer information from your old phone to your new one, all your&nbsp;_<span translate="no">Loop</span>_&nbsp;information is included and the&nbsp;_<span translate="no">Loop</span>_&nbsp;icon will appear, but the app will not open until you install&nbsp;_<span translate="no">Loop</span>_&nbsp;from either [*TestFlight*](../gh-actions/gh-deploy.md#install-app-with-testflight) or [*Mac-Xcode*](../build/build-app.md).
 
 Some people don't have access to their old phone. There are instructions for handling that on this page. It makes the whole process more stressful, but remember, pods continue to deliver basal rate and *Medtronic* pumps can be controlled on the pump itself. Use your backup plan until you can get&nbsp;_<span translate="no">Loop</span>_&nbsp;running on a new phone.
 
@@ -14,7 +14,7 @@ If you are using Dexcom G7, make sure you keep the 4-digit code for your current
 
 If you still have your old phone, you can prepare before switching to the new phone.
 
-* Be sure to record your *Loop* Settings (screenshots work well)
+* Be sure to record your&nbsp;_<span translate="no">Loop</span>_&nbsp;Settings (screenshots work well)
 
 If you don't have your old phone, hopefully you have an iCloud backup and can use that to transfer your information to your new phone.
 
@@ -42,7 +42,7 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
 ## Procure a New Phone
 
 1. Procure the new phone and keep the old one (if possible)
-    * [*Loop* with the old phone](#loopwith-the-old-phone) until it is convenient to switch to the new phone
+    * [Use the Old Phone](#use-the-old-phone-until-ready) until it is convenient to switch to the new phone
 1. Transfer your information to your new phone
     * Let the new phone vendor help you
     * Use an [iCloud back-up](https://support.apple.com/en-us/HT210217) for the transfer
@@ -62,13 +62,13 @@ If you cannot keep the old phone, or it is not available, then skip ahead to the
 
 ### Install the *Loop* App
 
-It is easier if you transfer information from the old phone to the new phone before you install and open&nbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new *Loop* app.
+It is easier if you transfer information from the old phone to the new phone before you install and open&nbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone. If this is not possible, then you will do the normal [Onboarding](../loop-3/onboarding.md) for a new&nbsp;_<span translate="no">Loop</span>_&nbsp;app.
 
-1. When you transfer information from your old phone to your new phone, all the *Loop* settings files get copied to the new device including information about the pod
-    * If the timing works, you can keep the pod if you switch to using the new phone for *Loop* after the information transfer and before changing pods with the old phone
+1. When you transfer information from your old phone to your new phone, all the&nbsp;_<span translate="no">Loop</span>_&nbsp;settings files get copied to the new device including information about the pod
+    * If the timing works, you can keep the pod if you switch to using the new phone for&nbsp;_<span translate="no">Loop</span>_&nbsp;after the information transfer and before changing pods with the old phone
     * If this is not possible, you will need to start a new pod with the new phone
     * *Medtronic* users will have all their information transferred but will only have one phone connected to the *RileyLink*
-1. Installnbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone (all your settings should be there)
+1. Install&nbsp;_<span translate="no">Loop</span>_&nbsp;on the new phone (all your settings should be there)
     * [Install from *TestFlight*](#install-from-testflight)<br>or
     * [Build using *Mac-Xcode*](#build-using-mac-xcode)
 1.  As soon as you install the *Loop* app on the new phone, go ahead and disable <code>Closed Loop</code>.
@@ -130,14 +130,14 @@ The Dexcom app might have transferred successfully, but it’s not a bad idea to
     * Within 5 to 10 minutes, Dexcom app should read the current session and keep going
 
 * Wait for Dexcom to connect
-* On new phone, add the CGM to *Loop*
+* On new phone, add the CGM to&nbsp;_<span translate="no">Loop</span>_
 
 #### <span translate="no">Libre</span>&nbsp;CGM
 
 Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Suggested procedures from the community are encouraged.
 
-* On the new phone, in *Loop*, delete&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
-* On the new phone, in *Loop*, add&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
+* On the new phone, in&nbsp;_<span translate="no">Loop</span>_, delete&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
+* On the new phone, in&nbsp;_<span translate="no">Loop</span>_, add&nbsp;<span translate="no">Libre</span>&nbsp;as your CGM
 * Wait for&nbsp;<span translate="no">Libre</span>&nbsp;to connect
 
 ### Check out the Transfer
@@ -148,9 +148,9 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
         * Make sure all the basal, ISF, CR, Insulin Selection and ranges are correct
         * Check Dosing Strategy selection
         * Check permissions and notification settings
-        * Check Focus mode settings - make sure *Loop* and CGM apps have permission for all Focus modes
+        * Check Focus mode settings - make sure&nbsp;_<span translate="no">Loop</span>_&nbsp;and CGM apps have permission for all Focus modes
 
-1. Do a manual bolus of the smallest possible amount to make sure *Loop* and pump are working.
+1. Do a manual bolus of the smallest possible amount to make sure&nbsp;_<span translate="no">Loop</span>_&nbsp;and pump are working.
 
 1. Monitor CGM values to ensure new readings are coming in.
 
@@ -159,7 +159,7 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
     !!! important "_<span translate="no">Apple Health</span>_&nbsp;History"
         Your COB and IOB may not carry over to your new phone.
 
-        *Loop* reads from&nbsp;_<span translate="no">Apple Health</span>_&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
+        _<span translate="no">Loop</span>_&nbsp; reads from&nbsp;_<span translate="no">Apple Health</span>_&nbsp;and may restore COB and IOB from health – this assumes health is stored on iCloud and synchronized between old and new phone
 
         If your COB and IOB show up as blank, you can go open loop for 3 to 6 hours.
         
@@ -169,11 +169,11 @@ Placeholder for&nbsp;<span translate="no">Libre</span>&nbsp;CGM instructions. Su
         * Wait about 5 minutes for that insulin to show up in the *Loop* app as Active Insulin
         * Finally, add the Carbohydrates by entering them in your Add Carb Entry screen and rolling back the Date/Time wheel to the time of the original entry(ies)
 
-1. Once you are happy with the configuration of *Loop* on your new phone, go ahead and enable closed loop mode again.
+1. Once you are happy with the configuration of&nbsp;_<span translate="no">Loop</span>_&nbsp;on your new phone, go ahead and enable closed loop mode again.
 
 ### Old Phone
 
-Once you are using *Loop* on your new phone, you can delete the pump from the old phone.
+Once you are using&nbsp;_<span translate="no">Loop</span>_&nbsp;on your new phone, you can delete the pump from the old phone.
 
 * On the old phone, in the *Loop* app:
     * Delete the pump

--- a/docs/faqs/safety-faqs.md
+++ b/docs/faqs/safety-faqs.md
@@ -13,9 +13,9 @@ If you do not understand the components displayed in the graphic below, please s
 
 If you configured the app with closed-loop enabled:
 
-* Once carbohydrates are entered into *Loop*, the algorithm will begin to dose insulin to anticipate those carbs
+* Once carbohydrates are entered into&nbsp;_<span translate="no">Loop</span>_, the algorithm will begin to dose insulin to anticipate those carbs
 
-If you entered carbs and then changed your mind on the amount or the time at which they were eaten, use these [instructions](../operation/features/carbs.md#edit-meals) to delete or edit them. This will make *Loop* better able to predict blood glucose and adjust insulin delivery appropriately.
+If you entered carbs and then changed your mind on the amount or the time at which they were eaten, use these [instructions](../operation/features/carbs.md#edit-meals) to delete or edit them. This will make&nbsp;_<span translate="no">Loop</span>_&nbsp;better able to predict blood glucose and adjust insulin delivery appropriately.
 
 ## How to Cancel a Bolus
 
@@ -25,7 +25,7 @@ Once a bolus starts, the progress of that bolus appears in the [HUD Status Row](
 
 ## Understand Delivery Limits
 
-With each cycle, *Loop* generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
+With each cycle, _<span translate="no">Loop</span>_&nbsp;generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
 
 * The automated response to a positive recommended dose depends on your Dosing Strategy and is adjusted by your Delivery Limits
 
@@ -33,9 +33,9 @@ For more information, please read [How do Delivery Limits Affect Automatic Dosin
 
 ## Health app permissions
 
-For older versions of *Loop*, or if you customized&nbsp;<span translate="no">Loop 3</span>&nbsp;to read carbohydrates from third-party apps, be aware that you cannot edit those entries inside the *Loop* app.
+For older versions of&nbsp;_<span translate="no">Loop</span>_, or if you customized&nbsp;<span translate="no">Loop 3</span>&nbsp;to read carbohydrates from third-party apps, be aware that you cannot edit those entries inside the&nbsp;_<span translate="no">Loop</span>_&nbsp;app.
 
-If you let other apps, such as MyFitnessPal, write carbohydrates to the Health app, *Loop* could read those carbohydrates and you could be dosed for those carbohydrates.
+If you let other apps, such as MyFitnessPal, write carbohydrates to the Health app, _<span translate="no">Loop</span>_&nbsp;could read those carbohydrates and you could be dosed for those carbohydrates.
 
 * <span translate="no">Loop 3</span>: review [Customization: Build Time Features](../build/code-customization.md#build-time-features)
 * <span translate="no">Loop 2</span>: Check your [Health](../build/health.md#loop-permissions) permissions and review .

--- a/docs/faqs/safety-faqs.md
+++ b/docs/faqs/safety-faqs.md
@@ -13,9 +13,9 @@ If you do not understand the components displayed in the graphic below, please s
 
 If you configured the app with closed-loop enabled:
 
-* Once carbohydrates are entered into&nbsp;<span translate="no">Loop</span>, the algorithm will begin to dose insulin to anticipate those carbs
+* Once carbohydrates are entered into *Loop*, the algorithm will begin to dose insulin to anticipate those carbs
 
-If you entered carbs and then changed your mind on the amount or the time at which they were eaten, use these [instructions](../operation/features/carbs.md#edit-meals) to delete or edit them. This will make&nbsp;<span translate="no">Loop</span>&nbsp;better able to predict blood glucose and adjust insulin delivery appropriately.
+If you entered carbs and then changed your mind on the amount or the time at which they were eaten, use these [instructions](../operation/features/carbs.md#edit-meals) to delete or edit them. This will make *Loop* better able to predict blood glucose and adjust insulin delivery appropriately.
 
 ## How to Cancel a Bolus
 
@@ -25,7 +25,7 @@ Once a bolus starts, the progress of that bolus appears in the [HUD Status Row](
 
 ## Understand Delivery Limits
 
-With each cycle, <span translate="no">Loop</span>&nbsp;generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
+With each cycle, *Loop* generates a glucose prediction and a recommended dose (positive or negative) to bring you to your correction range.
 
 * The automated response to a positive recommended dose depends on your Dosing Strategy and is adjusted by your Delivery Limits
 
@@ -33,9 +33,9 @@ For more information, please read [How do Delivery Limits Affect Automatic Dosin
 
 ## Health app permissions
 
-For older versions of&nbsp;<span translate="no">Loop</span>, or if you customized&nbsp;<span translate="no">Loop 3</span>&nbsp;to read carbohydrates from third-party apps, be aware that you cannot edit those entries inside the&nbsp;<span translate="no">Loop</span>&nbsp;app.
+For older versions of *Loop*, or if you customized&nbsp;<span translate="no">Loop 3</span>&nbsp;to read carbohydrates from third-party apps, be aware that you cannot edit those entries inside the *Loop* app.
 
-If you let other apps, such as MyFitnessPal, write carbohydrates to the Health app, <span translate="no">Loop</span>&nbsp;could read those carbohydrates and you could be dosed for those carbohydrates.
+If you let other apps, such as MyFitnessPal, write carbohydrates to the Health app, *Loop* could read those carbohydrates and you could be dosed for those carbohydrates.
 
 * <span translate="no">Loop 3</span>: review [Customization: Build Time Features](../build/code-customization.md#build-time-features)
 * <span translate="no">Loop 2</span>: Check your [Health](../build/health.md#loop-permissions) permissions and review .

--- a/docs/gh-actions/gh-customize.md
+++ b/docs/gh-actions/gh-customize.md
@@ -11,20 +11,20 @@
 !!! warning "Modules vs Submodule"
     This page has instructions to set up your own copy for the Modules, otherwise known as submodules, associated with&nbsp;<span translate="no">LoopWorkspace</span>&nbsp;that are needed for a selected customization.
 
-    Each Module has its own&nbsp;<span translate="no">GitHub repository</span>&nbsp;and you will be working with your copy of that Module at https://github.com/username/Module, where username is your username.
+    Each Module has its own *GitHub* <code>repository</code>;and you will be working with your copy of that Module at https://github.com/username/Module, where username is your username.
 
 !!! warning "Copy vs&nbsp;<span translate="no">Fork</span>"
-    We use the word "copy" on this page but when you look at&nbsp;<span translate="no">GitHub</span>, you will see the word&nbsp;"<span translate="no">Fork</span>".
+    We use the word "copy" on this page but when you look at *GitHub*, you will see the word&nbsp;"<span translate="no">Fork</span>".
 
 !!! question "What is a SHA-1?"
     SHA-1 means Secure Hash Algorithm 1; which is used to generate an alphanumeric code.
 
-    Each time you save a change to your&nbsp;<span translate="no">GitHub repository</span>, a unique SHA-1 is created. That identifier is used to tell&nbsp;<span translate="no">GitHub</span>&nbsp;a specific change that you want applied. These work for any compatible copy taken from the original&nbsp;<span translate="no">GitHub repository</span>.
+    Each time you save a change to your&nbsp;<span translate="no">GitHub repository</span>, a unique SHA-1 is created. That identifier is used to tell *GitHub* a specific change that you want applied. These work for any compatible copy taken from the original&nbsp;<span translate="no">GitHub repository</span>.
     
 ### Do Not Make a Pull Request to Original Copy
 
 !!! important "Ignore&nbsp;<span translate="no">Compare & pull request</span>&nbsp;Prompts"
-    Please do not click on boxes that&nbsp;<span translate="no">GitHub</span>&nbsp;might show you that ask if you want to**&nbsp;<span translate="no">Compare & pull request</span>**.
+    Please do not click on boxes that *GitHub* might show you that ask if you want to**&nbsp;<span translate="no">Compare & pull request</span>**.
     
     This would be an attempt to merge changes from your copy back to the original version that everyone uses. These changes are for you only. Ignore those prompts.
 
@@ -35,7 +35,7 @@
         * Typically 1 or 2 Modules
     * Ten minutes to add patch lines to your build_loop.yml file
     * One minute to start the build
-    * An hour before the build shows up on your phone in&nbsp;<span translate="no">TestFlight</span>
+    * An hour before the build shows up on your phone in *TestFlight*
 
 !!! abstract "Summary"
     * Prepare Customization (One Time):
@@ -46,7 +46,7 @@
         * It is a good idea to test each customization as soon as you install the new build on your phone
     * LoopDocs: Decide on Modules to modify using the [LoopDocs: Code Customization](../build/code-customization.md) page
         * You only need to create your own customization if what you want is not provided at [Loop and Learn: Customization List](https://www.loopandlearn.org/custom-code#custom-list)
-    * <span translate="no">GitHub</span>&nbsp;(each Module):
+    * *GitHub* (each Module):
         1. Copy Module (if needed) - this is your copy where you will make changes
         1. Sync the Module (if needed)
         1. Make the desired modification(s) using the pencil tool
@@ -57,7 +57,7 @@
         1. Add customization lines to the file
         1. Save your changes
         1. Action 4: Build Loop
-    * Phone: Install with&nbsp;<span translate="no">TestFlight</span>
+    * Phone: Install with *TestFlight*
 
 !!! question "FAQs"
     - **Do I need a Mac computer?** No. This can be done on any browser.
@@ -130,9 +130,9 @@ Choose your link:
 
 ### New Copy
 
-If you want a modification that uses a particular Module, you must make a copy of that module to your account in&nbsp;<span translate="no">GitHub</span>. You will repeat the Copy and Modify steps for each module.
+If you want a modification that uses a particular Module, you must make a copy of that module to your account in *GitHub*. You will repeat the Copy and Modify steps for each module.
 
-1. Log into your&nbsp;<span translate="no">GitHub</span>&nbsp;account
+1. Log into your *GitHub* account
 1. Right click (or control click) on the URL in the [Module Table](#module-table)
 1. This opens a new browser tab at the URL of the module you need to copy
 1. Click on&nbsp;<span translate="no">Fork</span>, your copy will show up in the browser
@@ -187,9 +187,9 @@ The GIF showing the creation of one customization is shown below. Please review 
 You will be using the "pencil" tool in the browser display for your copy.
 
 !!! question "Are there detailed instructions?"
-    For more information about editing with&nbsp;<span translate="no">GitHub</span>:
+    For more information about editing with *GitHub*:
 
-    * [<span translate="no">GitHub</span>&nbsp;Docs: Editing Files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
+    * [*GitHub* Docs: Editing Files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
 
 The bullets below go with Frame 1 of the [GIF](#example-gif) above:
 
@@ -266,10 +266,10 @@ curl https://github.com/username/Module/commit/SHA-1.patch | git apply -v --dire
 where:
 
 * `curl`&nbsp;means copy from URL
-* username is your&nbsp;<span translate="no">GitHub</span>&nbsp;username
+* username is your *GitHub* username
 * Module is where you made the customization (Module is in multiple places)
 * SHA-1 is the full identifier for the desired change; there is a copy button to make this easy
-* adding&nbsp;`.patch`&nbsp;after the SHA-1 informs&nbsp;<span translate="no">GitHub</span>&nbsp;to format that code change so it can be applied to your copy
+* adding&nbsp;`.patch`&nbsp;after the SHA-1 informs *GitHub* to format that code change so it can be applied to your copy
 * the final&nbsp;<code> --directory=Module</code>&nbsp;is critical to apply the customization to the correct Module
 
 To view the exact code change associated with that patch, open a browser at the URL of&nbsp;`https://github.com/username/Module/commit/SHA-1`.
@@ -336,7 +336,7 @@ At the top of the display, click on&nbsp;<span translate="no">Actions</span>.
 
 Wait about 2 minutes before walking away to make sure there are no errors. If you get an error, then look for the first "did not apply" error message and fix the customization right before that line.
 
-In about 1 hour, your customized app will be available for installation on your phone via&nbsp;<span translate="no">TestFlight</span>.
+In about 1 hour, your customized app will be available for installation on your phone via *TestFlight*.
 
 ## Special Cases
 
@@ -349,7 +349,7 @@ What if you already have a copy of one of the modules?
 * If you know this is a copy you do not care about, you can delete the repository.
 * If you care about this copy, you are probably experienced enough to know how to solve the issue.
 
-Instructions to delete a repository are found at&nbsp;[<span translate="no">GitHub</span>&nbsp;Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
+Instructions to delete a repository are found at&nbsp;[*GitHub* Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
 
 Once deleted, go to [Create Your Copy for Selected Module](#create-your-copy-for-selected-module).
 
@@ -357,10 +357,10 @@ Once deleted, go to [Create Your Copy for Selected Module](#create-your-copy-for
 
 ### <span translate="no">LoopWorkspace</span>
 
-The&nbsp;<span translate="no">LoopWorkspace repository</span>&nbsp;is the umbrella organization holding all the pieces needed to build the&nbsp;<span translate="no">Loop</span>&nbsp;app. It provides a list of pointers to a specific version for each of the Modules used in the workspace.
+The&nbsp;<span translate="no">LoopWorkspace repository</span>&nbsp;is the umbrella organization holding all the pieces needed to build the *Loop* app. It provides a list of pointers to a specific version for each of the Modules used in the workspace.
 
 * <span translate="no">commit</span>: a specific change to the code identified by the SHA-1; the most recent one indicates the most recent version of the code
 * <span translate="no">workspace</span>: a grouping of several repositories (Modules) into a complete package
 * <span translate="no">LoopWorkspace</span>: includes a list of the specific SHA-1 for each Module needed for the app
 
-You are telling&nbsp;<span translate="no">GitHub</span>&nbsp;to apply specific customizations when it builds your app for you. It makes a fresh copy of all the code needed, applies your specific customizations and then starts the build.
+You are telling *GitHub* to apply specific customizations when it builds your app for you. It makes a fresh copy of all the code needed, applies your specific customizations and then starts the build.

--- a/docs/gh-actions/gh-deploy.md
+++ b/docs/gh-actions/gh-deploy.md
@@ -1,6 +1,6 @@
 ## General Installation Information
 
-This is only available with&nbsp;<span translate="no">Loop 3</span>.
+This is only available with&nbsp;_<span translate="no">Loop 3</span>_.
 
 **You must build&nbsp;_<span translate="no">Loop</span>_&nbsp;every 90 days when you use this method.**
 

--- a/docs/gh-actions/gh-deploy.md
+++ b/docs/gh-actions/gh-deploy.md
@@ -2,9 +2,9 @@
 
 This is only available with&nbsp;<span translate="no">Loop 3</span>.
 
-**You must build *Loop* every 90 days when you use this method.**
+**You must build&nbsp;_<span translate="no">Loop</span>_&nbsp;every 90 days when you use this method.**
 
-After [building *Loop* using a browser](../gh-actions/gh-first-time.md#build-loop), you are ready to install on as many phones as you and your family members need.
+After [building&nbsp;_<span translate="no">Loop</span>_&nbsp;using a browser](../gh-actions/gh-first-time.md#build-loop), you are ready to install on as many phones as you and your family members need.
 
 * If you later need to add an adult family member to your list, refer to [Set Up Users and Access (TestFlight)](../gh-actions/gh-first-time.md#set-up-users-and-access-testflight).
 
@@ -40,17 +40,17 @@ The first time you use *TestFlight* on any phone associated with a given email, 
 ![redeem the code from email in testflight](img/testflight-redeem-code.gif){width="300"}
 {align="center"}
 
-If you already have the *Loop* app on the phone, you'll see the warning about possible loss of data. Don't worry, all your settings remain. Go ahead with the installation.
+If you already have the&nbsp;_<span translate="no">Loop</span>_&nbsp;app on the phone, you'll see the warning about possible loss of data. Don't worry, all your settings remain. Go ahead with the installation.
 
 ### Subsequent Times on Phone
 
-* Open *TestFlight* and find the name you used for your *Loop* app in the [Create *Loop* App in App Store Connect](../gh-actions/gh-first-time.md#create-loop-app-in-app-store-connect) step
+* Open *TestFlight* and find the name you used for your&nbsp;_<span translate="no">Loop</span>_&nbsp;app in the [Create *Loop* App in App Store Connect](../gh-actions/gh-first-time.md#create-loop-app-in-app-store-connect) step
 * Tap on Install
-    * If you already have *Loop* installed on this phone, you will be warned that the app already exists on your phone and that you might lose the app's data.
+    * If you already have&nbsp;_<span translate="no">Loop</span>_&nbsp;installed on this phone, you will be warned that the app already exists on your phone and that you might lose the app's data.
     * Click Install again (your pump connection and all your data will be fine)
 * Choose Open
-* Make sure the *Loop* app is operating as expected
-* If you are building *Loop* 3.x over *Loop* 2.x, you will be required to go through [Onboarding](../loop-3/onboarding.md)
+* Make sure the&nbsp;_<span translate="no">Loop</span>_&nbsp;app is operating as expected
+* If you are building&nbsp;_<span translate="no">Loop</span>_&nbsp;3.x over&nbsp;_<span translate="no">Loop</span>_&nbsp;2.x, you will be required to go through [Onboarding](../loop-3/onboarding.md)
 
 ![install Loop from TestFlight](img/testflight-install-loop.gif){width="300"}
 {align="center"}
@@ -94,7 +94,7 @@ If you tap on the bottom row that says `Previous Builds`, you can view and choos
 
 ## *TestFlight* for a Child
 
-The adult (Apple Developer Account owner) can log into Media & Purchase (see steps below) without affecting the child *Apple* ID associated with a phone (and thus their health records used by *Loop*). After the adult installs or updates the app using *TestFlight*, they probably should reverse those steps to remove their credentials from Media & Purchase.
+The adult (Apple Developer Account owner) can log into Media & Purchase (see steps below) without affecting the child *Apple* ID associated with a phone (and thus their health records used by&nbsp;_<span translate="no">Loop</span>_). After the adult installs or updates the app using *TestFlight*, they probably should reverse those steps to remove their credentials from Media & Purchase.
 
 Media & Purchase affects access to the App Store, Books, Music and Podcasts.
 
@@ -112,7 +112,7 @@ On the Child phone:
 
 ## Change the App Store Connect Name
 
-Suppose you really don't like the name you picked initially for the *Loop* app that shows up in the *TestFlight* app.
+Suppose you really don't like the name you picked initially for the&nbsp;_<span translate="no">Loop</span>_&nbsp;app that shows up in the *TestFlight* app.
 
 You can change it.
 

--- a/docs/gh-actions/gh-deploy.md
+++ b/docs/gh-actions/gh-deploy.md
@@ -2,35 +2,35 @@
 
 This is only available with&nbsp;<span translate="no">Loop 3</span>.
 
-**You must build&nbsp;<span translate="no">Loop</span>&nbsp;every 90 days when you use this method.**
+**You must build *Loop* every 90 days when you use this method.**
 
-After [building&nbsp;<span translate="no">Loop</span>&nbsp;using a browser](../gh-actions/gh-first-time.md#build-loop), you are ready to install on as many phones as you and your family members need.
+After [building *Loop* using a browser](../gh-actions/gh-first-time.md#build-loop), you are ready to install on as many phones as you and your family members need.
 
 * If you later need to add an adult family member to your list, refer to [Set Up Users and Access (TestFlight)](../gh-actions/gh-first-time.md#set-up-users-and-access-testflight).
 
-* Children (under 13 in US, varies by country) cannot use&nbsp;<span translate="no">TestFlight</span>&nbsp;with their ID. When you use&nbsp;[<span translate="no">TestFlight</span>&nbsp;for a Child](#testflightfor-a-child), you will need to use your ID on their phone (not the whole phone - just the Media & Purchase portion), so send the&nbsp;<span translate="no">TestFlight</span>&nbsp;invitation to the email associated with your ID.
+* Children (under 13 in US, varies by country) cannot use *TestFlight* with their ID. When you use&nbsp;[*TestFlight* for a Child](#testflight-for-a-child), you will need to use your ID on their phone (not the whole phone - just the Media & Purchase portion), so send the *TestFlight* invitation to the email associated with your ID.
 
 
-## Install&nbsp;<span translate="no">TestFlight</span>
+## Install *TestFlight*
 
-If you already have the&nbsp;<span translate="no">TestFlight</span>&nbsp;app installed on your phone, skip ahead to [Install App with&nbsp;<span translate="no">TestFlight</span>](#install-app-withtestflight).
+If you already have the *TestFlight* app installed on your phone, skip ahead to [Install App with *TestFlight*](#install-app-with-testflight).
 
-To install&nbsp;<span translate="no">TestFlight</span>, refer to the GIF below:
+To install *TestFlight*, refer to the GIF below:
 
-* On the phone, open the App Store and Search for&nbsp;<span translate="no">TestFlight</span>
-* Install or Download to that phone&nbsp;<span translate="no">TestFlight</span>
+* On the phone, open the App Store and Search for *TestFlight*
+* Install or Download to that phone *TestFlight*
     * Hint: On child's phone, do this while logged in as yourself for Media & Purchase
-    * Logging in as an adult is explained in [<span translate="no">TestFlight</span>&nbsp;for a Child](gh-deploy.md#testflightfor-a-child)
+    * Logging in as an adult is explained in [*TestFlight* for a Child](gh-deploy.md#testflight-for-a-child)
 
 ![search for and dowload TestFlight](img/testflight-app-store.gif){width="300"}
 {align="center"}
 
 
-## Install App with&nbsp;<span translate="no">TestFlight</span>
+## Install App with *TestFlight*
 
-Once you get an email that the&nbsp;<span translate="no">TestFlight</span> processing completed, you can install the app on your phone. Note this can be half-hour to an hour after the build displays the green check mark on your browser.
+Once you get an email that the *TestFlight* processing completed, you can install the app on your phone. Note this can be half-hour to an hour after the build displays the green check mark on your browser.
 
-The first time you use&nbsp;<span translate="no">TestFlight</span>&nbsp;on any phone associated with a given email, you must `Redeem` the code sent to that email inviting you to test the app. The GIF below is for someone who has never used&nbsp;<span translate="no">TestFlight</span>.
+The first time you use *TestFlight* on any phone associated with a given email, you must `Redeem` the code sent to that email inviting you to test the app. The GIF below is for someone who has never used *TestFlight*.
 
 * Initial screen indicates there are no Apps available to test, tap on Redeem
 * Enter your code and tap redeem to enter it
@@ -40,17 +40,17 @@ The first time you use&nbsp;<span translate="no">TestFlight</span>&nbsp;on any p
 ![redeem the code from email in testflight](img/testflight-redeem-code.gif){width="300"}
 {align="center"}
 
-If you already have the&nbsp;<span translate="no">Loop</span>&nbsp;app on the phone, you'll see the warning about possible loss of data. Don't worry, all your settings remain. Go ahead with the installation.
+If you already have the *Loop* app on the phone, you'll see the warning about possible loss of data. Don't worry, all your settings remain. Go ahead with the installation.
 
 ### Subsequent Times on Phone
 
-* Open&nbsp;<span translate="no">TestFlight</span>&nbsp;and find the name you used for your&nbsp;<span translate="no">Loop</span>&nbsp;app in the [Create&nbsp;<span translate="no">Loop</span>&nbsp;App in App Store Connect](../gh-actions/gh-first-time.md#create-loop-app-in-app-store-connect) step
+* Open *TestFlight* and find the name you used for your *Loop* app in the [Create *Loop* App in App Store Connect](../gh-actions/gh-first-time.md#create-loop-app-in-app-store-connect) step
 * Tap on Install
-    * If you already have&nbsp;<span translate="no">Loop</span>&nbsp;installed on this phone, you will be warned that the app already exists on your phone and that you might lose the app's data.
+    * If you already have *Loop* installed on this phone, you will be warned that the app already exists on your phone and that you might lose the app's data.
     * Click Install again (your pump connection and all your data will be fine)
 * Choose Open
-* Make sure the&nbsp;<span translate="no">Loop</span>&nbsp;app is operating as expected
-* If you are building&nbsp;<span translate="no">Loop</span>&nbsp;3.x over&nbsp;<span translate="no">Loop</span>&nbsp;2.x, you will be required to go through [Onboarding](../loop-3/onboarding.md)
+* Make sure the *Loop* app is operating as expected
+* If you are building *Loop* 3.x over *Loop* 2.x, you will be required to go through [Onboarding](../loop-3/onboarding.md)
 
 ![install Loop from TestFlight](img/testflight-install-loop.gif){width="300"}
 {align="center"}
@@ -60,41 +60,41 @@ If you already have the&nbsp;<span translate="no">Loop</span>&nbsp;app on the ph
 Automatic features will be available when version 3.4.0 is released and are available now in 3.3.0 (when&nbsp;<span translate="no">dev is the default branch</span>). The instructions on the [Configure to Use Browser](gh-first-time.md) page will, unless you make a change, automatically take the following actions for 3.4.0:
 
 * Update the version of your&nbsp;<span translate="no">fork</span>&nbsp;within a week of the change
-* Build the app at least once a month and upload to&nbsp;<span translate="no">TestFlight</span>
+* Build the app at least once a month and upload to *TestFlight*
 
 It is already true that, unless you make a change, the default setting will:
 
-* Install each new build on phone from&nbsp;<span translate="no">TestFlight</span>
+* Install each new build on phone from *TestFlight*
 
 ### Recommendation
 
 Recommended settings for 3.4.0 (when it is released) and later:
 
 * Allow automatic update of your&nbsp;<span translate="no">fork</span>
-* Allow automatic build and upload to&nbsp;<span translate="no">TestFlight</span>
-* [Disable automatic installation](#disable-automatic-install-fromtestflight) on phone from&nbsp;<span translate="no">TestFlight</span>
+* Allow automatic build and upload to *TestFlight*
+* [Disable automatic installation](#disable-automatic-install-from-testflight) on phone from *TestFlight*
 
 If you are running the development code, you may prefer to turn off the automatic update, but keep the automatic build. To read more about modifying automatic update and build options, please read [Modify Automatic Building](gh-update.md#modify-automatic-building).
 
-## Disable Automatic Install from&nbsp;<span translate="no">TestFlight</span>
+## Disable Automatic Install from *TestFlight*
 
 Once the app is installed one time, you can adjust whether it is automatically installed when updated versions are available. We recommend you disable automatic installation so you can choose when to switch to a newer build, which in some cases, may be a newer version.
 
-Go back to the&nbsp;<span translate="no">TestFlight</span>&nbsp;app on your phone and tap on your app name in the list to see an expanded screen similar to the graphic below. The row to enable or disable automatic updates is highlighted in the graphic, which shows the feature disabled. This is recommended for all users.
+Go back to the *TestFlight* app on your phone and tap on your app name in the list to see an expanded screen similar to the graphic below. The row to enable or disable automatic updates is highlighted in the graphic, which shows the feature disabled. This is recommended for all users.
 
-* If you leave automatic update enabled (default), then whenever a new build is created and uploaded to&nbsp;<span translate="no">TestFlight</span>&nbsp;, it will be installed immediately.
+* If you leave automatic update enabled (default), then whenever a new build is created and uploaded to *TestFlight* , it will be installed immediately.
 * WARNING: If you switch between Building with Browser and Mac-Xcode, you must disable automatic update or Xcode will not be able to install to your phone.
 
 ![enable or disable automatic update for Loop](img/testflight-auto-update.png){width="300"}
 {align="center"}
 
-When you are ready to install, just open the&nbsp;<span translate="no">TestFlight</span>&nbsp;app and click Install to get the most recent build and then click Open when it completes the installation. All your settings and connections to CGM and Pump are maintained.
+When you are ready to install, just open the *TestFlight* app and click Install to get the most recent build and then click Open when it completes the installation. All your settings and connections to CGM and Pump are maintained.
 
 If you tap on the bottom row that says `Previous Builds`, you can view and choose an older build (as long as it has not expired).
 
-## <span translate="no">TestFlight</span>&nbsp;for a Child
+## *TestFlight* for a Child
 
-The adult (Apple Developer Account owner) can log into Media & Purchase (see steps below) without affecting the child&nbsp;<span translate="no">Apple</span>&nbsp;ID associated with a phone (and thus their health records used by&nbsp;<span translate="no">Loop</span>). After the adult installs or updates the app using&nbsp;<span translate="no">TestFlight</span>, they probably should reverse those steps to remove their credentials from Media & Purchase.
+The adult (Apple Developer Account owner) can log into Media & Purchase (see steps below) without affecting the child *Apple* ID associated with a phone (and thus their health records used by *Loop*). After the adult installs or updates the app using *TestFlight*, they probably should reverse those steps to remove their credentials from Media & Purchase.
 
 Media & Purchase affects access to the App Store, Books, Music and Podcasts.
 
@@ -102,17 +102,17 @@ On the Child phone:
 
 * Tap on Settings
 * At the very top of Settings, tap on the Name of the phone, for example, `my kids phone`
-* <span translate="no">Apple</span>&nbsp;ID Screen appears
+* *Apple* ID Screen appears
     * Tap on Media & Purchases
     * Tap on Sign Out, and confirm
     * Sometimes the phone requires a reboot before you can sign in with a different ID
-* Sign in with the adult (Apple Developer Account owner) <span translate="no">Apple</span>&nbsp;ID and password
-* Install or Update the app from&nbsp;<span translate="no">TestFlight</span>&nbsp;on child phone
+* Sign in with the adult (Apple Developer Account owner) *Apple* ID and password
+* Install or Update the app from *TestFlight* on child phone
 * Repeat the process to sign out the adult and (if needed) sign back in the child
 
 ## Change the App Store Connect Name
 
-Suppose you really don't like the name you picked initially for the&nbsp;<span translate="no">Loop</span>&nbsp;app that shows up in the&nbsp;<span translate="no">TestFlight</span>&nbsp;app.
+Suppose you really don't like the name you picked initially for the *Loop* app that shows up in the *TestFlight* app.
 
 You can change it.
 

--- a/docs/gh-actions/gh-errors.md
+++ b/docs/gh-actions/gh-errors.md
@@ -2,7 +2,7 @@
     
 If you get an error when building with a browser, use this page to figure out what to do.
 
-If you are still unsuccessful, then post your request for help along with your&nbsp;<span translate="no">GitHub</span>&nbsp;**username**. Mentors can go to your public&nbsp;<span translate="no">GitHub repository</span>, check the status and then view your log files directly.
+If you are still unsuccessful, then post your request for help along with your *GitHub* **username**. Mentors can go to your public&nbsp;<span translate="no">GitHub repository</span>, check the status and then view your log files directly.
 
 * Do not copy from the log file and post the words
 * Do not take a screenshot of what you think is an error

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -45,7 +45,7 @@
     - **Do I need a Mac computer?** No. This can be done on any browser, although it will be easier using a computer or tablet than just using a phone.
     - **Can I do this on my phone?** Yes, but the graphics shown on this page are from a computer browser.
     - **Isn't it hard to build every 90 days?** The initial setup and deployment take a lot of your focused time. But once you build once, subsequent builds take very little of your time to start, then the rest is done automatically.
-    - **Can I use this for my child?** You, as the adult, can install using *TestFlight* on your child's phone. The explicit steps are provided at [Install on Phone: *TestFlight* for a Child](gh-deploy.md#testflightfor-a-child).
+    - **Can I use this for my child?** You, as the adult, can install using *TestFlight* on your child's phone. The explicit steps are provided at [Install on Phone: *TestFlight* for a Child](gh-deploy.md#testflight-for-a-child).
     - **Can I still use my customizations?** Yes. [Customize with Browser](gh-customize.md)
 
 ## Tips and Tricks

--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -1,10 +1,10 @@
 ## Using *GitHub* Browser Build Method to Build Other Apps
 
-Once Loop 3 was released with the ability to build using a browser, a lot of other repositories in the DIY universe began to add the same feature. **Only apps that are companions to &nbsp;<span translate="no">Loop</span>&nbsp; are included on this page.** If you want to build another DIY app that is not included here, look for the file `fastlane/testflight.md` in that app's repository and open it in a browser. The instruction for that apps should be located in that file.
+Once Loop 3 was released with the ability to build using a browser, a lot of other repositories in the DIY universe began to add the same feature. **Only apps that are companions to *Loop* are included on this page.** If you want to build another DIY app that is not included here, look for the file `fastlane/testflight.md` in that app's repository and open it in a browser. The instruction for that apps should be located in that file.
 
 The same technique is used and the same six Secrets are applied to each repository. Those secrets are tied to your *Apple* Developer ID and your *GitHub* account.
 
-* <span translate="no">Loop Caregiver</span>
+* *Loop Caregiver*
 * <span translate="no">Loop Follow</span>
 
 !!! warning "GH_PAT - NEW RECOMMENDATION"
@@ -26,19 +26,20 @@ The same technique is used and the same six Secrets are applied to each reposito
         * Use that table to find the link of the repository you will fork
 
 !!! important "Use the repository for the application you are building"
-    Many graphics on this page show &nbsp;<span translate="no">LoopWorkspace</span>, just remember to use the repository for the app you want to build, that is either &nbsp;<span translate="no">Loop Follow</span>&nbsp; or &nbsp;<span translate="no">Loop Caregiver</span>.
+    Many graphics on this page show &nbsp;<span translate="no">LoopWorkspace</span>, just remember to use the repository for the app you want to build, that is either  *Loop Follow*  or *Loop Caregiver*.
 
 ## Fork and Add Secrets
 
 * You will return to this page after reviewing (but not doing) this step [GitHub First-Time: Fork LoopWorkspace](../gh-actions/gh-first-time.md#fork-loopworkspace)
     * Use the same method as that section, but fork the repository for the app you plan to build
-    * <span translate="no">Loop Caregiver</span>, expect the branch to be "dev"
+    * *Loop Caregiver*, expect the branch to be "dev"
     * <span translate="no">Loop Follow</span>, expect the branch to be "main"
 
 
 | App | Fork from this Address | Documentation |
 |---|---|---|
-| <span translate="no">Loop Caregiver</span> | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver) | [LoopDocs: <span translate="no">Loop Caregiver</span>](../nightscout/loop-caregiver.md) |
+| *Loop Caregiver* | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver) | [*LoopDocs*: 
+*Loop Caregiver*](../nightscout/loop-caregiver.md) |
 |Loop Follow | [https://github.com/loopandlearn/LoopFollow](https://github.com/loopandlearn/LoopFollow) | [Loop Follow](https://github.com/loopandlearn/LoopFollow#loop-follow)|
 
 
@@ -99,7 +100,7 @@ The workflows are now displayed: look at the list on the left side similar to th
 
 This step validates most of your six Secrets and provides error messages if it detects an issue with one or more.
 
-1. Click on the "Actions" tab of your &nbsp;<span translate="no">Loop Follow</span>&nbsp; or &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; repository and enable workflows if needed
+1. Click on the "Actions" tab of your  *Loop Follow*  or  *Loop Caregiver*repository and enable workflows if needed
 1. On the left side, click on 1. <code>Validate Secrets</code>
 1. On the right side, click `Run Workflow` to show a drop-down menu
     * You will see your default branch (`main` for LoopFollow, `dev` for LoopCaregiver)
@@ -151,12 +152,12 @@ After successfully performing the Add Identifiers Action, you will see the ident
 
 | App Name | Name | Bundle ID |
 | --- | --- | --- |
-| <span translate="no">Loop Caregiver</span> | <span translate="no">Loop Caregiver</span> | com.TEAMID.loopkit.LoopCaregiver |
+| *Loop Caregiver* | *Loop Caregiver* | com.TEAMID.loopkit.LoopCaregiver |
 | Loop Follow | LoopFollow | com.TEAMID.LoopFollow |
 
 Some apps, like Loop, require updates to the Identifiers after they are generated.
 
-These apps, &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; and &nbsp;<span translate="no">Loop Follow</span>, do not require that extra step.
+These apps,  *Loop Caregiver*and  *Loop Follow*, do not require that extra step.
 
 ## Create App in App Store Connect
 
@@ -166,7 +167,7 @@ This requires you to provide some information. Examine the table below for the b
 
 | App Name | Bundle ID |
 | --- | --- |
-| <span translate="no">Loop Caregiver</span> | com.TEAMID.loopkit.LoopCaregiver |
+| *Loop Caregiver* | com.TEAMID.loopkit.LoopCaregiver |
 | <span translate="no">Loop Follow</span> | com.TEAMID.LoopFollow |
 
 1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps) to view your apps; log in if needed. 

--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -35,13 +35,10 @@ The same technique is used and the same six Secrets are applied to each reposito
     * *Loop Caregiver*, expect the branch to be "dev"
     * <span translate="no">Loop Follow</span>, expect the branch to be "main"
 
-
 | App | Fork from this Address | Documentation |
 |---|---|---|
-| *Loop Caregiver* | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver) | [*LoopDocs*: 
-*Loop Caregiver*](../nightscout/loop-caregiver.md) |
-|Loop Follow | [https://github.com/loopandlearn/LoopFollow](https://github.com/loopandlearn/LoopFollow) | [Loop Follow](https://github.com/loopandlearn/LoopFollow#loop-follow)|
-
+| *Loop Caregiver* | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver) | [*LoopDocs*: *Loop Caregiver*](../nightscout/loop-caregiver.md) |
+| *Loop Follow* | [https://github.com/loopandlearn/LoopFollow](https://github.com/loopandlearn/LoopFollow) | [*Loop Follow*](https://github.com/loopandlearn/LoopFollow#loop-follow)|
 
 ## Configure Secrets for this App
 
@@ -248,8 +245,8 @@ Refer to the graphic below for the first four steps:
 
 Once the first build completes, you will be able to configure *TestFlight* for the app - follow the template for setting up *TestFlight* for Loop found in [GitHub First-Time: Set Up Users and Access (TestFlight)](../gh-actions/gh-first-time.md#set-up-users-and-access-testflight)
 
-## Deployment
+## Install on Phone
 
-The [GitHub Deployment](gh-deploy.md) walks you through the steps to deploy to a phone. When going through those steps, replace your App Name for Loop. Everything else is the same.
+The [Install on Phone](gh-deploy.md) walks you through the steps to install the app to a phone. When going through those steps, replace your App Name for&nbsp;_<span translate="no">Loop</span>_. Everything else is the same.
 
 

--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -1,6 +1,6 @@
 ## Using *GitHub* Browser Build Method to Build Other Apps
 
-Once Loop 3 was released with the ability to build using a browser, a lot of other repositories in the DIY universe began to add the same feature. **Only apps that are companions to *Loop* are included on this page.** If you want to build another DIY app that is not included here, look for the file `fastlane/testflight.md` in that app's repository and open it in a browser. The instruction for that apps should be located in that file.
+Once Loop 3 was released with the ability to build using a browser, a lot of other repositories in the DIY universe began to add the same feature. **Only apps that are companions to&nbsp;_<span translate="no">Loop</span>_&nbsp;are included on this page.** If you want to build another DIY app that is not included here, look for the file `fastlane/testflight.md` in that app's repository and open it in a browser. The instruction for that apps should be located in that file.
 
 The same technique is used and the same six Secrets are applied to each repository. Those secrets are tied to your *Apple* Developer ID and your *GitHub* account.
 

--- a/docs/gh-actions/gh-overview.md
+++ b/docs/gh-actions/gh-overview.md
@@ -20,7 +20,7 @@
     * With the next release, which includes automatic builds, this should not be an issue
 * After the&nbsp;<span translate="no">GitHub Build</span>&nbsp;starts, the process takes about an hour to complete
     * You will receive an email indicating success (or failure)
-    * The *Loop* app appears in the *TestFlight* app on the phone, where it can be installed in seconds
+    * The&nbsp;_<span translate="no">Loop</span>_&nbsp;app appears in the *TestFlight* app on the phone, where it can be installed in seconds
 * Frequently used customizations are easy to copy and paste as documented at [Loop and Learn: Loop Customization](https://www.loopandlearn.org/custom-code#custom-list)
 * Personalized code customizations are tedious to set up but easy to maintain
     * Instructions are documented at [Customize using Browser](../gh-actions/gh-customize.md)
@@ -30,7 +30,7 @@
 
 * **Loop 3 requires iOS 15.1 or higher on the phone.**
 
-To build the *Loop* app using a browser, you need:
+To build the&nbsp;_<span translate="no">Loop</span>_&nbsp;app using a browser, you need:
 
 1. Free *GitHub* account (instructions included in [Configure to use Browser](gh-first-time.md))
 1. [*Apple* Developer Membership](../build/apple-developer.md)
@@ -40,7 +40,7 @@ To build the *Loop* app using a browser, you need:
     * If building for a child (age depends on the country), review this section:
         * [Install *TestFlight* Loop for Child](../gh-actions/gh-deploy.md#testflightfor-child)
 
-Once you have the *Loop* app in TestFlight, you need:
+Once you have the&nbsp;_<span translate="no">Loop</span>_&nbsp;app in *TestFlight*, you need:
 
 1. [Compatible iPhone](../build/phone.md)
 1. [Compatible Pump](../build/pump.md)

--- a/docs/gh-actions/gh-overview.md
+++ b/docs/gh-actions/gh-overview.md
@@ -1,7 +1,7 @@
 ## Build with a Browser
 
 * <span translate="no">Loop 3</span>&nbsp;can be built with a web browser using <span translate="no">GitHub Actions</span>
-* The app is then installed remotely on the phone using <span translate="no">TestFlight</span>
+* The app is then installed remotely on the phone using *TestFlight*
 
 ### Advantages of Building with a Browser
 

--- a/docs/gh-actions/gh-overview.md
+++ b/docs/gh-actions/gh-overview.md
@@ -15,12 +15,12 @@
 
 ### Considerations for Building with a Browser
 
-* The app is delivered to your phone via&nbsp;<span translate="no">TestFlight</span>
-    * The app is considered "Beta" by &nbsp;<span translate="no">Apple</span>&nbsp;and expires after 90 days
+* The app is delivered to your phone via *TestFlight*
+    * The app is considered "Beta" by  *Apple* and expires after 90 days
     * With the next release, which includes automatic builds, this should not be an issue
 * After the&nbsp;<span translate="no">GitHub Build</span>&nbsp;starts, the process takes about an hour to complete
     * You will receive an email indicating success (or failure)
-    * The&nbsp;<span translate="no">Loop</span>&nbsp;app appears in the&nbsp;<span translate="no">TestFlight</span>&nbsp;app on the phone, where it can be installed in seconds
+    * The *Loop* app appears in the *TestFlight* app on the phone, where it can be installed in seconds
 * Frequently used customizations are easy to copy and paste as documented at [Loop and Learn: Loop Customization](https://www.loopandlearn.org/custom-code#custom-list)
 * Personalized code customizations are tedious to set up but easy to maintain
     * Instructions are documented at [Customize using Browser](../gh-actions/gh-customize.md)
@@ -30,17 +30,17 @@
 
 * **Loop 3 requires iOS 15.1 or higher on the phone.**
 
-To build the&nbsp;<span translate="no">Loop</span>&nbsp;app using a browser, you need:
+To build the *Loop* app using a browser, you need:
 
-1. Free&nbsp;<span translate="no">GitHub</span>&nbsp;account (instructions included in [Configure to use Browser](gh-first-time.md))
-1. [<span translate="no">Apple</span>&nbsp;Developer Membership](../build/apple-developer.md)
+1. Free *GitHub* account (instructions included in [Configure to use Browser](gh-first-time.md))
+1. [*Apple* Developer Membership](../build/apple-developer.md)
     * Must be a paid developer account
     * If building for a family member, review this section:
         * [Loopers Need Their Own *Apple* ID](../build/apple-developer.md#loopers-need-their-own-apple-id)
     * If building for a child (age depends on the country), review this section:
         * [Install *TestFlight* Loop for Child](../gh-actions/gh-deploy.md#testflightfor-child)
 
-Once you have the &nbsp;<span translate="no">Loop</span>&nbsp;app in TestFlight, you need:
+Once you have the *Loop* app in TestFlight, you need:
 
 1. [Compatible iPhone](../build/phone.md)
 1. [Compatible Pump](../build/pump.md)
@@ -81,5 +81,5 @@ Try to:
 * Compare your display with the graphics in LoopDocs.
     * Is something different or does yours have an error message?
     * Does the error message guide you to the problem and solution?
-    * Be aware that &nbsp;<span translate="no">GitHub</span>&nbsp;often updates where things are - search for &nbsp;<span translate="no">GitHub</span>&nbsp;directions if your display looks different than LoopDocs.
+    * Be aware that  *GitHub* often updates where things are - search for  *GitHub* directions if your display looks different than LoopDocs.
 * If you are still stumped - reach out for help: [How to Find Help](../intro/loopdocs-how-to.md#how-to-find-help).

--- a/docs/gh-actions/gh-update.md
+++ b/docs/gh-actions/gh-update.md
@@ -321,11 +321,11 @@ If you have already completed the One-Time Changes, skip ahead to [Build Branch]
 
 #### Transition to dev
 
-When updating from&nbsp;<span translate="no">Loop</span>&nbsp;3.2.x to dev, you will need to take some extra steps. 
+When updating from *Loop* 3.2.x to dev, you will need to take some extra steps. 
 
 You have a choice:
 
-* You can change your default branch to dev, see [Change Default Branch](#change-default-branch) and then your &nbsp;<span translate="no">Loop</span>&nbsp;app will be automatically updated and automatically built at least once a month
+* You can change your default branch to dev, see [Change Default Branch](#change-default-branch) and then your *Loop* app will be automatically updated and automatically built at least once a month
     * Be sure to review the [Modify Automatic Building](#modify-automatic-building) section
 * You can leave your default branch at main, but no automated updates will happen
     * Running each action below requires you to select the dev branch in the drop-down menu

--- a/docs/gh-actions/gh-update.md
+++ b/docs/gh-actions/gh-update.md
@@ -321,11 +321,11 @@ If you have already completed the One-Time Changes, skip ahead to [Build Branch]
 
 #### Transition to dev
 
-When updating from *Loop* 3.2.x to dev, you will need to take some extra steps. 
+When updating from&nbsp;_<span translate="no">Loop</span>_&nbsp;3.2.x to dev, you will need to take some extra steps. 
 
 You have a choice:
 
-* You can change your default branch to dev, see [Change Default Branch](#change-default-branch) and then your *Loop* app will be automatically updated and automatically built at least once a month
+* You can change your default branch to dev, see [Change Default Branch](#change-default-branch) and then your&nbsp;_<span translate="no">Loop</span>_&nbsp;app will be automatically updated and automatically built at least once a month
     * Be sure to review the [Modify Automatic Building](#modify-automatic-building) section
 * You can leave your default branch at main, but no automated updates will happen
     * Running each action below requires you to select the dev branch in the drop-down menu

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,42 +5,42 @@ hide:
 
 ## Welcome to *Loop*
 
-Welcome to the *LoopDocs* website where you can learn about *Loop*.
+Welcome to the *LoopDocs* website where you can learn about&nbsp;_<span translate="no">Loop</span>_.
 
-This site shows you step-by-step how to **build**, **set up** and **operate** the *Loop* app.
+This site shows you step-by-step how to **build**, **set up** and **operate** the&nbsp;_<span translate="no">Loop</span>_&nbsp;app.
 
 * **You do not need a technical or computer background to do this**
-* **You can choose to build the *Loop* app using a [browser](gh-actions/gh-overview.md) on any computer and install it on your Apple phone via *TestFlight* **
+* **You can choose to build the&nbsp;_<span translate="no">Loop</span>_&nbsp;app using a [browser](gh-actions/gh-overview.md) on any computer and install it on your Apple phone via *TestFlight* **
 
 In order to become a proficient with the app, you should learn the information on this site. Consider doing this over a period of time and reviewing the materials more than once.
 
-* You should test and perhaps adjust your settings to be successful with *Loop* (or any hybrid closed-loop system)
+* You should test and perhaps adjust your settings to be successful with&nbsp;_<span translate="no">Loop</span>_&nbsp;(or any hybrid closed-loop system)
 * You will find links as you read to a robust volunteer support community
 
-Once you are using the app, you should regularly follow one or more support forums for important updates on *Loop*. Spending this time is important for success in building and operating *Loop* safely.
+Once you are using the app, you should regularly follow one or more support forums for important updates on&nbsp;_<span translate="no">Loop</span>_. Spending this time is important for success in building and operating&nbsp;_<span translate="no">Loop</span>_&nbsp;safely.
 
-This website is updated regularly to keep pace with *Loop* developments and *Apple* releases.
+This website is updated regularly to keep pace with&nbsp;_<span translate="no">Loop</span>_&nbsp;developments and *Apple* releases.
 
 ## What is *Loop*?
 
-*Loop* is an app you build and load on an iPhone.
+_<span translate="no">Loop</span>_&nbsp;is an app you build and load on an iPhone.
 
-After building the *Loop* app:
+After building the&nbsp;_<span translate="no">Loop</span>_&nbsp;app:
 
 * You enter your personal therapy settings (e.g., carbohydrate ratio, basal rates, insulin sensitivity)
 * You enter the carbs you eat
-* *Loop* uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
-* You can choose to have *Loop* automatically control insulin dosing (closed-loop mode) or have *Loop* recommend insulin that you manually accept or modify (open-loop mode)
+*&nbsp;_<span translate="no">Loop</span>_&nbsp;uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
+* You can choose to have&nbsp;_<span translate="no">Loop</span>_&nbsp;automatically control insulin dosing (closed-loop mode) or have&nbsp;_<span translate="no">Loop</span>_&nbsp;recommend insulin that you manually accept or modify (open-loop mode)
 
 ![Loop main display on phone](img/phone-loop-3.svg){width="300"}
 ![Loop watch screen on watch](img/watch-loop-3.svg){width="200"}
 
 ### What is *Loop* Video
 
-If you have never used *Loop*, click on links below for an introduction.
+If you have never used&nbsp;_<span translate="no">Loop</span>_, click on links below for an introduction.
 
-!!! success " *Loop* Video"
-    * This [What is *Loop*](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
+!!! success "&nbsp;_<span translate="no">Loop</span>_&nbsp;Video"
+    * This [What is&nbsp;_<span translate="no">Loop</span>_](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
     * Special thanks to Tina and Reese Hammer for the terrific video
     * Special thanks to Matthew Fouse for the generous use of his beautiful graphics
 
@@ -48,12 +48,12 @@ If you have never used *Loop*, click on links below for an introduction.
 
 Please consult with your health care professional regarding your diabetes management.
 
-* The *Loop* app is an open source project used by many, but it is not approved for therapy by any government organization.
+* The&nbsp;_<span translate="no">Loop</span>_&nbsp;app is an open source project used by many, but it is not approved for therapy by any government organization.
 * **You take full responsibility for building and running this system and do so at your own risk.**
 
 ## Volunteer Community
 
-*Loop* has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to use this app because many volunteers have given their personal and family time.
+_<span translate="no">Loop</span>_&nbsp;has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to use this app because many volunteers have given their personal and family time.
 
-Please add your time by reading this website before embarking on your *Loop* journey.
+Please add your time by reading this website before embarking on your&nbsp;_<span translate="no">Loop</span>_&nbsp;journey.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,44 +3,44 @@ hide:
     - navigation
 ---
 
-## Welcome to&nbsp;<span translate="no">Loop</span>
+## Welcome to *Loop*
 
-Welcome to the&nbsp;<span translate="no">LoopDocs</span>&nbsp;website where you can learn about&nbsp;<span translate="no">Loop</span>.
+Welcome to the *LoopDocs* website where you can learn about *Loop*.
 
-This site shows you step-by-step how to **build**, **set up** and **operate** the&nbsp;<span translate="no">Loop</span>&nbsp;app.
+This site shows you step-by-step how to **build**, **set up** and **operate** the *Loop* app.
 
 * **You do not need a technical or computer background to do this**
-* **You can choose to build the&nbsp;<span translate="no">Loop</span>&nbsp;app using a [browser](gh-actions/gh-overview.md) on any computer and install it on your Apple phone via&nbsp;<span translate="no">TestFlight</span>&nbsp;**
+* **You can choose to build the *Loop* app using a [browser](gh-actions/gh-overview.md) on any computer and install it on your Apple phone via *TestFlight* **
 
 In order to become a proficient with the app, you should learn the information on this site. Consider doing this over a period of time and reviewing the materials more than once.
 
-* You should test and perhaps adjust your settings to be successful with&nbsp;<span translate="no">Loop</span>&nbsp;(or any hybrid closed-loop system)
+* You should test and perhaps adjust your settings to be successful with *Loop* (or any hybrid closed-loop system)
 * You will find links as you read to a robust volunteer support community
 
-Once you are using the app, you should regularly follow one or more support forums for important updates on&nbsp;<span translate="no">Loop</span>. Spending this time is important for success in building and operating&nbsp;<span translate="no">Loop</span>&nbsp;safely.
+Once you are using the app, you should regularly follow one or more support forums for important updates on *Loop*. Spending this time is important for success in building and operating *Loop* safely.
 
-This website is updated regularly to keep pace with&nbsp;<span translate="no">Loop</span>&nbsp;developments and&nbsp;<span translate="no">Apple</span>&nbsp;releases.
+This website is updated regularly to keep pace with *Loop* developments and *Apple* releases.
 
-## What is&nbsp;<span translate="no">Loop</span>?
+## What is *Loop*?
 
-<span translate="no">Loop</span>&nbsp;is an app you build and load on an iPhone.
+*Loop* is an app you build and load on an iPhone.
 
-After building the&nbsp;<span translate="no">Loop</span>&nbsp;app:
+After building the *Loop* app:
 
 * You enter your personal therapy settings (e.g., carbohydrate ratio, basal rates, insulin sensitivity)
 * You enter the carbs you eat
-* <span translate="no">Loop</span>&nbsp;uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
-* You can choose to have&nbsp;<span translate="no">Loop</span>&nbsp;automatically control insulin dosing (closed-loop mode) or have&nbsp;<span translate="no">Loop</span>&nbsp;recommend insulin that you manually accept or modify (open-loop mode)
+* *Loop* uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
+* You can choose to have *Loop* automatically control insulin dosing (closed-loop mode) or have *Loop* recommend insulin that you manually accept or modify (open-loop mode)
 
 ![Loop main display on phone](img/phone-loop-3.svg){width="300"}
 ![Loop watch screen on watch](img/watch-loop-3.svg){width="200"}
 
-### What is&nbsp;<span translate="no">Loop</span>&nbsp;Video
+### What is *Loop* Video
 
-If you have never used&nbsp;<span translate="no">Loop</span>, click on links below for an introduction.
+If you have never used *Loop*, click on links below for an introduction.
 
-!!! success "&nbsp;<span translate="no">Loop</span>&nbsp;Video"
-    * This [What is&nbsp;<span translate="no">Loop</span>](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
+!!! success " *Loop* Video"
+    * This [What is *Loop*](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
     * Special thanks to Tina and Reese Hammer for the terrific video
     * Special thanks to Matthew Fouse for the generous use of his beautiful graphics
 
@@ -48,12 +48,12 @@ If you have never used&nbsp;<span translate="no">Loop</span>, click on links bel
 
 Please consult with your health care professional regarding your diabetes management.
 
-* The&nbsp;<span translate="no">Loop</span>&nbsp;app is an open source project used by many, but it is not approved for therapy by any government organization.
+* The *Loop* app is an open source project used by many, but it is not approved for therapy by any government organization.
 * **You take full responsibility for building and running this system and do so at your own risk.**
 
 ## Volunteer Community
 
-<span translate="no">Loop</span>&nbsp;has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to use this app because many volunteers have given their personal and family time.
+*Loop* has been, and continues to be, developed and supported by volunteers. From the code to this website, you are able to use this app because many volunteers have given their personal and family time.
 
-Please add your time by reading this website before embarking on your&nbsp;<span translate="no">Loop</span>&nbsp;journey.
+Please add your time by reading this website before embarking on your *Loop* journey.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ hide:
     - navigation
 ---
 
-## Welcome to *Loop*
+## Welcome to&nbsp;_<span translate="no">Loop</span>_
 
 Welcome to the *LoopDocs* website where you can learn about&nbsp;_<span translate="no">Loop</span>_.
 
@@ -21,7 +21,7 @@ Once you are using the app, you should regularly follow one or more support foru
 
 This website is updated regularly to keep pace with&nbsp;_<span translate="no">Loop</span>_&nbsp;developments and *Apple* releases.
 
-## What is *Loop*?
+## What is&nbsp;_<span translate="no">Loop</span>_?
 
 _<span translate="no">Loop</span>_&nbsp;is an app you build and load on an iPhone.
 
@@ -35,7 +35,7 @@ After building the&nbsp;_<span translate="no">Loop</span>_&nbsp;app:
 ![Loop main display on phone](img/phone-loop-3.svg){width="300"}
 ![Loop watch screen on watch](img/watch-loop-3.svg){width="200"}
 
-### What is *Loop* Video
+### What is&nbsp;_<span translate="no">Loop</span>_&nbsp;Video
 
 If you have never used&nbsp;_<span translate="no">Loop</span>_, click on links below for an introduction.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ After building the&nbsp;_<span translate="no">Loop</span>_&nbsp;app:
 
 * You enter your personal therapy settings (e.g., carbohydrate ratio, basal rates, insulin sensitivity)
 * You enter the carbs you eat
-*&nbsp;_<span translate="no">Loop</span>_&nbsp;uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
+* &nbsp;_<span translate="no">Loop</span>_&nbsp;uses this information, your insulin on board (IOB) and glucose data, to determine how much insulin you need to bring your blood glucose within the target range you set
 * You can choose to have&nbsp;_<span translate="no">Loop</span>_&nbsp;automatically control insulin dosing (closed-loop mode) or have&nbsp;_<span translate="no">Loop</span>_&nbsp;recommend insulin that you manually accept or modify (open-loop mode)
 
 ![Loop main display on phone](img/phone-loop-3.svg){width="300"}

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -1,42 +1,42 @@
-It is totally understandable if the thought of building and operating your own *Loop* app feels intimidating. As you learn the information explained in *LoopDocs*, this will start feeling more comfortable.
+It is totally understandable if the thought of building and operating your own&nbsp;<span translate="no">Loop</span>&nbsp;app feels intimidating. As you learn the information explained in&nbsp;<span translate="no">LoopDocs</span>, this will start feeling more comfortable.
 
-## *LoopDocs* Contents
+## <span translate="no">LoopDocs</span>&nbsp;Contents
 
-The *LoopDocs* website is organized as follows
+The&nbsp;<span translate="no">LoopDocs</span>&nbsp;website is organized as follows
 
-* [Home](../index.md): What is *Loop*?
-* [Intro](overview-intro.md): Introduction to *LoopDocs*
+* [Home](../index.md): What is&nbsp;<span translate="no">Loop</span>?
+* [Intro](overview-intro.md): Introduction to&nbsp;<span translate="no">LoopDocs</span>
     * [Requirements](requirements.md): What is needed regardless of build method
 * New with&nbsp;<span translate="no">Loop 3</span>: Two ways to build - you get the same app either way
-    * [Build with Browser](../gh-actions/gh-overview.md): Build *Loop* app using a browser
-    * [Build with Mac-Xcode](../build/overview.md): Build *Loop* app with a Mac the first time, or [Update](../build/updating.md) next time
-* [Set Up](../loop-3/loop-3-overview.md): How to set up the *Loop* app
-* [Operate](../operation/loop/open-loop.md): How to use the *Loop* app
-* [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the *Loop* app
-* [Version](../version/overview-version.md): Information about *Loop* versions, code customization and development
-* [<span translate="no">Nightscout</span>](../nightscout/overview.md): *Loop*-specific *Nightscout* details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
-    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a *Loop* app using *Nightscout* and Apple Push Notifications
+    * [Build with Browser](../gh-actions/gh-overview.md): Build&nbsp;<span translate="no">Loop</span>&nbsp;app using a browser
+    * [Build with Mac-Xcode](../build/overview.md): Build&nbsp;<span translate="no">Loop</span>&nbsp;app with a Mac the first time, or [Update](../build/updating.md) next time
+* [Set Up](../loop-3/loop-3-overview.md): How to set up the&nbsp;<span translate="no">Loop</span>&nbsp;app
+* [Operate](../operation/loop/open-loop.md): How to use the&nbsp;<span translate="no">Loop</span>&nbsp;app
+* [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the&nbsp;<span translate="no">Loop</span>&nbsp;app
+* [Version](../version/overview-version.md): Information about&nbsp;<span translate="no">Loop</span>&nbsp;versions, code customization and development
+* [<span translate="no">Nightscout</span>](../nightscout/overview.md): <span translate="no">Loop</span>-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
+    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a&nbsp;<span translate="no">Loop</span>&nbsp;app using&nbsp;<span translate="no">Nightscout</span>&nbsp;and Apple Push Notifications
     * [Loop Caregiver](../nightscout/loop-caregiver.md): Companion app useful for remote commands
 * [FAQs](../faqs/overview-faqs.md): Pages with safety tips, frequently asked questions and the Glossary
 * [Translation](../translate.md): Links to Google Translate provided as a convenience, no guaratees about the quality of the translation
 
-## Building *Loop*
+## Building&nbsp;<span translate="no">Loop</span>
 
-The process for building the *Loop* app is divided into short segments (sections or pages) in the Build tabs of *LoopDocs*.
+The process for building the&nbsp;<span translate="no">Loop</span>&nbsp;app is divided into short segments (sections or pages) in the Build tabs of&nbsp;<span translate="no">LoopDocs</span>.
 
 !!! warning "Best Practice: Learn to Build"
-    You are strongly encouraged to build *Loop* for yourself.
+    You are strongly encouraged to build&nbsp;<span translate="no">Loop</span>&nbsp;for yourself.
 
-    * No links to providers who build *Loop* as a service  are found in *LoopDocs*
+    * No links to providers who build&nbsp;<span translate="no">Loop</span>&nbsp;as a service  are found in&nbsp;<span translate="no">LoopDocs</span>
     * If you choose to use such a service, before you begin, you should:
-        * Read *LoopDocs*
-        * Know how to Set up and Operate *Loop*
+        * Read&nbsp;<span translate="no">LoopDocs</span>
+        * Know how to Set up and Operate&nbsp;<span translate="no">Loop</span>
         * Ask what features, if any, available with DIY loop are not available with their service
         * **These steps are important for your safety**
 
 ### Using a Simulator
 
-You can build *Loop* and practice with a simulated phone, CGM and/or pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
+You can build&nbsp;<span translate="no">Loop</span>&nbsp;and practice with a simulated phone, CGM and/or pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
 
 Starting with a simulator can help you decide if you want to move forward with purchasing additional items required to use the app. You can:
 
@@ -48,24 +48,24 @@ Starting with a simulator can help you decide if you want to move forward with p
 
 Please review [Simulator Build](../version/simulator.md) for more information.
 
-## Operating *Loop*
+## Operating&nbsp;<span translate="no">Loop</span>
 
-A significant amount of content is provided on this website and via link to other sources. Please review these pages when initially setting up and learning to use *Loop*.
+A significant amount of content is provided on this website and via link to other sources. Please review these pages when initially setting up and learning to use&nbsp;<span translate="no">Loop</span>.
 
-Some techniques are specific to *Loop*, but the general concepts of how man-made insulin works and strategies to test basal, carb ratios and insulin sensitivity apply to all the hybrid closed-loop systems, commercial and open source.
+Some techniques are specific to&nbsp;<span translate="no">Loop</span>, but the general concepts of how man-made insulin works and strategies to test basal, carb ratios and insulin sensitivity apply to all the hybrid closed-loop systems, commercial and open source.
 
 ## Development History
 
-*Loop* is an open-source, shared project. The entire project has been, and continues to be, done by volunteers. From the code to the website, you're getting all this because dozens of volunteers have given their time, so please add your time by reading this website thoroughly before embarking on your *Loop* journey.
+<span translate="no">Loop</span>&nbsp;is an open-source, shared project. The entire project has been, and continues to be, done by volunteers. From the code to the website, you're getting all this because dozens of volunteers have given their time, so please add your time by reading this website thoroughly before embarking on your&nbsp;<span translate="no">Loop</span>&nbsp;journey.
 
 Here are development history links to other resources for you to explore.
 
-* The early history of *Loop* development:
-    * [History of *Loop* and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805), written by *Loop* developer Nate Racklyeft
+* The early history of&nbsp;<span translate="no">Loop</span>&nbsp;development:
+    * [History of&nbsp;<span translate="no">Loop</span>&nbsp;and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805), written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Nate Racklyeft
 
 * The early days and the many advances brought about by the `#We Are Not Waiting` diabetes community:
     * [The Artificial Pancreas Book](https://www.artificialpancreasbook.com/) written by Dana Lewis and check out her website [DIYPS](https://diyps.org).
 
-* How the Omnipod Eros pods were cracked to work with *Loop*:
-    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by *Loop* developer Pete Schwamb
+* How the Omnipod Eros pods were cracked to work with&nbsp;<span translate="no">Loop</span>:
+    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Pete Schwamb
     * [Deep Dip Teardown of Tubeless Insulin Pump](https://arxiv.org/ftp/arxiv/papers/1709/1709.06026.pdf) by Sergei Skorobogatov

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -1,42 +1,42 @@
-It is totally understandable if the thought of building and operating your own&nbsp;<span translate="no">Loop</span>&nbsp;app feels intimidating. As you learn the information explained in&nbsp;<span translate="no">LoopDocs</span>, this will start feeling more comfortable.
+It is totally understandable if the thought of building and operating your own *Loop* app feels intimidating. As you learn the information explained in *LoopDocs*, this will start feeling more comfortable.
 
-## <span translate="no">LoopDocs</span>&nbsp;Contents
+## *LoopDocs* Contents
 
-The&nbsp;<span translate="no">LoopDocs</span>&nbsp;website is organized as follows
+The *LoopDocs* website is organized as follows
 
-* [Home](../index.md): What is&nbsp;<span translate="no">Loop</span>?
-* [Intro](overview-intro.md): Introduction to&nbsp;<span translate="no">LoopDocs</span>
+* [Home](../index.md): What is *Loop*?
+* [Intro](overview-intro.md): Introduction to *LoopDocs*
     * [Requirements](requirements.md): What is needed regardless of build method
 * New with&nbsp;<span translate="no">Loop 3</span>: Two ways to build - you get the same app either way
-    * [Build with Browser](../gh-actions/gh-overview.md): Build&nbsp;<span translate="no">Loop</span>&nbsp;app using a browser
-    * [Build with Mac-Xcode](../build/overview.md): Build&nbsp;<span translate="no">Loop</span>&nbsp;app with a Mac the first time, or [Update](../build/updating.md) next time
-* [Set Up](../loop-3/loop-3-overview.md): How to set up the&nbsp;<span translate="no">Loop</span>&nbsp;app
-* [Operate](../operation/loop/open-loop.md): How to use the&nbsp;<span translate="no">Loop</span>&nbsp;app
-* [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the&nbsp;<span translate="no">Loop</span>&nbsp;app
-* [Version](../version/overview-version.md): Information about&nbsp;<span translate="no">Loop</span>&nbsp;versions, code customization and development
-* [<span translate="no">Nightscout</span>](../nightscout/overview.md): <span translate="no">Loop</span>-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
-    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a&nbsp;<span translate="no">Loop</span>&nbsp;app using&nbsp;<span translate="no">Nightscout</span>&nbsp;and Apple Push Notifications
+    * [Build with Browser](../gh-actions/gh-overview.md): Build *Loop* app using a browser
+    * [Build with Mac-Xcode](../build/overview.md): Build *Loop* app with a Mac the first time, or [Update](../build/updating.md) next time
+* [Set Up](../loop-3/loop-3-overview.md): How to set up the *Loop* app
+* [Operate](../operation/loop/open-loop.md): How to use the *Loop* app
+* [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the *Loop* app
+* [Version](../version/overview-version.md): Information about *Loop* versions, code customization and development
+* [<span translate="no">Nightscout</span>](../nightscout/overview.md): *Loop*-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
+    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a *Loop* app using&nbsp;<span translate="no">Nightscout</span>&nbsp;and Apple Push Notifications
     * [Loop Caregiver](../nightscout/loop-caregiver.md): Companion app useful for remote commands
 * [FAQs](../faqs/overview-faqs.md): Pages with safety tips, frequently asked questions and the Glossary
 * [Translation](../translate.md): Links to Google Translate provided as a convenience, no guaratees about the quality of the translation
 
-## Building&nbsp;<span translate="no">Loop</span>
+## Building *Loop*
 
-The process for building the&nbsp;<span translate="no">Loop</span>&nbsp;app is divided into short segments (sections or pages) in the Build tabs of&nbsp;<span translate="no">LoopDocs</span>.
+The process for building the *Loop* app is divided into short segments (sections or pages) in the Build tabs of *LoopDocs*.
 
 !!! warning "Best Practice: Learn to Build"
-    You are strongly encouraged to build&nbsp;<span translate="no">Loop</span>&nbsp;for yourself.
+    You are strongly encouraged to build *Loop* for yourself.
 
-    * No links to providers who build&nbsp;<span translate="no">Loop</span>&nbsp;as a service  are found in&nbsp;<span translate="no">LoopDocs</span>
+    * No links to providers who build *Loop* as a service  are found in *LoopDocs*
     * If you choose to use such a service, before you begin, you should:
-        * Read&nbsp;<span translate="no">LoopDocs</span>
-        * Know how to Set up and Operate&nbsp;<span translate="no">Loop</span>
+        * Read *LoopDocs*
+        * Know how to Set up and Operate *Loop*
         * Ask what features, if any, available with DIY loop are not available with their service
         * **These steps are important for your safety**
 
 ### Using a Simulator
 
-You can build&nbsp;<span translate="no">Loop</span>&nbsp;and practice with a simulated phone, CGM and/or pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
+You can build *Loop* and practice with a simulated phone, CGM and/or pump. You can "dose" the simulated pump and your real pump at the same time and watch the glucose predictions.
 
 Starting with a simulator can help you decide if you want to move forward with purchasing additional items required to use the app. You can:
 
@@ -48,24 +48,24 @@ Starting with a simulator can help you decide if you want to move forward with p
 
 Please review [Simulator Build](../version/simulator.md) for more information.
 
-## Operating&nbsp;<span translate="no">Loop</span>
+## Operating *Loop*
 
-A significant amount of content is provided on this website and via link to other sources. Please review these pages when initially setting up and learning to use&nbsp;<span translate="no">Loop</span>.
+A significant amount of content is provided on this website and via link to other sources. Please review these pages when initially setting up and learning to use *Loop*.
 
-Some techniques are specific to&nbsp;<span translate="no">Loop</span>, but the general concepts of how man-made insulin works and strategies to test basal, carb ratios and insulin sensitivity apply to all the hybrid closed-loop systems, commercial and open source.
+Some techniques are specific to *Loop*, but the general concepts of how man-made insulin works and strategies to test basal, carb ratios and insulin sensitivity apply to all the hybrid closed-loop systems, commercial and open source.
 
 ## Development History
 
-<span translate="no">Loop</span>&nbsp;is an open-source, shared project. The entire project has been, and continues to be, done by volunteers. From the code to the website, you're getting all this because dozens of volunteers have given their time, so please add your time by reading this website thoroughly before embarking on your&nbsp;<span translate="no">Loop</span>&nbsp;journey.
+*Loop* is an open-source, shared project. The entire project has been, and continues to be, done by volunteers. From the code to the website, you're getting all this because dozens of volunteers have given their time, so please add your time by reading this website thoroughly before embarking on your *Loop* journey.
 
 Here are development history links to other resources for you to explore.
 
-* The early history of&nbsp;<span translate="no">Loop</span>&nbsp;development:
-    * [History of&nbsp;<span translate="no">Loop</span>&nbsp;and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805), written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Nate Racklyeft
+* The early history of *Loop* development:
+    * [History of *Loop* and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805), written by *Loop* developer Nate Racklyeft
 
 * The early days and the many advances brought about by the `#We Are Not Waiting` diabetes community:
     * [The Artificial Pancreas Book](https://www.artificialpancreasbook.com/) written by Dana Lewis and check out her website [DIYPS](https://diyps.org).
 
-* How the Omnipod Eros pods were cracked to work with&nbsp;<span translate="no">Loop</span>:
-    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Pete Schwamb
+* How the Omnipod Eros pods were cracked to work with *Loop*:
+    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by *Loop* developer Pete Schwamb
     * [Deep Dip Teardown of Tubeless Insulin Pump](https://arxiv.org/ftp/arxiv/papers/1709/1709.06026.pdf) by Sergei Skorobogatov

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -14,8 +14,8 @@ The *LoopDocs* website is organized as follows
 * [Operate](../operation/loop/open-loop.md): How to use the *Loop* app
 * [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the *Loop* app
 * [Version](../version/overview-version.md): Information about *Loop* versions, code customization and development
-* [<span translate="no">Nightscout</span>](../nightscout/overview.md): *Loop*-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
-    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a *Loop* app using&nbsp;<span translate="no">Nightscout</span>&nbsp;and Apple Push Notifications
+* [<span translate="no">Nightscout</span>](../nightscout/overview.md): *Loop*-specific *Nightscout* details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
+    * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a *Loop* app using *Nightscout* and Apple Push Notifications
     * [Loop Caregiver](../nightscout/loop-caregiver.md): Companion app useful for remote commands
 * [FAQs](../faqs/overview-faqs.md): Pages with safety tips, frequently asked questions and the Glossary
 * [Translation](../translate.md): Links to Google Translate provided as a convenience, no guaratees about the quality of the translation

--- a/docs/intro/requirements.md
+++ b/docs/intro/requirements.md
@@ -1,8 +1,8 @@
 ## Two Ways to Build the App
 
-With the release of&nbsp;<span translate="no">Loop 3</span>&nbsp;, there are two ways to build the app.
+With the release of&nbsp;_<span translate="no">Loop 3</span>_&nbsp;, there are two ways to build the app.
 
-* If you have never built *Loop* before, we recommend you use the Build with Browser method.
+* If you have never built&nbsp;_<span translate="no">Loop</span>_&nbsp;before, we recommend you use the Build with Browser method.
 * If you use a Mac and keep the operating system up to date all the time, then you may prefer the Mac-Xcode method.
 
 The Build Steps have been split into two tabs:

--- a/docs/intro/requirements.md
+++ b/docs/intro/requirements.md
@@ -2,14 +2,14 @@
 
 With the release of&nbsp;<span translate="no">Loop 3</span>&nbsp;, there are two ways to build the app.
 
-* If you have never built&nbsp;<span translate="no">Loop</span>&nbsp;before, we recommend you use the Build with Browser method.
+* If you have never built *Loop* before, we recommend you use the Build with Browser method.
 * If you use a Mac and keep the operating system up to date all the time, then you may prefer the Mac-Xcode method.
 
 The Build Steps have been split into two tabs:
 
 * [Build with Browser](../gh-actions/gh-overview.md)
     * Build with a browser on any computer or tablet
-    * App is installed on the phone using&nbsp;<span translate="no">TestFlight</span>
+    * App is installed on the phone using *TestFlight*
 * [Build with Mac-Xcode](../build/overview.md)
     * App is built on a Mac with Xcode connected to the phone
     * The operating system on the Mac and the version of Xcode must be kept up-to-date
@@ -32,7 +32,7 @@ These requirements are independent of how you build the Loop app:
 
 If you plan to build using the Build with Browser instructions, you also need:
 
-1.  A free&nbsp;<span translate="no">GitHub</span>&nbsp;account
+1.  A free *GitHub* account
 
 Detailed instructions are included in the link above.
 

--- a/docs/nightscout/loop-caregiver.md
+++ b/docs/nightscout/loop-caregiver.md
@@ -1,14 +1,14 @@
-## <span translate="no">Loop Caregiver</span>&nbsp;   ![icon for &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app](img/lcg-icon.jpg){width="50"}
+## *Loop Caregiver*   ![icon for *Loop Caregiver* app](img/lcg-icon.jpg){width="50"}
 
-The &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app is under development to make remote commands easier to implement and monitor.
+The *Loop Caregiver* app is under development to make remote commands easier to implement and monitor.
 
 ### Minimum Requirements:
 
-* <span translate="no">Loop</span>&nbsp; version 3.2.0 or newer
+* *Loop* version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
-    * version 3.3 and higher offers improved feedback to the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; user
-* iOS 16 or newer for &nbsp;<span translate="no">Loop Caregiver</span>&nbsp;&#39;s phone
-* iOS 15.1 with *Loop* 3 for Looper&#39;s phone
+    * version 3.3 and higher offers improved feedback to the *Loop Caregiver* user
+* iOS 16 or newer for *Loop Caregiver* phone
+* iOS 15.1 with *Loop 3* for *Loop* phone
 * <span translate="no">Nightscout</span>&nbsp; version 14.2.6
 
 ### Prerequisites:
@@ -29,13 +29,13 @@ The &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app is under developm
     * Please take the time to update your *Nightscout* site to `master`
     * *Nightscout* 14.2.6 was released 30-Sep-2022 as `Classic Liquorice`
 
-If you use &nbsp;<span translate="no">Loop Caregiver</span>, please join &nbsp;[<span translate="no">Loop Caregiver App</span>](https://loop.zulipchat.com/#narrow/stream/358458-Loop-Caregiver-App) *Zulipchat* stream.
+If you use *Loop Caregiver*, please join [*Loop Caregiver* App](https://loop.zulipchat.com/#narrow/stream/358458-Loop-Caregiver-App) *Zulipchat* stream.
 
 **As with all development code, monitor *Zulipchat* for announcements, report any problems you experience, be prepared to build frequently, and pay attention.**
 
-## Build &nbsp;<span translate="no">Loop Caregiver</span>
+## Build *Loop Caregiver*
 
-You can build &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; using the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; method or the &nbsp;[<span translate="no">Mac-Xcode Build</span>](#mac-xcode-build) method.
+You can build *Loop Caregiver* using the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; method or the &nbsp;[<span translate="no">Mac-Xcode Build</span>](#mac-xcode-build) method.
 
 ### GitHub Browser Build:
 
@@ -43,7 +43,7 @@ The &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; method is docum
 
 ### Mac-Xcode Build:
 
-A build script is available to assist in building &nbsp;<span translate="no">Loop Caregiver</span>. This should be straightforward for anyone who has previously built &nbsp;<span translate="no">Loop 3</span>&nbsp; using the script.
+A build script is available to assist in building *Loop Caregiver*. This should be straightforward for anyone who has previously built &nbsp;<span translate="no">Loop 3</span>&nbsp; using the script.
 
 - Open a terminal window. 
 - Spot the line below that starts with `/bin/bash`
@@ -64,18 +64,18 @@ A build script is available to assist in building &nbsp;<span translate="no">Loo
 - The script displays the directions for downloading and building.    
     Please read them carefully.
 
-!!! warning "Not &nbsp;_<span translate="no">Loop</span>_"
-    The output you see in the Terminal may look very similar to when you build &nbsp;_<span translate="no">Loop 3</span>_&nbsp; from a script.
+!!! warning "Not *Loop*"
+    The output you see in the Terminal may look very similar to when you build *Loop 3* from a script.
     
-    It is pulling down a clone from a different location (<span translate="no">LoopKit/LoopCaregiver</span>&nbsp;). It uses some modules from *Loop*. The target and scheme are automatically selected for *&nbsp;<span translate="no">Loop Caregiver</span>&nbsp;* and if you follow directions for a paid Developer account, the signing is automatic.
+    It is pulling down a clone from a different location (*LoopKit/LoopCaregiver*). It uses some modules from *Loop*. The target and scheme are automatically selected for *Loop Caregiver*  and if you follow directions for a paid Developer account, the signing is automatic.
 
-## Use &nbsp;<span translate="no">Loop Caregiver</span>
+## Use *Loop Caregiver*
 
-Some limited directions for using the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app are provided - please also read the *Zulipchat* stream to stay up-to-date with improvements - especially if you are using a development branch of &nbsp;<span translate="no">Loop</span>.
+Some limited directions for using the *Loop Caregiver* app are provided - please also read the *Zulipchat* stream to stay up-to-date with improvements - especially if you are using a development branch of  *Loop*.
 
-### <span translate="no">Loop Caregiver</span>&nbsp; Add Looper
+### *Loop Caregiver* Add Looper
 
-You must add a Looper to continue with &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; as shown in the graphic below.
+You must add a Looper to continue with *Loop Caregiver* as shown in the graphic below.
 
 ![add Looper to Loop Caregiver](img/lcg-add-looper.png){width="300"}
 {align="center"}
@@ -86,21 +86,21 @@ You must add a Looper to continue with &nbsp;<span translate="no">Loop Caregiver
     !!! tip "Pro-tip"
         Take a screenshot of the QR code and store it on your computer.
         
-        You can then add the QR code to *&nbsp;<span translate="no">Loop Caregiver</span>&nbsp;* without bothering your Looper.
+        You can then add the QR code to *Loop Caregiver*  without bothering your Looper.
 
         * Keep the screenshot secure
         * Do not share the QR screenshot when asking for help
 
-* On the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp;&#39;s phone:
-    * Tap on &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; -> `Settings`
+* On the *Loop Caregiver* &#39;s phone:
+    * Tap on *Loop Caregiver* -> `Settings`
     * Enter the name of the Looper, the *Nightscout* URL (use &nbsp;<span translate="no"> http**s**://</span>&nbsp;) and `API_SECRET`
     * Touch the QR code row - this opens the camera - point the camera at the QR code from Looper's phone
 
-You can add additional Looper's under settings. (*<span translate="no">Loop Caregiver</span>&nbsp;* can monitor more than one Looper).
+You can add additional Looper's under settings. (**Loop Caregiver* * can monitor more than one Looper).
 
-### <span translate="no">Loop Caregiver</span>&nbsp; Main Screen
+### *Loop Caregiver* Main Screen
 
-*&nbsp;<span translate="no">Loop Caregiver</span>&nbsp;* uses a lot of features from *Loop* with some Nightscout-like features in the Timeline.
+* *Loop Caregiver* * uses a lot of features from *Loop* with some Nightscout-like features in the Timeline.
 
 The Timeline:
 
@@ -109,22 +109,22 @@ The Timeline:
 * Horizontal display can be adjusted using the dropdown hours selector and scrolling left/right.
 * A double tap on the Timeline alternates between 1 and 6 hour display
 
-![main screen of the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app](img/lcg-main.jpg){width="300"}
+![main screen of the *Loop Caregiver* app](img/lcg-main.jpg){width="300"}
 {align="center"}
 
 
-You can also use the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; -> `Settings` screen to modify:
+You can also use the *Loop Caregiver* -> `Settings` screen to modify:
 
 * Units used for glucose display: `mg/dL` or `mmol/L`
-* Include the &nbsp;*&nbsp;<span translate="no">Loop</span>&nbsp;* forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
+* Include the &nbsp;* *Loop* * forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
 
-### Issue Remote Commands with &nbsp;<span translate="no">Loop Caregiver</span>
+### Issue Remote Commands with *Loop Caregiver*
 
 You issue override, carb, and bolus commands using a toolbar similar to the one seen on *Loop*. In the example graphic above, the carb and bolus entries visible were issued remotely.
 
-Carb and bolus commands each require authorization before they are accepted. The authorization (*FaceID*, Fingerprint, or passcode) matches that required to unlock the &nbsp;<span translate="no">Loop Caregiver</span>&nbsp;&#39;s phone.
+Carb and bolus commands each require authorization before they are accepted. The authorization (*FaceID*, Fingerprint, or passcode) matches that required to unlock the *Loop Caregiver* &#39;s phone.
 
-The use of *&nbsp;<span translate="no">Loop Caregiver</span>&nbsp;* makes remote commands much easier and more reliable.
+The use of * *Loop Caregiver* * makes remote commands much easier and more reliable.
 
 Go back and review the details about [Remote Commands](remote-commands.md) before using the app.
 

--- a/docs/nightscout/loop-caregiver.md
+++ b/docs/nightscout/loop-caregiver.md
@@ -63,14 +63,14 @@ A build script is available to assist in building *Loop Caregiver*. This should 
 - The script displays the directions for downloading and building.    
     Please read them carefully.
 
-!!! warning "Not *Loop*"
+!!! warning "Not&nbsp;_<span translate="no">Loop</span>_"
     The output you see in the Terminal may look very similar to when you build *Loop 3* from a script.
     
-    It is pulling down a clone from a different location (*LoopKit/LoopCaregiver*). It uses some modules from *Loop*. The target and scheme are automatically selected for *Loop Caregiver*  and if you follow directions for a paid Developer account, the signing is automatic.
+    It is pulling down a clone from a different location (*LoopKit/LoopCaregiver*). It uses some modules from&nbsp;_<span translate="no">Loop</span>_. The target and scheme are automatically selected for *Loop Caregiver*  and if you follow directions for a paid Developer account, the signing is automatic.
 
 ## Use *Loop Caregiver*
 
-Some limited directions for using the *Loop Caregiver* app are provided - please also read the *Zulipchat* stream to stay up-to-date with improvements - especially if you are using a development branch of  *Loop*.
+Some limited directions for using the *Loop Caregiver* app are provided - please also read the *Zulipchat* stream to stay up-to-date with improvements - especially if you are using a development branch of &nbsp;_<span translate="no">Loop</span>_.
 
 ### *Loop Caregiver* Add Looper
 
@@ -79,7 +79,7 @@ You must add a Looper to continue with *Loop Caregiver* as shown in the graphic 
 ![add Looper to Loop Caregiver](img/lcg-add-looper.png){width="300"}
 {align="center"}
 
-* On the *Loop* phone:
+* On the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone:
     * Tap on `Loop -> Settings -> Services -> Nightscout`
     * Tap on the `One-Time-Password` row to see the QR code  
     !!! tip "Pro-tip"
@@ -99,7 +99,7 @@ You can add additional more people under settings. (**Loop Caregiver* * can moni
 
 ### *Loop Caregiver* Main Screen
 
-* *Loop Caregiver* * uses a lot of features from *Loop* with some Nightscout-like features in the Timeline.
+* *Loop Caregiver* * uses a lot of features from&nbsp;_<span translate="no">Loop</span>_&nbsp;with some Nightscout-like features in the Timeline.
 
 The Timeline:
 
@@ -115,11 +115,11 @@ The Timeline:
 You can also use the *Loop Caregiver* -> `Settings` screen to modify:
 
 * Units used for glucose display: `mg/dL` or `mmol/L`
-* Include the *Loop* forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
+* Include the&nbsp;_<span translate="no">Loop</span>_&nbsp;forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
 
 ### Issue Remote Commands with *Loop Caregiver*
 
-You issue override, carb, and bolus commands using a toolbar similar to the one seen on *Loop*. In the example graphic above, the carb and bolus entries visible were issued remotely.
+You issue override, carb, and bolus commands using a toolbar similar to the one seen on&nbsp;_<span translate="no">Loop</span>_. In the example graphic above, the carb and bolus entries visible were issued remotely.
 
 Carb and bolus commands each require authorization before they are accepted. The authorization (*FaceID*, Fingerprint, or passcode) matches that required to unlock the *Loop Caregiver* &#39;s phone.
 

--- a/docs/nightscout/loop-caregiver.md
+++ b/docs/nightscout/loop-caregiver.md
@@ -9,7 +9,7 @@ The *Loop Caregiver* app is under development to make remote commands easier to 
     * version 3.3 and higher offers improved feedback to the *Loop Caregiver* user
 * iOS 16 or newer for *Loop Caregiver* phone
 * iOS 15.1 with *Loop 3* for *Loop* phone
-* <span translate="no">Nightscout</span>&nbsp; version 14.2.6
+* *Nightscout* version 14.2.6
 
 ### Prerequisites:
 

--- a/docs/nightscout/loop-caregiver.md
+++ b/docs/nightscout/loop-caregiver.md
@@ -4,11 +4,10 @@ The *Loop Caregiver* app is under development to make remote commands easier to 
 
 ### Minimum Requirements:
 
-* *Loop* version 3.2.0 or newer
+* _<span translate="no">Loop</span>_&nbsp;version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
     * version 3.3 and higher offers improved feedback to the *Loop Caregiver* user
 * iOS 16 or newer for *Loop Caregiver* phone
-* iOS 15.1 with *Loop 3* for *Loop* phone
 * *Nightscout* version 14.2.6
 
 ### Prerequisites:
@@ -80,7 +79,7 @@ You must add a Looper to continue with *Loop Caregiver* as shown in the graphic 
 ![add Looper to Loop Caregiver](img/lcg-add-looper.png){width="300"}
 {align="center"}
 
-* On the Looper&#39;s phone:
+* On the *Loop* phone:
     * Tap on `Loop -> Settings -> Services -> Nightscout`
     * Tap on the `One-Time-Password` row to see the QR code  
     !!! tip "Pro-tip"
@@ -91,12 +90,12 @@ You must add a Looper to continue with *Loop Caregiver* as shown in the graphic 
         * Keep the screenshot secure
         * Do not share the QR screenshot when asking for help
 
-* On the *Loop Caregiver* &#39;s phone:
+* On the *Loop Caregiver* phone:
     * Tap on *Loop Caregiver* -> `Settings`
     * Enter the name of the Looper, the *Nightscout* URL (use &nbsp;<span translate="no"> http**s**://</span>&nbsp;) and `API_SECRET`
     * Touch the QR code row - this opens the camera - point the camera at the QR code from Looper's phone
 
-You can add additional Looper's under settings. (**Loop Caregiver* * can monitor more than one Looper).
+You can add additional more people under settings. (**Loop Caregiver* * can monitor more than one Looper).
 
 ### *Loop Caregiver* Main Screen
 
@@ -116,7 +115,7 @@ The Timeline:
 You can also use the *Loop Caregiver* -> `Settings` screen to modify:
 
 * Units used for glucose display: `mg/dL` or `mmol/L`
-* Include the &nbsp;* *Loop* * forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
+* Include the *Loop* forecast display on the Timeline chart as well as the Glucose chart of the main display (`Show Prediction` is turned off in the graphic above)
 
 ### Issue Remote Commands with *Loop Caregiver*
 
@@ -124,7 +123,7 @@ You issue override, carb, and bolus commands using a toolbar similar to the one 
 
 Carb and bolus commands each require authorization before they are accepted. The authorization (*FaceID*, Fingerprint, or passcode) matches that required to unlock the *Loop Caregiver* &#39;s phone.
 
-The use of * *Loop Caregiver* * makes remote commands much easier and more reliable.
+The use of *Loop Caregiver* makes remote commands much easier and more reliable.
 
 Go back and review the details about [Remote Commands](remote-commands.md) before using the app.
 

--- a/docs/nightscout/remote-commands.md
+++ b/docs/nightscout/remote-commands.md
@@ -9,12 +9,12 @@ All remote commands require the configuration steps from [Remote Configuration](
     * There are some versions of &nbsp;<span translate="no">Nightscout</span>&nbsp; that provide a row for entry of an OTP for &nbsp;<span translate="no">Temporary Override</span>&nbsp; in the &nbsp;<span translate="no">Nightscout Careportal</span>
     * Leave that row blank
 
-!!! question "Do I have to use &nbsp;<span translate="no">Loop Caregiver</span>?"
+!!! question "Do I have to use *Loop Caregiver* ?"
     There are a number of methods for using remote commands.
 
     Things everyone needs to know are covered on this page, so you should read it regardless of how you plan to issue remote commands.
     
-    If you decide on &nbsp;<span translate="no">Loop Caregiver</span>, review both this page and &nbsp;[<span translate="no">Loop Caregiver</span>](loop-caregiver.md) page.
+    If you decide on *Loop Caregiver* , review both this page and &nbsp;[*Loop Caregiver*](loop-caregiver.md) page.
 
 ## QR Code
 
@@ -38,9 +38,9 @@ While you are on the Settings -> Services -> NightScout screen, notice that the 
 
 You need to set up an authentication app to generate one-time-passwords for remote bolus and carbs.
 
-One of the nice features of &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; is that it handles the one-time password (OTP) requirements for you.
+One of the nice features of *Loop Caregiver* is that it handles the one-time password (OTP) requirements for you.
 
-But even if you choose to use &nbsp;<span translate="no">Loop Caregiver</span>, you should configure an authentication app for cases where you don't have access to your &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; phone.
+But even if you choose to use *Loop Caregiver* , you should configure an authentication app for cases where you don't have access to your *Loop Caregiver* phone.
 
 There are several authentication apps that support one-time passwords.
 
@@ -93,10 +93,10 @@ There are other Authentication apps available. Here’s a few options that you c
 ## FAQs for all Remote Commands
 
 1. **If I have multiple &nbsp;<span translate="no">Nightscout</span>&nbsp; sites because I support multiple people with T1D looping, do I need multiple APNs Keys?**  
-   **Answer**: No. If you support multiple people using &nbsp;<span translate="no">Loop</span>, you can use the one APNs key in each of their &nbsp;<span translate="no">Nightscout</span>&nbsp; sites.
+   **Answer**: No. If you support multiple people using  *Loop*, you can use the one APNs key in each of their &nbsp;<span translate="no">Nightscout</span>&nbsp; sites.
 
 1. **How can I tell if it worked?**  
-   **Answer**: You should see your override pill in &nbsp;<span translate="no">Nightscout</span>, with &nbsp;<span>the  **NEXT** <span translate="no">Loop</span>&nbsp; cycle</span>, reflecting that the desired remote action took place. If you are near the &nbsp;<span translate="no">Loop</span>&nbsp; app, you should see the new override within less than 30 seconds or so.
+   **Answer**: You should see your override pill in &nbsp;<span translate="no">Nightscout</span>, with &nbsp;<span>the  **NEXT** *Loop* cycle</span>, reflecting that the desired remote action took place. If you are near the *Loop* app, you should see the new override within less than 30 seconds or so.
 
 ## FAQs on Remote Overrides
 
@@ -104,26 +104,26 @@ Don't forget to read [Loopdocs: Overrides](../operation/features/overrides.md).
 
 For remote overrides in particular:
 
-1. **Can I set a different override in *Nighscout* than I have programmed into &nbsp;<span translate="no">Loop</span>&nbsp; app?**  
+1. **Can I set a different override in *Nighscout* than I have programmed into *Loop* app?**  
    **Answer**: No. You will only be able to enact override presets already programmed into the Loop app.
 
-1. **If I didn't start the override in &nbsp;<span translate="no">Nightscout</span>&nbsp; (it was started in &nbsp;<span translate="no">Loop</span>&nbsp; itself), can I still use &nbsp;<span translate="no">Nightscout</span>&nbsp; to cancel it?**  
-   **Answer**: Yes. You can cancel an override set in &nbsp;<span translate="no">Loop</span>&nbsp; with a Nightscout-set cancel "temporary override" command in the careportal.
+1. **If I didn't start the override in &nbsp;<span translate="no">Nightscout</span>&nbsp; (it was started in *Loop* itself), can I still use &nbsp;<span translate="no">Nightscout</span>&nbsp; to cancel it?**  
+   **Answer**: Yes. You can cancel an override set in *Loop* with a Nightscout-set cancel "temporary override" command in the careportal.
 
-1. **Can I replace an override set in &nbsp;<span translate="no">Loop</span>&nbsp; with an override set in &nbsp;<span translate="no">Nightscout</span>?**  
+1. **Can I replace an override set in *Loop* with an override set in &nbsp;<span translate="no">Nightscout</span>?**  
    **Answer**: Yes.
 
 1. **Can I see on &nbsp;<span translate="no">Nightscout</span>&nbsp; when a temporary override has been set using the looper’s phone?**  
-   **Answer**: Yes. There will be a grey bar with the name of the override noted and the &nbsp;<span>&nbsp;<span translate="no">Loop</span>&nbsp; Pill</span>&nbsp; will display the targets and duration. Remember, there is a KNOWN issue with the grey bars, so use the pill as your best guide.
+   **Answer**: Yes. There will be a grey bar with the name of the override noted and the *Loop pill* will display the targets and duration. Remember, there is a KNOWN issue with the grey bars, so use the *pill* as your best guide.
 
 1. **Can a looper cancel a remote override**?  
-   **Answer**: Yes. They can tap the heart icon <font color="blue">:fontawesome-solid-heart-pulse:</font> in &nbsp;<span translate="no">Loop</span>&nbsp; so that it is no longer highlighted. This turns off the override, regardless of where it was initiated.
+   **Answer**: Yes. They can tap the heart icon <font color="blue">:fontawesome-solid-heart-pulse:</font> in *Loop* so that it is no longer highlighted. This turns off the override, regardless of where it was initiated.
 
-1. **I set a remote override in &nbsp;<span translate="no">Nightscout</span>&nbsp; but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the &nbsp;<span translate="no">Loop</span>&nbsp; app, so the override turned off. Will the override get reinstated  the next time &nbsp;<span translate="no">Loop</span>&nbsp; completes with internet access?**  
+1. **I set a remote override in &nbsp;<span translate="no">Nightscout</span>&nbsp; but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the *Loop* app, so the override turned off. Will the override get reinstated  the next time *Loop* completes with internet access?**  
    **Answer**: No. The *APN* is only sent once. You can set the remote override again if need be.
 
 1. **Can I schedule a remote override ahead of time using Nightscout?**    
-   **Answer**: No. When you set a remote override in &nbsp;<span translate="no">Nightscout</span>, it starts immediately and lasts for the duration programmed for that override in the &nbsp;<span translate="no">Loop</span>&nbsp; app. You can only set an override in advance using the &nbsp;<span translate="no">Loop</span>&nbsp; app.
+   **Answer**: No. When you set a remote override in &nbsp;<span translate="no">Nightscout</span>, it starts immediately and lasts for the duration programmed for that override in the *Loop* app. You can only set an override in advance using the *Loop* app.
 
 ## Remote Commands
 
@@ -156,28 +156,28 @@ You can see the danger of sending duplicate bolus/carbs so be careful. If a remo
     There are 2 scenarios of concern that could lead to too much insulin:
     
     * *Looper* is using the **`Temp Basal`** (temporary basal) Dosing Strategy
-        * <span translate="no">Loop</span>&nbsp; will initiate a max `Temp Basal` when it receives the carbs remote command
+        * *Loop* will initiate a max `Temp Basal` when it receives the carbs remote command
         * Your bolus will be accepted and take place in addition to the high temporary basal
     * *Looper* is using **`Automatic Bolus`** Dosing Strategy
-        * <span translate="no">Loop</span>&nbsp; will initiate 40% of the recommended dose when it receives the carbs remote command
+        * *Loop* will initiate 40% of the recommended dose when it receives the carbs remote command
         * Your bolus will be accepted and take place in addition to an automatic boluses
     
-    Typically, sending a remote carb entry alone is sufficient for &nbsp;<span translate="no">Loop</span>&nbsp; to know about the carbs and begin to dose for them.
+    Typically, sending a remote carb entry alone is sufficient for *Loop* to know about the carbs and begin to dose for them.
     
     If you really want to both bolus for carbs and enter carbs, then do it in that order.
     
-    1. The bolus, when accepted, will cause &nbsp;<span translate="no">Loop</span>&nbsp; to issue a 0 `Temp Basal` (temporary basal) (which is "safer")
-    2. The carbs, when accepted, will cause &nbsp;<span translate="no">Loop</span>&nbsp; to respond to the carbs while including the bolus already delivered and included in the Looper&#39; IOB
+    1. The bolus, when accepted, will cause *Loop* to issue a 0 `Temp Basal` (temporary basal) (which is "safer")
+    2. The carbs, when accepted, will cause *Loop* to respond to the carbs while including the bolus already delivered and included in the Looper&#39; IOB
     
     ❗️ Remember - you should pause at least 60 seconds between remote commands or the One-Time-Password (OTP) will be rejected as having already been used.
 
 ## Using Remote Commands
 
-There are four ways you can trigger your commands remotely; &nbsp;[<span translate="no">Loop Caregiver</span>](loop-caregiver.md) (link takes you to a new page), [Nightscout Careportal](#nightscout-careportal), [Shortcuts](#shortcuts), and [IFTTT](#ifttt).
+There are four ways you can trigger your commands remotely; &nbsp;[*Loop Caregiver*](loop-caregiver.md) (link takes you to a new page), [Nightscout Careportal](#nightscout-careportal), [Shortcuts](#shortcuts), and [IFTTT](#ifttt).
 
-### [<span translate="no">Loop Caregiver</span>](loop-caregiver.md)
+### [*Loop Caregiver*](loop-caregiver.md)
 
-Click the link above to read more about &nbsp;<span translate="no">Loop Caregiver</span>.
+Click the link above to read more about *Loop Caregiver* .
 
 ### <span translate="no">Nightscout Careportal</span>
 
@@ -188,7 +188,7 @@ Pay particular attention to these entries in the `ENABLE` line: `override` `care
 You'll also need to have your [site authenticated](update-user.md#authenticate-site) so that your &nbsp;<span translate="no">Careportal</span>&nbsp; is active to send remote overrides . 
 
 Once authenticated by entering your `API_SECRET`, there is a plus sign (:material-plus-thick:) in the upper right corner of your site. That is your *Careportal*. Tap the *Careportal* plus sign (:material-plus-thick:) and then scroll down in the `event type` menu to find `Temporary Override`.  
-Within there, you will find all your &nbsp;<span translate="no">Loop</span>&nbsp; override presets already loaded for you.
+Within there, you will find all your *Loop* override presets already loaded for you.
 
 #### Start and End Remote Override
 
@@ -216,13 +216,13 @@ Open your Nightscout site in a browser or app.
 
 Note that Loop will honor both the current OTP code and the one that just expired.
 
-If the Looper is with you, you can see the notification on their phone. You can see the entry on the &nbsp;<span translate="no">Loop</span>&nbsp; carbohydrate or the insulin displays to see if it went through.
+If the Looper is with you, you can see the notification on their phone. You can see the entry on the *Loop* carbohydrate or the insulin displays to see if it went through.
 
 If the Looper is not with you, you should see the result in the &nbsp;<span translate="no">Nightscout</span>&nbsp; dashboard within 5 minutes.
 
 ### Shortcuts
 
-If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate &nbsp;<span translate="no">Loop</span>&nbsp; overrides with &nbsp;<span translate="no">Nightscout</span>.
+If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate *Loop* overrides with &nbsp;<span translate="no">Nightscout</span>.
 
 !!! important "Important Note"
     Before you click on the download file below...save yourself some trouble.
@@ -238,7 +238,7 @@ If you want to make your life SUPER AMAZING, check out using the iPhone's Shortc
 
 Click these links on your iPhone and you'll be prompted to download the premade shortcuts (assuming you open the links in Safari browser on iPhone):
 
-[Comprehensive &nbsp;<span translate="no">Loop</span>&nbsp; Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut)
+[Comprehensive *Loop* Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut)
  *includes Set Remote Override, Cancel Override, Loop Troubleshooting Tips, Quick Text options, Manual BG entry, Bookmarks to websites, etc.*
 
 And if you want to save one click to get to these one functions more directly: these shortcuts are simplified to offer only one function:
@@ -253,8 +253,8 @@ And if you want to save one click to get to these one functions more directly: t
     After the download finishes, tap the button marked `AA` near your *Safari* address bar and tap `Downloads` (downloads)  to find and open the downloaded Shortcut.
     
     Wait a bit, and the shortcut's inner guts will be there...scroll ALL the way down to the bottom to click the button to save the untrusted shortcut
-3. When you enter your &nbsp;<span translate="no">Nightscout</span>&nbsp; URL in &nbsp;<span>the `URL` field</span>&nbsp; of the &nbsp;<span translate="no">Loop</span>&nbsp; shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
-4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup &nbsp;<span translate="no">Nightscout</span>&nbsp; and update your &nbsp;<span translate="no">Loop</span>&nbsp; app as described in steps 1-3 above.
+3. When you enter your &nbsp;<span translate="no">Nightscout</span>&nbsp; URL in &nbsp;<span>the `URL` field</span>&nbsp; of the *Loop* shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
+4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup &nbsp;<span translate="no">Nightscout</span>&nbsp; and update your *Loop* app as described in steps 1-3 above.
 5. You can absolutely customize these bits and pieces within the shortcut. Change the text messages, and change the links... It is totally up to you.
 
 ### *IFTTT*

--- a/docs/nightscout/remote-commands.md
+++ b/docs/nightscout/remote-commands.md
@@ -6,7 +6,7 @@ All remote commands require the configuration steps from [Remote Configuration](
     * The OTP updates every 30 seconds
     * Both the sending device and the Looper's phone must have automatic time enabled
 * Remote Overrides do not require a One-Time Password (OTP)
-    * There are some versions of &nbsp;<span translate="no">Nightscout</span>&nbsp; that provide a row for entry of an OTP for &nbsp;<span translate="no">Temporary Override</span>&nbsp; in the &nbsp;<span translate="no">Nightscout Careportal</span>
+    * There are some versions of *Nightscout* that provide a row for entry of an OTP for &nbsp;<span translate="no">Temporary Override</span>&nbsp; in the &nbsp;<span translate="no">Nightscout Careportal</span>
     * Leave that row blank
 
 !!! question "Do I have to use *Loop Caregiver* ?"
@@ -18,7 +18,7 @@ All remote commands require the configuration steps from [Remote Configuration](
 
 ## QR Code
 
-On the Looper's phone, &nbsp;<span translate="no">Nightscout</span>&nbsp; must be included under the `Loop` -> Settings -> Services section. Navigate to Services and select &nbsp;<span translate="no">Nightscout</span>. Tap on the One-Time Password row to view the QR code.
+On the Looper's phone, *Nightscout* must be included under the `Loop` -> Settings -> Services section. Navigate to Services and select *Nightscout*. Tap on the One-Time Password row to view the QR code.
 
 When you need to configure your authentication method, you can either use a saved QR screenshot or scan the QR on the Looper's phone.
 
@@ -46,9 +46,9 @@ There are several authentication apps that support one-time passwords.
 
 ### <span translate="no">Apple Keychain</span>
 
-If you are using a iPhone or Mac to issue remote commands through a browser or &nbsp;<span translate="no">Nightscout</span>&nbsp; app, you can use the &nbsp;<span translate="no">Apple Keychain</span>&nbsp; which has native support to store passwords and generate one-time passwords. 
+If you are using a iPhone or Mac to issue remote commands through a browser or *Nightscout* app, you can use the &nbsp;<span translate="no">Apple Keychain</span>&nbsp; which has native support to store passwords and generate one-time passwords. 
 
-To setup your &nbsp;<span translate="no">Nightscout</span>&nbsp; credentials in &nbsp;<span translate="no">Apple Keychain</span>:
+To setup your *Nightscout* credentials in &nbsp;<span translate="no">Apple Keychain</span>:
 
 On the Caregivers device (iPhone or Mac):
 
@@ -58,14 +58,14 @@ On the Caregivers device (iPhone or Mac):
     ![add password screen for apple keychain](img/add-password-apple-keychain.png ){width="500"}
     {align="center"}
 
-* You will enter your &nbsp;<span translate="no">Nightscout</span>&nbsp; credentials
-    * Website: Enter a portion of the &nbsp;<span translate="no">Nightscout</span>&nbsp; URL, without the leading “https://”
-    * Username: Enter the full &nbsp;<span translate="no">Nightscout</span>&nbsp; URL including the leading “https://” part
-    * Password: Enter the API_SECRET for the Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site
+* You will enter your *Nightscout* credentials
+    * Website: Enter a portion of the *Nightscout* URL, without the leading “https://”
+    * Username: Enter the full *Nightscout* URL including the leading “https://” part
+    * Password: Enter the API_SECRET for the Looper's *Nightscout* site
     * Tap Done
 * Next, you are offered a screen that allows you to set up a `Verification Code`
     * If you need to come back later, you can find that screen again
-    * Go to Apple Settings -> Passwords -> Tap the row with your &nbsp;<span translate="no">Nightscout</span>&nbsp; URL
+    * Go to Apple Settings -> Passwords -> Tap the row with your *Nightscout* URL
 * Tap “Setup Verification Code”
     * This is where you can scan your QR code from the Looper's phone or the saved QR screenshot
     * As soon as the camera reads the QR code, an OTP will begin to appear
@@ -76,7 +76,7 @@ On the Caregivers device (iPhone or Mac):
 
 ### Using Safari
 
-* When you use Safari to view your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site and choose the Careportal (:material-plus-thick:)
+* When you use Safari to view your Looper's *Nightscout* site and choose the Careportal (:material-plus-thick:)
     * Choose a remote command from Event Type drop-down menu (remote commands are at the bottom of the list)
     * The OTP will be offered to you for every row - ignore it when entering Carb amount or Absorption Time, or Bolus Amount
     * Select it for the OTP row
@@ -92,11 +92,11 @@ There are other Authentication apps available. Here’s a few options that you c
 
 ## FAQs for all Remote Commands
 
-1. **If I have multiple &nbsp;<span translate="no">Nightscout</span>&nbsp; sites because I support multiple people with T1D looping, do I need multiple APNs Keys?**  
-   **Answer**: No. If you support multiple people using  *Loop*, you can use the one APNs key in each of their &nbsp;<span translate="no">Nightscout</span>&nbsp; sites.
+1. **If I have multiple *Nightscout* sites because I support multiple people with T1D looping, do I need multiple APNs Keys?**  
+   **Answer**: No. If you support multiple people using  *Loop*, you can use the one APNs key in each of their *Nightscout* sites.
 
 1. **How can I tell if it worked?**  
-   **Answer**: You should see your override pill in &nbsp;<span translate="no">Nightscout</span>, with &nbsp;<span>the  **NEXT** *Loop* cycle</span>, reflecting that the desired remote action took place. If you are near the *Loop* app, you should see the new override within less than 30 seconds or so.
+   **Answer**: You should see your override pill in *Nightscout*, with &nbsp;<span>the  **NEXT** *Loop* cycle</span>, reflecting that the desired remote action took place. If you are near the *Loop* app, you should see the new override within less than 30 seconds or so.
 
 ## FAQs on Remote Overrides
 
@@ -107,23 +107,23 @@ For remote overrides in particular:
 1. **Can I set a different override in *Nighscout* than I have programmed into *Loop* app?**  
    **Answer**: No. You will only be able to enact override presets already programmed into the Loop app.
 
-1. **If I didn't start the override in &nbsp;<span translate="no">Nightscout</span>&nbsp; (it was started in *Loop* itself), can I still use &nbsp;<span translate="no">Nightscout</span>&nbsp; to cancel it?**  
+1. **If I didn't start the override in *Nightscout* (it was started in *Loop* itself), can I still use *Nightscout* to cancel it?**  
    **Answer**: Yes. You can cancel an override set in *Loop* with a Nightscout-set cancel "temporary override" command in the careportal.
 
-1. **Can I replace an override set in *Loop* with an override set in &nbsp;<span translate="no">Nightscout</span>?**  
+1. **Can I replace an override set in *Loop* with an override set in *Nightscout*?**  
    **Answer**: Yes.
 
-1. **Can I see on &nbsp;<span translate="no">Nightscout</span>&nbsp; when a temporary override has been set using the looper’s phone?**  
+1. **Can I see on *Nightscout* when a temporary override has been set using the looper’s phone?**  
    **Answer**: Yes. There will be a grey bar with the name of the override noted and the *Loop pill* will display the targets and duration. Remember, there is a KNOWN issue with the grey bars, so use the *pill* as your best guide.
 
 1. **Can a looper cancel a remote override**?  
    **Answer**: Yes. They can tap the heart icon <font color="blue">:fontawesome-solid-heart-pulse:</font> in *Loop* so that it is no longer highlighted. This turns off the override, regardless of where it was initiated.
 
-1. **I set a remote override in &nbsp;<span translate="no">Nightscout</span>&nbsp; but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the *Loop* app, so the override turned off. Will the override get reinstated  the next time *Loop* completes with internet access?**  
+1. **I set a remote override in *Nightscout* but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the *Loop* app, so the override turned off. Will the override get reinstated  the next time *Loop* completes with internet access?**  
    **Answer**: No. The *APN* is only sent once. You can set the remote override again if need be.
 
 1. **Can I schedule a remote override ahead of time using Nightscout?**    
-   **Answer**: No. When you set a remote override in &nbsp;<span translate="no">Nightscout</span>, it starts immediately and lasts for the duration programmed for that override in the *Loop* app. You can only set an override in advance using the *Loop* app.
+   **Answer**: No. When you set a remote override in *Nightscout*, it starts immediately and lasts for the duration programmed for that override in the *Loop* app. You can only set an override in advance using the *Loop* app.
 
 ## Remote Commands
 
@@ -141,12 +141,12 @@ Remote Commands to deliver a bolus or add a carb entry **require** a &nbsp;<span
     
     * You send a 5-unit remote bolus.
     * The bolus is delivered to the Looper.
-    * <span translate="no">Nightscout</span>&nbsp; is having a temporary technical issue and doesn't show the bolus was received.
-    * You are watching &nbsp;<span translate="no">Nightscout</span>&nbsp; and you don’t see a delivery so you assume it failed.
+    * *Nightscout* is having a temporary technical issue and doesn't show the bolus was received.
+    * You are watching *Nightscout* and you don’t see a delivery so you assume it failed.
     * You send another remote 5-unit bolus.
     * The second 5-unit bolus is delivered to the Looper (10 Units total).
 
-You can see the danger of sending duplicate bolus/carbs so be careful. If a remote bolus/carb entry doesn’t show in &nbsp;<span translate="no">Nightscout</span>, use your own judgment on whether enough time has passed to try again.
+You can see the danger of sending duplicate bolus/carbs so be careful. If a remote bolus/carb entry doesn’t show in *Nightscout*, use your own judgment on whether enough time has passed to try again.
 
 ### Remote Bolus, Then Remote Carb
 
@@ -181,7 +181,7 @@ Click the link above to read more about *Loop Caregiver* .
 
 ### <span translate="no">Nightscout Careportal</span>
 
-To use remote commands in the &nbsp;<span translate="no">Careportal</span>, you must configure &nbsp;<span translate="no">Nightscout</span>&nbsp; site according to the directions [here](update-user.md) in &nbsp;<span translate="no">Loopdocs</span>&nbsp; in addition to setting up the [Remote Configuration](remote-config.md). 
+To use remote commands in the &nbsp;<span translate="no">Careportal</span>, you must configure *Nightscout* site according to the directions [here](update-user.md) in &nbsp;<span translate="no">Loopdocs</span>&nbsp; in addition to setting up the [Remote Configuration](remote-config.md). 
 
 Pay particular attention to these entries in the `ENABLE` line: `override` `careportal` `Loop`. The order of the words in the `ENABLE` line is not important.
 
@@ -218,11 +218,11 @@ Note that Loop will honor both the current OTP code and the one that just expire
 
 If the Looper is with you, you can see the notification on their phone. You can see the entry on the *Loop* carbohydrate or the insulin displays to see if it went through.
 
-If the Looper is not with you, you should see the result in the &nbsp;<span translate="no">Nightscout</span>&nbsp; dashboard within 5 minutes.
+If the Looper is not with you, you should see the result in the *Nightscout* dashboard within 5 minutes.
 
 ### Shortcuts
 
-If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate *Loop* overrides with &nbsp;<span translate="no">Nightscout</span>.
+If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate *Loop* overrides with *Nightscout*.
 
 !!! important "Important Note"
     Before you click on the download file below...save yourself some trouble.
@@ -253,8 +253,8 @@ And if you want to save one click to get to these one functions more directly: t
     After the download finishes, tap the button marked `AA` near your *Safari* address bar and tap `Downloads` (downloads)  to find and open the downloaded Shortcut.
     
     Wait a bit, and the shortcut's inner guts will be there...scroll ALL the way down to the bottom to click the button to save the untrusted shortcut
-3. When you enter your &nbsp;<span translate="no">Nightscout</span>&nbsp; URL in &nbsp;<span>the `URL` field</span>&nbsp; of the *Loop* shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
-4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup &nbsp;<span translate="no">Nightscout</span>&nbsp; and update your *Loop* app as described in steps 1-3 above.
+3. When you enter your *Nightscout* URL in &nbsp;<span>the `URL` field</span>&nbsp; of the *Loop* shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
+4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup *Nightscout* and update your *Loop* app as described in steps 1-3 above.
 5. You can absolutely customize these bits and pieces within the shortcut. Change the text messages, and change the links... It is totally up to you.
 
 ### *IFTTT*

--- a/docs/nightscout/remote-commands.md
+++ b/docs/nightscout/remote-commands.md
@@ -96,7 +96,7 @@ There are other Authentication apps available. Here’s a few options that you c
    **Answer**: No. If you support multiple people, you can use the one APNs key in each of their *Nightscout* sites.
 
 1. **How can I tell if it worked?**  
-   **Answer**: You should see your override pill in *Nightscout*, with the **NEXT** *Loop* cycle, reflecting that the desired remote action took place. If you are near the *Loop* phone, you should see the new override within less than 30 seconds or so.
+   **Answer**: You should see your override pill in *Nightscout*, with the **NEXT**&nbsp;_<span translate="no">Loop</span>_&nbsp;cycle, reflecting that the desired remote action took place. If you are near the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone, you should see the new override within less than 30 seconds or so.
 
 ## FAQs on Remote Overrides
 
@@ -104,22 +104,22 @@ Don't forget to read [*Loopdocs*: Overrides](../operation/features/overrides.md)
 
 For remote overrides in particular:
 
-1. **Can I set a different override in *Nighscout* than I have programmed into *Loop* app?**  
+1. **Can I set a different override in *Nighscout* than I have programmed into&nbsp;_<span translate="no">Loop</span>_&nbsp;app?**  
    **Answer**: No. You will only be able to enact override presets already programmed into the Loop app.
 
-1. **If I didn't start the override in *Nightscout* (it was started in *Loop* itself), can I still use *Nightscout* to cancel it?**  
-   **Answer**: Yes. You can cancel an override set in *Loop* with a Nightscout-set cancel "temporary override" command in the careportal.
+1. **If I didn't start the override in *Nightscout* (it was started in&nbsp;_<span translate="no">Loop</span>_&nbsp;itself), can I still use *Nightscout* to cancel it?**  
+   **Answer**: Yes. You can cancel an override set in&nbsp;_<span translate="no">Loop</span>_&nbsp;with a Nightscout-set cancel "temporary override" command in the careportal.
 
-1. **Can I replace an override set in *Loop* with an override set in *Nightscout*?**  
+1. **Can I replace an override set in&nbsp;_<span translate="no">Loop</span>_&nbsp;with an override set in *Nightscout*?**  
    **Answer**: Yes.
 
 1. **Can I see on *Nightscout* when a temporary override has been set using the looper’s phone?**  
    **Answer**: Yes. There will be a grey bar with the name of the override noted and the *Loop pill* will display the targets and duration. Remember, there is a KNOWN issue with the grey bars, so use the *pill* as your best guide.
 
 1. **Can a looper cancel a remote override**?  
-   **Answer**: Yes. They can tap the heart icon <font color="blue">:fontawesome-solid-heart-pulse:</font> in *Loop* so that it is no longer highlighted. This turns off the override, regardless of where it was initiated.
+   **Answer**: Yes. They can tap the heart icon <font color="blue">:fontawesome-solid-heart-pulse:</font> in&nbsp;_<span translate="no">Loop</span>_&nbsp;so that it is no longer highlighted. This turns off the override, regardless of where it was initiated.
 
-1. **I set a remote override in *Nightscout* but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the *Loop* app, so the override turned off. Will the override get reinstated  the next time *Loop* completes with internet access?**  
+1. **I set a remote override in *Nightscout* but the Looper tapped the heart symbol <font color="blue">:fontawesome-solid-heart-pulse:</font> in the *Loop* app, so the override turned off. Will the override get reinstated  the next time&nbsp;_<span translate="no">Loop</span>_&nbsp;completes with internet access?**  
    **Answer**: No. The *APN* is only sent once. You can set the remote override again if need be.
 
 1. **Can I schedule a remote override ahead of time using Nightscout?**    
@@ -162,7 +162,7 @@ You can see the danger of sending duplicate bolus/carbs so be careful. If a remo
         * _<span translate="no">Loop</span>_&nbsp;will initiate a percentage of the recommended dose when it receives the carbs remote command
         * Your bolus will be accepted and take place in addition to an automatic boluses or be rejected because a bolus is already in progress
     
-    Typically, sending a remote carb entry alone is sufficient for *Loop* to know about the carbs and begin to dose for them.
+    Typically, sending a remote carb entry alone is sufficient for&nbsp;_<span translate="no">Loop</span>_&nbsp;to know about the carbs and begin to dose for them.
     
     If you really want to both bolus for carbs and enter carbs, then do it in that order.
     
@@ -189,7 +189,7 @@ Pay particular attention to these entries in the `ENABLE` line: `override` `care
 You'll also need to have your [site authenticated](update-user.md#authenticate-site) so that your &nbsp;<span translate="no">Careportal</span>&nbsp; is active to send remote overrides . 
 
 Once authenticated by entering your `API_SECRET`, there is a plus sign (:material-plus-thick:) in the upper right corner of your site. That is your *Careportal*. Tap the *Careportal* plus sign (:material-plus-thick:) and then scroll down in the `event type` menu to find `Temporary Override`.  
-Within there, you will find all your *Loop* override presets already loaded for you.
+Within there, you will find all your&nbsp;_<span translate="no">Loop</span>_&nbsp;override presets already loaded for you.
 
 #### Start and End Remote Override
 
@@ -217,13 +217,13 @@ Open your Nightscout site in a browser or app.
 
 Note that Loop will honor both the current OTP code and the one that just expired.
 
-If the Looper is with you, you can see the notification on their phone. You can see the entry on the *Loop* carbohydrate or the insulin displays to see if it went through.
+If the Looper is with you, you can see the notification on their phone. You can see the entry on the&nbsp;_<span translate="no">Loop</span>_&nbsp;carbohydrate or the insulin displays to see if it went through.
 
 If the Looper is not with you, you should see the result in the *Nightscout* dashboard within 5 minutes.
 
 ### Shortcuts
 
-If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate *Loop* overrides with *Nightscout*.
+If you want to make your life SUPER AMAZING, check out using the iPhone's Shortcuts app. The Shortcuts app is for making little automations (like mini apps) that can integrate parts of your life. In this case, we've written a couple of shortcuts for you that integrate&nbsp;_<span translate="no">Loop</span>_&nbsp;overrides with *Nightscout*.
 
 !!! important "Important Note"
     Before you click on the download file below...save yourself some trouble.
@@ -239,7 +239,7 @@ If you want to make your life SUPER AMAZING, check out using the iPhone's Shortc
 
 Click these links on your iPhone and you'll be prompted to download the premade shortcuts (assuming you open the links in Safari browser on iPhone):
 
-[Comprehensive *Loop* Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut)
+[Comprehensive&nbsp;_<span translate="no">Loop</span>_&nbsp;Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut)
  *includes Set Remote Override, Cancel Override, Loop Troubleshooting Tips, Quick Text options, Manual BG entry, Bookmarks to websites, etc.*
 
 And if you want to save one click to get to these one functions more directly: these shortcuts are simplified to offer only one function:
@@ -254,8 +254,8 @@ And if you want to save one click to get to these one functions more directly: t
     After the download finishes, tap the button marked `AA` near your *Safari* address bar and tap `Downloads` (downloads)  to find and open the downloaded Shortcut.
     
     Wait a bit, and the shortcut's inner guts will be there...scroll ALL the way down to the bottom to click the button to save the untrusted shortcut
-3. When you enter your *Nightscout* URL in &nbsp;<span>the `URL` field</span>&nbsp; of the *Loop* shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
-4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup *Nightscout* and update your *Loop* app as described in steps 1-3 above.
+3. When you enter your *Nightscout* URL in &nbsp;<span>the `URL` field</span>&nbsp; of the&nbsp;_<span translate="no">Loop</span>_&nbsp;shortcut setup, make sure you don't include a &nbsp;<span>trailing `/`</span>, or the API calls to *Heroku* will error out.
+4. When a remote override is set properly, you'll see an `ok` message displayed. If there is an error, you'll see an error message. Most errors will be that you have an `API_SECRET` wrong (make sure there isn't a space at the end of your `API_SECRET` that you don't see) or you failed to do the steps to setup *Nightscout* and update your&nbsp;_<span translate="no">Loop</span>_&nbsp;app as described in steps 1-3 above.
 5. You can absolutely customize these bits and pieces within the shortcut. Change the text messages, and change the links... It is totally up to you.
 
 ### *IFTTT*

--- a/docs/nightscout/remote-commands.md
+++ b/docs/nightscout/remote-commands.md
@@ -4,9 +4,9 @@ All remote commands require the configuration steps from [Remote Configuration](
 
 * A new One-Time Password (OTP) is required for each remote command that issues a bolus or adds a carb entry
     * The OTP updates every 30 seconds
-    * Both the sending device and the Looper's phone must have automatic time enabled
+    * Both the sending device and the Loop phone must have automatic time enabled
 * Remote Overrides do not require a One-Time Password (OTP)
-    * There are some versions of *Nightscout* that provide a row for entry of an OTP for &nbsp;<span translate="no">Temporary Override</span>&nbsp; in the &nbsp;<span translate="no">Nightscout Careportal</span>
+    * There are some versions of *Nightscout* that provide a row for entry of an OTP for Temporary Override in the *Nightscout* Careportal
     * Leave that row blank
 
 !!! question "Do I have to use *Loop Caregiver* ?"
@@ -18,9 +18,9 @@ All remote commands require the configuration steps from [Remote Configuration](
 
 ## QR Code
 
-On the Looper's phone, *Nightscout* must be included under the `Loop` -> Settings -> Services section. Navigate to Services and select *Nightscout*. Tap on the One-Time Password row to view the QR code.
+On the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone, *Nightscout* must be included under the `Loop` -> Settings -> Services section. Navigate to Services and select *Nightscout*. Tap on the One-Time Password row to view the QR code.
 
-When you need to configure your authentication method, you can either use a saved QR screenshot or scan the QR on the Looper's phone.
+When you need to configure your authentication method, you can either use a saved QR screenshot or scan the QR on the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone.
 
 Options:
 
@@ -67,9 +67,9 @@ On the Caregivers device (iPhone or Mac):
     * If you need to come back later, you can find that screen again
     * Go to Apple Settings -> Passwords -> Tap the row with your *Nightscout* URL
 * Tap “Setup Verification Code”
-    * This is where you can scan your QR code from the Looper's phone or the saved QR screenshot
+    * This is where you can scan your QR code from the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone or the saved QR screenshot
     * As soon as the camera reads the QR code, an OTP will begin to appear
-    * If the Looper's phone is handy, wait a cycle or two and ensure the 6-digit OTP on the password screen matches that on the Looper's phone and they update at the same time
+    * If the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone is handy, wait a cycle or two and ensure the 6-digit OTP on the password screen matches that on the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone and they update at the same time
     * Click Passwords on upper left to return to the prevous screen
 * Select Passwords Options
     * Enable the `Autofill Passwords` and check `Keychain`
@@ -93,14 +93,14 @@ There are other Authentication apps available. Here’s a few options that you c
 ## FAQs for all Remote Commands
 
 1. **If I have multiple *Nightscout* sites because I support multiple people with T1D looping, do I need multiple APNs Keys?**  
-   **Answer**: No. If you support multiple people using  *Loop*, you can use the one APNs key in each of their *Nightscout* sites.
+   **Answer**: No. If you support multiple people, you can use the one APNs key in each of their *Nightscout* sites.
 
 1. **How can I tell if it worked?**  
-   **Answer**: You should see your override pill in *Nightscout*, with &nbsp;<span>the  **NEXT** *Loop* cycle</span>, reflecting that the desired remote action took place. If you are near the *Loop* app, you should see the new override within less than 30 seconds or so.
+   **Answer**: You should see your override pill in *Nightscout*, with the **NEXT** *Loop* cycle, reflecting that the desired remote action took place. If you are near the *Loop* phone, you should see the new override within less than 30 seconds or so.
 
 ## FAQs on Remote Overrides
 
-Don't forget to read [Loopdocs: Overrides](../operation/features/overrides.md). 
+Don't forget to read [*Loopdocs*: Overrides](../operation/features/overrides.md). 
 
 For remote overrides in particular:
 
@@ -130,7 +130,7 @@ For remote overrides in particular:
 Remote Commands to deliver a bolus or add a carb entry **require** a &nbsp;<span translate="no">One Time Passcode</span>&nbsp; (OTP).
 
 !!! important "Minimum Versions: <span translate="no">Loop 3</span>&nbsp; and &nbsp;<span translate="no">**Nightscout 14.2.6**</span>"
-    If your Nightscout version does not meet that minimum requirement, remote commands **might** be accepted but if they are, the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the looper's phone.
+    If your Nightscout version does not meet that minimum requirement, remote commands **might** be accepted but if they are, the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the&nbsp;_<span translate="no">loop</span>_&nbsp;phone.
 
 ### Warnings on Remote Commands
 
@@ -155,19 +155,20 @@ You can see the danger of sending duplicate bolus/carbs so be careful. If a remo
 
     There are 2 scenarios of concern that could lead to too much insulin:
     
-    * *Looper* is using the **`Temp Basal`** (temporary basal) Dosing Strategy
-        * *Loop* will initiate a max `Temp Basal` when it receives the carbs remote command
-        * Your bolus will be accepted and take place in addition to the high temporary basal
-    * *Looper* is using **`Automatic Bolus`** Dosing Strategy
-        * *Loop* will initiate 40% of the recommended dose when it receives the carbs remote command
-        * Your bolus will be accepted and take place in addition to an automatic boluses
+    * Dosing Strategy is **Temp Basal Only** (temporary basal)
+        * _<span translate="no">Loop</span>_&nbsp;will initiate a max Temp Basal when it receives the carbs remote command
+        * Your bolus is accepted next and takes place in addition to the high temporary basal
+    * Dosing Strategy is **Automatic Bolus** 
+        * _<span translate="no">Loop</span>_&nbsp;will initiate a percentage of the recommended dose when it receives the carbs remote command
+        * Your bolus will be accepted and take place in addition to an automatic boluses or be rejected because a bolus is already in progress
     
     Typically, sending a remote carb entry alone is sufficient for *Loop* to know about the carbs and begin to dose for them.
     
     If you really want to both bolus for carbs and enter carbs, then do it in that order.
     
-    1. The bolus, when accepted, will cause *Loop* to issue a 0 `Temp Basal` (temporary basal) (which is "safer")
-    2. The carbs, when accepted, will cause *Loop* to respond to the carbs while including the bolus already delivered and included in the Looper&#39; IOB
+    1. The bolus, when accepted, may start a zero Temp Basal (temporary basal) (which is "safer")
+    2. The carbs, when accepted, will cause the app to respond to the carbs
+    3. In this case, the prediction includes both carbs and bolus
     
     ❗️ Remember - you should pause at least 60 seconds between remote commands or the One-Time-Password (OTP) will be rejected as having already been used.
 
@@ -179,7 +180,7 @@ There are four ways you can trigger your commands remotely; &nbsp;[*Loop Caregiv
 
 Click the link above to read more about *Loop Caregiver* .
 
-### <span translate="no">Nightscout Careportal</span>
+### *Nightscout* Careportal
 
 To use remote commands in the &nbsp;<span translate="no">Careportal</span>, you must configure *Nightscout* site according to the directions [here](update-user.md) in &nbsp;<span translate="no">Loopdocs</span>&nbsp; in addition to setting up the [Remote Configuration](remote-config.md). 
 

--- a/docs/nightscout/remote-config.md
+++ b/docs/nightscout/remote-config.md
@@ -2,24 +2,24 @@
 
     1. [Update the Looper's iPhone Settings](#step-1-update-the-loopers-iphone-settings)
     2. [Create a Key for an `Apple Push Notifications service (APNs)`](#step-2-apple-push-notifications)
-    3. [Update &nbsp;<span translate="no">Nightscout</span>&nbsp; site and add some "config vars" lines in &nbsp;<span translate="no">Nightscout</span>&nbsp; site settings](#step-3-add-apn-to-nightscout)
+    3. [Update *Nightscout* site and add some "config vars" lines in *Nightscout* site settings](#step-3-add-apn-to-nightscout)
     4. [Test Remote Overrides](#step-4-test-remote-overrides)
 
-## Set Up Remote for &nbsp;<span translate="no">Nightscout</span>
+## Set Up Remote for *Nightscout*
 
-You can use the Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely set and cancel override presets in your Looper's *Loop* app.
+You can use the Looper's *Nightscout* site to remotely set and cancel override presets in your Looper's *Loop* app.
 
-With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the *Loop* phone.
+With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's *Nightscout* version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the *Loop* phone.
 
 After you complete the configuration, read the entire [Remote Commands](remote-commands.md) page - pay attention to the warnings and caveats. Test this while your Looper is sitting next to you so you can watch their phone.
 
-!!! warning "Remote &nbsp;<span translate="no">Nightscout</span>&nbsp; Interface Caveats"
+!!! warning "Remote *Nightscout* Interface Caveats"
     * Must use a paid &nbsp;<span translate="no">Apple Developer</span>&nbsp; account to build  *Loop*
         * <span translate="no">Apple Push Notifications</span>&nbsp; (APN) service is not available with a Free account
     * When you build  *Loop*, the required *APN* information is tied to your Apple Developer account
-        * You add your *APN* information to your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site
-        * If you support multiple Looper's, you add the same APN variables to each of their &nbsp;<span translate="no">Nightscout</span>&nbsp; sites
-    * There are many choices for building your own or paying someone to build a &nbsp;<span translate="no">Nightscout</span>&nbsp; site
+        * You add your *APN* information to your Looper's *Nightscout* site
+        * If you support multiple Looper's, you add the same APN variables to each of their *Nightscout* sites
+    * There are many choices for building your own or paying someone to build a *Nightscout* site
         * The directions for only one of the options is documented on this page
         * Use that as a guide for your site
     * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)
@@ -45,7 +45,7 @@ Consequence if Looper's phone is not configured correctly:
 
 ## Step 2: *Apple Push Notifications*
 
-The step is required for the *Loop* app to give permissions to your &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely interact with it. To enable this, you need to create a key and grant it access to the &nbsp;<span translate="no">Apple Push Notification Service (APNS)</span>. 
+The step is required for the *Loop* app to give permissions to your *Nightscout* site to remotely interact with it. To enable this, you need to create a key and grant it access to the &nbsp;<span translate="no">Apple Push Notification Service (APNS)</span>. 
 
 !!! info "Reminder"
     This only works with the **paid** Apple Developer ID.
@@ -70,7 +70,7 @@ The step is required for the *Loop* app to give permissions to your &nbsp;<span 
    Click on `Choose Application...` and then select *`TextEdit`* as your application to open it with.  
 > ![img/apns-open.png](img/apns-open.png)
 > ![img/apns-textedit.png](img/apns-textedit.png)
-7. When the file opens, it will look similar to the screenshot below. In a few minutes, after we do a few other steps first, we will need to highlight **ALL OF THE CONTENTS** of that file and copy it because we will be pasting it in *Heroku* or whichever &nbsp;<span translate="no">Nightscout</span>&nbsp; provider you are using. Yes, *allllll* of the contents.  
+7. When the file opens, it will look similar to the screenshot below. In a few minutes, after we do a few other steps first, we will need to highlight **ALL OF THE CONTENTS** of that file and copy it because we will be pasting it in *Heroku* or whichever *Nightscout* provider you are using. Yes, *allllll* of the contents.  
     So, the easiest way is to:
       * **Click inside that file**
       * Highlight **all** the text, and then
@@ -81,29 +81,29 @@ The step is required for the *Loop* app to give permissions to your &nbsp;<span 
       You don't have to do it right now...just keep that window open in the background for now until we need it a little further down. Then we will copy all that text.
     > ![img/apns-copy-key.png](img/apns-copy-key.png)
 
-## Step 3: Add APN to &nbsp;<span translate="no">Nightscout</span>
+## Step 3: Add APN to *Nightscout*
 
-### Update &nbsp;<span translate="no">Nightscout</span>&nbsp; Site
+### Update *Nightscout* Site
 
-You'll need to make sure your &nbsp;<span translate="no">Nightscout</span>&nbsp; site version is version `13.0.1` or newer for remote overrides and version `14.2.6` or newer for access to all the remote command features. 
+You'll need to make sure your *Nightscout* site version is version `13.0.1` or newer for remote overrides and version `14.2.6` or newer for access to all the remote command features. 
 
-!!! info "What is my &nbsp;<span translate="no">Nightscout</span>&nbsp; Version Number?"
-    To find your &nbsp;<span translate="no">Nightscout</span>&nbsp; version number:
+!!! info "What is my *Nightscout* Version Number?"
+    To find your *Nightscout* version number:
     
      - **Tap** on (`☰`) the hamburger button (3 horizontal lines stacked on each other) at the upper right, near the authentication button.
      - A context menu slides in from below the hamburger.
      - **Scroll** to the very bottom of this menu.
      - The **version** is located in the **`About`** section after the `Settings` section, (below the `Save` button).
 
-This link should be used if you want to [Nightscout: Update](https://nightscout.github.io/update/update/) your &nbsp;<span translate="no">Nightscout</span>&nbsp; site.
+This link should be used if you want to [Nightscout: Update](https://nightscout.github.io/update/update/) your *Nightscout* site.
 
-!!! note "Note for &nbsp;<span translate="no">Google Cloud</span>&nbsp; Users"
-    The &nbsp;[<span translate="no">Xdrip: Google Cloud Nightscout</span>](https://navid200.github.io/xDrip/docs/Nightscout/GoogleCloud.html) instructions include information about updating your site.  
+!!! note "Note for *Google Cloud* Users"
+    The [*Nightscout* with *Google Cloud*](https://navid200.github.io/xDrip/docs/Nightscout/GoogleCloud.html) instructions include information about updating your site.  
     Scroll down to the line (on that page) that says `Update Nightscout`.
 
-### Add APN Variables to &nbsp;<span translate="no">Nightscout</span>
+### Add APN Variables to *Nightscout*
 
-In order to use remote overrides, you must add a couple of new variables. If you don't know how to update your &nbsp;<span translate="no">Nightscout</span>&nbsp; configuration, review [Nightscout: Setup Variables](https://nightscout.github.io/nightscout/setup_variables/) and then come back.
+In order to use remote overrides, you must add a couple of new variables. If you don't know how to update your *Nightscout* configuration, review [Nightscout: Setup Variables](https://nightscout.github.io/nightscout/setup_variables/) and then come back.
 
 The instructions in this section show *Heroku* images. If you are using a different method, you should be able to "translate" the steps.
 
@@ -130,14 +130,14 @@ That last row of the table above is needed if you are using a remote build optio
 
 When executed properly, you should have something that looks like this for the three (or four) new variables that you added:
 
-> ![the 3 or 4 config vars required for &nbsp;<span translate="no">Nightscout</span>&nbsp; remote commands to work](img/override_vars_complete.svg)
+> ![the 3 or 4 config vars required for *Nightscout* remote commands to work](img/override_vars_complete.svg)
 
 #### BadDeviceToken
 
-When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
+When the *Nightscout* config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
+* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
 
 ### Do Not Confuse Your Keys
 
@@ -146,33 +146,33 @@ When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH
 
     The Secrets for building with *GitHub* use the API Key.
     
-    The config vars for &nbsp;<span translate="no">Nightscout</span>&nbsp; use the APN Key.
+    The config vars for *Nightscout* use the APN Key.
     
-    * If you are using remote commands with &nbsp;<span translate="no">Nightscout</span>&nbsp; and building with the **GitHub Browser** build method, you must also add the config var of `LOOP_PUSH_SERVER_ENVIRONMENT` with a value of `production` to your &nbsp;<span translate="no">Nightscout</span>&nbsp; site or the remote commands will not work.
+    * If you are using remote commands with *Nightscout* and building with the **GitHub Browser** build method, you must also add the config var of `LOOP_PUSH_SERVER_ENVIRONMENT` with a value of `production` to your *Nightscout* site or the remote commands will not work.
     * If you are using the **Mac-Xcode** build method, you should not have a config var of `LOOP_PUSH_SERVER_ENVIRONMENT` entered - remove it if it is present.
 
 ## Step 4: Test Remote Overrides
 
 If remote overrides do not function, remote commands for delivering a bolus or adding a carb entry will not work either.
 
-After you finish setting up your &nbsp;<span translate="no">Nightscout</span>&nbsp; site:
+After you finish setting up your *Nightscout* site:
 
 1. Use the Looper's phone to set an override
-1. Make sure that override shows up on the &nbsp;<span translate="no">Nightscout</span>&nbsp; site
+1. Make sure that override shows up on the *Nightscout* site
 1. Then using the &nbsp;<span translate="no">Nightscout Careportal</span>, test that you can turn off that override
 
 ### Things to Check:
 
 *    Remote overrides will not start working until after you activate an override in the app at least once
-    * Activating an override from the *Loop* interface will upload the necessary push notification token to &nbsp;<span translate="no">Nightscout</span>&nbsp; which will enable remote commands to work
+    * Activating an override from the *Loop* interface will upload the necessary push notification token to *Nightscout* which will enable remote commands to work
     * If your Looper gets a new phone - be sure to activate an override from the new phone before trying to use remote commands
 *    Notifications must be allowed in  *Loop*
 *    Give loop access to all health data
 *    Enable Background App Refresh
-*    Double check your &nbsp;<span translate="no">Nightscout</span>&nbsp; credentials
+*    Double check your *Nightscout* credentials
 *    Low Power Mode may prevent background notifications from working
 *    Some have found that activating the “Focus” and Do-Not-Disturb features on iOS can prevent push notifications from being delivered
     * Turn these off when troubleshooting to eliminate this as a source of problems
 *    iOS 15.3.x: Note there are reports of Remote notifications not being received to the Loopers device for iOS version 15.3 and 15.3.1; this is fixed in iOS version 15.4
-*    If you distribute the app remotely (i.e. TestFlight, Diawi, AppCenter), you must set a special &nbsp;<span translate="no">Nightscout</span>&nbsp; variable, LOOP_PUSH_SERVER_ENVIRONMENT to “production”, to enable push notifications
+*    If you distribute the app remotely (i.e. TestFlight, Diawi, AppCenter), you must set a special *Nightscout* variable, LOOP_PUSH_SERVER_ENVIRONMENT to “production”, to enable push notifications
     * See [Remote Build Config Var Requirement](#remote-build-config-var-requirement)

--- a/docs/nightscout/remote-config.md
+++ b/docs/nightscout/remote-config.md
@@ -7,16 +7,16 @@
 
 ## Set Up Remote for *Nightscout*
 
-You can use the Looper's *Nightscout* site to remotely set and cancel override presets in your Looper's *Loop* app.
+You can use the *Nightscout* site to remotely set and cancel override presets remotely in the *Loop* app.
 
-With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's *Nightscout* version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the *Loop* phone.
+With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's *Nightscout* version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone.
 
 After you complete the configuration, read the entire [Remote Commands](remote-commands.md) page - pay attention to the warnings and caveats. Test this while your Looper is sitting next to you so you can watch their phone.
 
 !!! warning "Remote *Nightscout* Interface Caveats"
-    * Must use a paid &nbsp;<span translate="no">Apple Developer</span>&nbsp; account to build  *Loop*
+    * Must use a paid &nbsp;<span translate="no">Apple Developer</span>&nbsp; account to build&nbsp;_<span translate="no">Loop</span>_
         * <span translate="no">Apple Push Notifications</span>&nbsp; (APN) service is not available with a Free account
-    * When you build  *Loop*, the required *APN* information is tied to your Apple Developer account
+    * When you build &nbsp;_<span translate="no">Loop</span>_, the required *APN* information is tied to your Apple Developer account
         * You add your *APN* information to your Looper's *Nightscout* site
         * If you support multiple Looper's, you add the same APN variables to each of their *Nightscout* sites
     * There are many choices for building your own or paying someone to build a *Nightscout* site
@@ -37,11 +37,11 @@ Consequence if Looper's phone is not configured correctly:
 - If Background app refresh is not enabled, the remote overrides might only enact if the *Loop* app is open and the phone is unlocked
 
 !!! warning "Keep Notifications Turned on for Looper's Phone"
-    Typically, the Looper's phone has Notifications enabled for  *Loop*. In fact, if they don't, a red warning bar is prominently displayed. 
+    Typically, the Looper's phone has Notifications enabled for &nbsp;_<span translate="no">Loop</span>_. In fact, if they don't, a red warning bar is prominently displayed. 
     
-    There may be times when you really need *Loop* to be quiet, so you can turn off Notifications. The remote commands still go through but the Looper does not see a notification that this happened.
+    There may be times when you really need&nbsp;_<span translate="no">Loop</span>_&nbsp;to be quiet, so you can turn off Notifications. The remote commands still go through but the Looper does not see a notification that this happened.
 
-    Best practice is to keep *Loop* Notifications enabled.
+    Best practice is to keep&nbsp;_<span translate="no">Loop</span>_&nbsp;Notifications enabled.
 
 ## Step 2: *Apple Push Notifications*
 
@@ -121,8 +121,8 @@ Scroll down the bottom of the `Config Vars` lines until you find the last blank 
 |---------|---------|
 |`LOOP_APNS_KEY`| Enter the **ENTIRE** contents of the downloaded `.p8` file including the `BEGIN` and `END` lines. Here's where you can use the ++command+"A"++ and ++command+"C"++ to highlight and copy all the text in that file so you can paste it into Heroku here for this new variable you are creating. ![img/apns-copy-key2.png](img/apns-copy-key2.png)|
 |`LOOP_APNS_KEY_ID`|String of characters on the `.p8` download file immediately following the underscore (`_`) and not including the file extension (`.p8`), or you can get it from your saved key in your developer account as shown next step, too. This is a part of the downloaded filename located after the underscore (`_`) and before the file extension (`.p8`).    ![img/apns-open2.png](img/apns-open2.png)
-|`LOOP_DEVELOPER_TEAM_ID`| Get this value from *Loop* app signing or in your &nbsp;<span translate="no">Apple Developer</span>&nbsp; account's top right corner under your name ![img/apns-vars.png](img/apns-vars.png)|
-|`LOOP_PUSH_SERVER_ENVIRONMENT`| (optional) Set this to `production` if you installed *Loop* remotely such as with *TestFlight*, *Diawi*, *AppCenter*, or an *IPA*. <br/>If you built directly to your phone in *XCode* with your phone plugged into to your computer, do not include this variable.|
+|`LOOP_DEVELOPER_TEAM_ID`| Get this value from the *Loop* app signing or in your &nbsp;<span translate="no">Apple Developer</span>&nbsp; account's top right corner under your name ![img/apns-vars.png](img/apns-vars.png)|
+|`LOOP_PUSH_SERVER_ENVIRONMENT`| (optional) Set this to `production` if you installed&nbsp;_<span translate="no">Loop</span>_&nbsp;remotely such as with *TestFlight*, *Diawi*, *AppCenter*, or an *IPA*. <br/>If you built directly to your phone in *XCode* with your phone plugged into to your computer, do not include this variable.|
 
 #### Remote Build Config Var Requirement
 
@@ -136,8 +136,8 @@ When executed properly, you should have something that looks like this for the t
 
 When the *Nightscout* config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
+* If&nbsp;_<span translate="no">Loop</span>_&nbsp;was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If&nbsp;_<span translate="no">Loop</span>_&nbsp;was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
 
 ### Do Not Confuse Your Keys
 
@@ -164,9 +164,9 @@ After you finish setting up your *Nightscout* site:
 ### Things to Check:
 
 *    Remote overrides will not start working until after you activate an override in the app at least once
-    * Activating an override from the *Loop* interface will upload the necessary push notification token to *Nightscout* which will enable remote commands to work
+    * Activating an override from the&nbsp;_<span translate="no">Loop</span>_&nbsp;interface will upload the necessary push notification token to *Nightscout* which will enable remote commands to work
     * If your Looper gets a new phone - be sure to activate an override from the new phone before trying to use remote commands
-*    Notifications must be allowed in  *Loop*
+*    Notifications must be allowed in&nbsp;_<span translate="no">Loop</span>_
 *    Give loop access to all health data
 *    Enable Background App Refresh
 *    Double check your *Nightscout* credentials

--- a/docs/nightscout/remote-config.md
+++ b/docs/nightscout/remote-config.md
@@ -7,16 +7,16 @@
 
 ## Set Up Remote for &nbsp;<span translate="no">Nightscout</span>
 
-You can use the Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely set and cancel override presets in your Looper's &nbsp;<span translate="no">Loop</span>&nbsp; app.
+You can use the Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely set and cancel override presets in your Looper's *Loop* app.
 
-With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the &nbsp;<span translate="no">Loop</span>&nbsp; phone.
+With &nbsp;<span translate="no">Loop 3</span>, you can also send remote commands to add carbs and command a bolus. **Remote bolus/carb commands** have a minimum requirement of &nbsp;<span translate="no">**Nightscout 14.2.6**</span>. If your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; version does not meet that minimum requirement, remote commands **might** be accepted, but the time for the commands is always the current time. In other words, Carbs in the Past or Future might be accepted, but would be entered at the current time on the *Loop* phone.
 
 After you complete the configuration, read the entire [Remote Commands](remote-commands.md) page - pay attention to the warnings and caveats. Test this while your Looper is sitting next to you so you can watch their phone.
 
 !!! warning "Remote &nbsp;<span translate="no">Nightscout</span>&nbsp; Interface Caveats"
-    * Must use a paid &nbsp;<span translate="no">Apple Developer</span>&nbsp; account to build &nbsp;<span translate="no">Loop</span>
+    * Must use a paid &nbsp;<span translate="no">Apple Developer</span>&nbsp; account to build  *Loop*
         * <span translate="no">Apple Push Notifications</span>&nbsp; (APN) service is not available with a Free account
-    * When you build &nbsp;<span translate="no">Loop</span>, the required *APN* information is tied to your Apple Developer account
+    * When you build  *Loop*, the required *APN* information is tied to your Apple Developer account
         * You add your *APN* information to your Looper's &nbsp;<span translate="no">Nightscout</span>&nbsp; site
         * If you support multiple Looper's, you add the same APN variables to each of their &nbsp;<span translate="no">Nightscout</span>&nbsp; sites
     * There are many choices for building your own or paying someone to build a &nbsp;<span translate="no">Nightscout</span>&nbsp; site
@@ -34,23 +34,23 @@ For remote commands to successfully deploy to a Looper's iPhone when the phone i
 
 Consequence if Looper's phone is not configured correctly:
 
-- If Background app refresh is not enabled, the remote overrides might only enact if the &nbsp;<span translate="no">Loop</span>&nbsp; app is open and the phone is unlocked
+- If Background app refresh is not enabled, the remote overrides might only enact if the *Loop* app is open and the phone is unlocked
 
 !!! warning "Keep Notifications Turned on for Looper's Phone"
-    Typically, the Looper's phone has Notifications enabled for &nbsp;<span translate="no">Loop</span>. In fact, if they don't, a red warning bar is prominently displayed. 
+    Typically, the Looper's phone has Notifications enabled for  *Loop*. In fact, if they don't, a red warning bar is prominently displayed. 
     
-    There may be times when you really need &nbsp;<span translate="no">Loop</span>&nbsp; to be quiet, so you can turn off Notifications. The remote commands still go through but the Looper does not see a notification that this happened.
+    There may be times when you really need *Loop* to be quiet, so you can turn off Notifications. The remote commands still go through but the Looper does not see a notification that this happened.
 
-    Best practice is to keep &nbsp;<span translate="no">Loop</span>&nbsp; Notifications enabled.
+    Best practice is to keep *Loop* Notifications enabled.
 
 ## Step 2: *Apple Push Notifications*
 
-The step is required for the &nbsp;<span translate="no">Loop</span>&nbsp; app to give permissions to your &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely interact with it. To enable this, you need to create a key and grant it access to the &nbsp;<span translate="no">Apple Push Notification Service (APNS)</span>. 
+The step is required for the *Loop* app to give permissions to your &nbsp;<span translate="no">Nightscout</span>&nbsp; site to remotely interact with it. To enable this, you need to create a key and grant it access to the &nbsp;<span translate="no">Apple Push Notification Service (APNS)</span>. 
 
 !!! info "Reminder"
     This only works with the **paid** Apple Developer ID.
 
-1. To get started, go to the `Keys` section under Apple Developer's [`Certificates, Identifiers & Profiles`](https://developer.apple.com/account/resources/authkeys/list) and login with the *Apple ID* associated with your developer team that you used to build the &nbsp;<span translate="no">Loop</span>&nbsp; app.
+1. To get started, go to the `Keys` section under Apple Developer's [`Certificates, Identifiers & Profiles`](https://developer.apple.com/account/resources/authkeys/list) and login with the *Apple ID* associated with your developer team that you used to build the *Loop* app.
 2. If not already open in your browser (compare with the below screenshot), 
     - Click on **`Keys`** (located in the left-hand column). 
     - Either click on the blue **`Create a new key`** button **OR** the plus button (<font color="#2997FF">:material-plus-circle:</font>)  to add a new key.
@@ -121,8 +121,8 @@ Scroll down the bottom of the `Config Vars` lines until you find the last blank 
 |---------|---------|
 |`LOOP_APNS_KEY`| Enter the **ENTIRE** contents of the downloaded `.p8` file including the `BEGIN` and `END` lines. Here's where you can use the ++command+"A"++ and ++command+"C"++ to highlight and copy all the text in that file so you can paste it into Heroku here for this new variable you are creating. ![img/apns-copy-key2.png](img/apns-copy-key2.png)|
 |`LOOP_APNS_KEY_ID`|String of characters on the `.p8` download file immediately following the underscore (`_`) and not including the file extension (`.p8`), or you can get it from your saved key in your developer account as shown next step, too. This is a part of the downloaded filename located after the underscore (`_`) and before the file extension (`.p8`).    ![img/apns-open2.png](img/apns-open2.png)
-|`LOOP_DEVELOPER_TEAM_ID`| Get this value from &nbsp;<span translate="no">Loop</span>&nbsp; app signing or in your &nbsp;<span translate="no">Apple Developer</span>&nbsp; account's top right corner under your name ![img/apns-vars.png](img/apns-vars.png)|
-|`LOOP_PUSH_SERVER_ENVIRONMENT`| (optional) Set this to `production` if you installed &nbsp;<span translate="no">Loop</span>&nbsp; remotely such as with *TestFlight*, *Diawi*, *AppCenter*, or an *IPA*. <br/>If you built directly to your phone in *XCode* with your phone plugged into to your computer, do not include this variable.|
+|`LOOP_DEVELOPER_TEAM_ID`| Get this value from *Loop* app signing or in your &nbsp;<span translate="no">Apple Developer</span>&nbsp; account's top right corner under your name ![img/apns-vars.png](img/apns-vars.png)|
+|`LOOP_PUSH_SERVER_ENVIRONMENT`| (optional) Set this to `production` if you installed *Loop* remotely such as with *TestFlight*, *Diawi*, *AppCenter*, or an *IPA*. <br/>If you built directly to your phone in *XCode* with your phone plugged into to your computer, do not include this variable.|
 
 #### Remote Build Config Var Requirement
 
@@ -134,10 +134,10 @@ When executed properly, you should have something that looks like this for the t
 
 #### BadDeviceToken
 
-When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the &nbsp;<span translate="no">Loop</span>&nbsp; app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
+When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If &nbsp;<span translate="no">Loop</span>&nbsp; was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If &nbsp;<span translate="no">Loop</span>&nbsp; was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
+* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
 
 ### Do Not Confuse Your Keys
 
@@ -164,9 +164,9 @@ After you finish setting up your &nbsp;<span translate="no">Nightscout</span>&nb
 ### Things to Check:
 
 *    Remote overrides will not start working until after you activate an override in the app at least once
-    * Activating an override from the &nbsp;<span translate="no">Loop</span>&nbsp; interface will upload the necessary push notification token to &nbsp;<span translate="no">Nightscout</span>&nbsp; which will enable remote commands to work
+    * Activating an override from the *Loop* interface will upload the necessary push notification token to &nbsp;<span translate="no">Nightscout</span>&nbsp; which will enable remote commands to work
     * If your Looper gets a new phone - be sure to activate an override from the new phone before trying to use remote commands
-*    Notifications must be allowed in &nbsp;<span translate="no">Loop</span>
+*    Notifications must be allowed in  *Loop*
 *    Give loop access to all health data
 *    Enable Background App Refresh
 *    Double check your &nbsp;<span translate="no">Nightscout</span>&nbsp; credentials

--- a/docs/nightscout/remote-errors.md
+++ b/docs/nightscout/remote-errors.md
@@ -1,7 +1,7 @@
 ## *Loop* data is not showing in *Nightscout*
 
-* This is a *Loop* and/or *Nightscout* issue, not related to remote configuration
-    * Review the [LoopDocs: *Nightscout* with  *Loop*](update-user.md) page
+* This is a&nbsp;_<span translate="no">Loop</span>_&nbsp;and/or *Nightscout* issue, not related to remote configuration
+    * Review the [LoopDocs: *Nightscout* with&nbsp;_<span translate="no">Loop</span>_](update-user.md) page
     * Check out links on the [LoopDocs: *Nightscout* Troubleshooting](troubleshoot.md) page
 * Make sure Looper's phone is connected to the internet so it can upload to *Nightscout*
 
@@ -11,14 +11,14 @@
 
 Ensure your *Nightscout* version is at least version 14.2.6.
 
-Verify that you performed all the [Remote Configuration](remote-config.md) steps for the *Nightscout* site including sending an override from the *Loop* phone to *Nightscout*.
+Verify that you performed all the [Remote Configuration](remote-config.md) steps for the *Nightscout* site including sending an override from the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone to *Nightscout*.
 
 #### BadDeviceToken
 
-When the *Nightscout* config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
+When the *Nightscout* config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the&nbsp;_<span translate="no">Loop</span>_&nbsp;app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
+* If&nbsp;_<span translate="no">Loop</span>_&nbsp;was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If&nbsp;_<span translate="no">Loop</span>_&nbsp;was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
 
 If you attempt to issue a command from *Nightscout* Careportal; after you hit submit and then OK, you will see the error message:
 
@@ -45,21 +45,21 @@ If you added this Build-Time Flag: `REMOTE_OVERRIDES_DISABLED`
 
 You will not see any errors, but nothing will happen when you issue any kind of remote command.
 
-**Solution**: Remove  `REMOTE_OVERRIDES_DISABLED` from  `LoopConfigOverride.xcconfig` file and rebuild the *Loop* app.
+**Solution**: Remove  `REMOTE_OVERRIDES_DISABLED` from  `LoopConfigOverride.xcconfig` file and rebuild the&nbsp;_<span translate="no">Loop</span>_&nbsp;app.
 
 ### Incorrect Password (OTP) Error
 
-The references to Caregiver below is the person sending the commands. There are specific *Loop Caregiver* app insructions that you modify for your authenticator. You must have the *Loop* phone with you to troubleshoot this problem.
+The references to Caregiver below is the person sending the commands. There are specific *Loop Caregiver* app insructions that you modify for your authenticator. You must have the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone with you to troubleshoot this problem.
 
 * The Apple clock should be set to automatic on both the Looper's phone and Caregiver’s device.
     * If the clock is incorrect, even slightly, remote commands will fail.
-* Check if One-Time Passwords (OTP) align between Caregiver and  *Loop*.
-    * In  *Loop*: Settings -> Services -> *Nightscout*
+* Check if One-Time Passwords (OTP) align between Caregiver and&nbsp;_<span translate="no">Loop</span>_.
+    * In&nbsp;_<span translate="no">Loop</span>_: Settings -> Services -> *Nightscout*
     * In *Loop Caregiver* : Settings -> Tap on Loopers Name
     * Observe the 6-digit OTP as they change
 * If the OTP don't match, you can reset it:
     * **Warning**: If there are multiple devices (or people) sending remote commands, this procedure **resets the OTP for all**
-    * *Loop*: Settings -> Services -> *Nightscout* -> One-Time Password -> Tap Reload button
+    * _<span translate="no">Loop</span>_: Settings -> Services -> *Nightscout* -> One-Time Password -> Tap Reload button
         * The QR code is different as soon as you hit `Reload`
     * *Loop Caregiver*: Delete the Looper's profile from *Loop Caregiver* and add the Looper again by scanning their new QR code
     * Authenticators for every device used to send remote commands must be updated
@@ -71,29 +71,29 @@ The references to Caregiver below is the person sending the commands. There are 
 Apple Push Notifications will often not make it to an app, either due to your settings or intentional limitations by Apple. This error can appear in various forms:
 
 * Push notification banner never shows on Looper’s device.
-* Push notification banner shows but nothing happens in *Loop* (no error or success message afterwards)
+* Push notification banner shows but nothing happens in&nbsp;_<span translate="no">Loop</span>_ (no error or success message afterwards)
 * Error message shows that Password (OTP) is expired
 
-While *Loop* does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding  *Loop*, *Loop Caregiver* or *Nightscout* is generally not going to help.
+While&nbsp;_<span translate="no">Loop</span>_&nbsp;does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding&nbsp;_<span translate="no">Loop</span>_, *Loop Caregiver* or *Nightscout* is generally not going to help.
 
 Check these settings on the Looper’s device, not the Caregivers. Several of these are related to Apple suppressing notifications.
 
 * Notifications
-    * Settings -> Notifications ->  *Loop*
+    * Settings -> Notifications ->&nbsp;_<span translate="no">Loop</span>_
     * Turn on “Allow Notifications”
     * Turn on “Time Sensitive Notifications”
 * Focus Modes
-    * For all focus modes (ex: Do Not Disturb, Sleep), make sure *Loop* is listed as an app allowing Notifications.
+    * For all focus modes (ex: Do Not Disturb, Sleep), make sure&nbsp;_<span translate="no">Loop</span>_&nbsp;is listed as an app allowing Notifications.
     * To Adjust
         * Settings -> Focus
         * Select the focus mode (ex: Do Not Disturb, Sleep)
         * Under “Allow Notifications, tap “Apps”
-        * Add “ *Loop* ” to the list.               
+        * Add “&nbsp;_<span translate="no">Loop</span>_&nbsp;” to the list.               
         * Turn on “Time Sensitive Notifications”.
 * Background App Refresh
     * Settings -> General -> Background App Refresh
     * Select “On” up top
-    * Activate *Loop* toggle in list
+    * Activate&nbsp;_<span translate="no">Loop</span>_&nbsp;toggle in list
 * Lower Power Mode
     * Turn off if able
 
@@ -105,8 +105,8 @@ Some other things to try on the Looper’s phone:
     * Apple may not deliver notifications on cellular as often as wifi.
 * Charge the phone
     * If the battery is low, iOS may not deliver notifications to save battery life.
-* Limit the number of *Loop* commands you send in a short period. Apple may throttle notifications if too many are received. (i.e. no more than 1 or 2 per hour may help).
-* Consider disabling “spammy” notifications from other apps. This is only a theory, but it is possible that other apps can cause the system to throttle all notifications, including *Loop* ’s.
+* Limit the number of&nbsp;_<span translate="no">Loop</span>_&nbsp;commands you send in a short period. Apple may throttle notifications if too many are received. (i.e. no more than 1 or 2 per hour may help).
+* Consider disabling “spammy” notifications from other apps. This is only a theory, but it is possible that other apps can cause the system to throttle all notifications, including&nbsp;_<span translate="no">Loop</span>_.
 * Wait 24 hours or so as it often just takes time for the push notification limits to “reset”.
 * iOS 15.3.x: Note there are reports of Remote notifications not being received to the Loopers device for iOS version 15.3 and 15.3.1. This is fixed in iOS version 15.4.
 
@@ -114,19 +114,19 @@ Some other things to try on the Looper’s phone:
 
 This is helpful information to share when requested by helpers. If you are not using *Loop Caregiver*, review the response seen on the *Nightscout* site.
 
-1. Activate an override _from within *Loop* _. Does *Nightscout* show the active override?
-1. Activate an override _from  *Nightscout* _. Does it change the active override in  *Loop*?
+1. Activate an override _from within&nbsp;_<span translate="no">Loop</span>_ _. Does *Nightscout* show the active override?
+1. Activate an override _from  *Nightscout* _. Does it change the active override in&nbsp;_<span translate="no">Loop</span>_?
 1. Do errors show in *Loop Caregiver* or *Nightscout* Careportal when you send a remote command?
     * Share screenshots of error if any
 1. Do errors show in iOS Notifications on the Looper’s device?
     * Check their Notification history in iOS by swiping down 
     * Share screenshots of errors if any
-1. What *Loop* version are you using? Released (main) or development (dev)? Approximately when did you update last?
-    * The minimum version that support remote bolus and carbs is *Loop* 3
+1. What&nbsp;_<span translate="no">Loop</span>_&nbsp;version are you using? Released (main) or development (dev)? Approximately when did you update last?
+    * The minimum version that support remote bolus and carbs is&nbsp;_<span translate="no">Loop</span>_&nbsp;3
 1. What iOS version is being used on the Looper’s device?
     * Note that iOS 15.3.x had notification issues
     * Update to a newer version
-1. How did you build  *Loop*?
+1. How did you build&nbsp;_<span translate="no">Loop</span>_?
     * Build with Xcode to device (typical)?
     * Using AppCenter or Diawai? A special environment variable must be set LOOP_PUSH_SERVER_ENVIRONMENT=production
 
@@ -137,7 +137,7 @@ Mention which troubleshooting steps you have completed so we know whether to ask
 
 Once you've set up remote commands, you may encounter errors when trying to run them via *Nightscout* or iOS Shortcuts.  Below are the most common and typical solutions.
 
-1. **`Error: *Loop* notification failed: Could not find deviceToken in loopSettings`** You might see this in either *Nightscout* or Shortcuts.  The error is most commonly caused by *Loop* not pointing to the right *Nightscout* instance or you haven't yet run an override locally (with the *Loop* app) before trying to run one remotely.  
+1. **`Error: Loop notification failed: Could not find deviceToken in loopSettings`** You might see this in either *Nightscout* or Shortcuts.  The error is most commonly caused by&nbsp;_<span translate="no">Loop</span>_&nbsp;not pointing to the right *Nightscout* instance or you haven't yet run an override locally (with the&nbsp;_<span translate="no">Loop</span>_ app) before trying to run one remotely.  
     **Solution:** Confirm the *Loop* app is pointing to the right *Nightscout* site (and there are no extra spaces or a slash (`/`) at the end, and always run an override for a few seconds in the *Loop* app before you try to run one remotely.
 2. **`Error: cannot POST/api/v2/notifications/loop`** You might see this in iOS Shortcuts.  This means *Nightscout* is not updated correctly and you are running a version of *Nightscout* that doesn't yet support remote overrides.   
    **Solution:** Follow the [Remote Configuration](remote-config.md) documentation.

--- a/docs/nightscout/remote-errors.md
+++ b/docs/nightscout/remote-errors.md
@@ -1,24 +1,24 @@
-## <span translate="no">Loop</span>&nbsp; data is not showing in &nbsp;<span translate="no">Nightscout</span>
+## *Loop* data is not showing in &nbsp;<span translate="no">Nightscout</span>
 
-* This is a &nbsp;<span translate="no">Loop</span>&nbsp; and/or &nbsp;<span translate="no">Nightscout</span>&nbsp; issue, not related to remote configuration
-    * Review the [LoopDocs: <span translate="no">Nightscout</span>&nbsp; with &nbsp;<span translate="no">Loop</span>](update-user.md) page
+* This is a *Loop* and/or &nbsp;<span translate="no">Nightscout</span>&nbsp; issue, not related to remote configuration
+    * Review the [LoopDocs: <span translate="no">Nightscout</span>&nbsp; with  *Loop*](update-user.md) page
     * Check out links on the [LoopDocs: <span translate="no">Nightscout</span>&nbsp; Troubleshooting](troubleshoot.md) page
 * Make sure Looper's phone is connected to the internet so it can upload to &nbsp;<span translate="no">Nightscout</span>
 
 ## Improper Configuration
 
-### <span translate="no">Nightscout</span>&nbsp; Config and &nbsp;<span translate="no">Loop</span>&nbsp; Build Method
+### <span translate="no">Nightscout</span>&nbsp; Config and *Loop* Build Method
 
 Ensure your &nbsp;<span translate="no">Nightscout</span>&nbsp; version is at least version 14.2.6.
 
-Verify that you performed all the [Remote Configuration](remote-config.md) steps for the &nbsp;<span translate="no">Nightscout</span>&nbsp; site including sending an override from the &nbsp;<span translate="no">Loop</span>&nbsp; phone to &nbsp;<span translate="no">Nightscout</span>.
+Verify that you performed all the [Remote Configuration](remote-config.md) steps for the &nbsp;<span translate="no">Nightscout</span>&nbsp; site including sending an override from the *Loop* phone to &nbsp;<span translate="no">Nightscout</span>.
 
 #### BadDeviceToken
 
-When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the &nbsp;<span translate="no">Loop</span>&nbsp; app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
+When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If &nbsp;<span translate="no">Loop</span>&nbsp; was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If &nbsp;<span translate="no">Loop</span>&nbsp; was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
+* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
 
 If you attempt to issue a command from &nbsp;<span translate="no">Nightscout</span>&nbsp; Careportal; after you hit submit and then OK, you will see the error message:
 
@@ -26,7 +26,7 @@ If you attempt to issue a command from &nbsp;<span translate="no">Nightscout</sp
 Error: APNs delivery failed: BadDeviceToken
 ```
 
-If you attempt to issue a command using &nbsp;<span translate="no">Loop Caregiver</span>; after you authenticate the command, you will see the error message listed below and shown in the screenshot.
+If you attempt to issue a command using *Loop Caregiver* ; after you authenticate the command, you will see the error message listed below and shown in the screenshot.
 
 ```
 HTTP Error
@@ -37,7 +37,7 @@ body: APNs delivery failed: BadDeviceToken
 ![site and build method mismatch](img/site-build-mismatch.png){width="300"}
 {align="center"}
 
-### <span translate="no">Loop</span>&nbsp; `REMOTE_OVERRIDES_DISABLED`
+### *Loop* `REMOTE_OVERRIDES_DISABLED`
 
 You can build Loop with [Build-Time Features](../build/code-customization.md#build-time-features) as part of code customization.
 
@@ -45,23 +45,23 @@ If you added this Build-Time Flag: `REMOTE_OVERRIDES_DISABLED`
 
 You will not see any errors, but nothing will happen when you issue any kind of remote command.
 
-**Solution**: Remove  `REMOTE_OVERRIDES_DISABLED` from  `LoopConfigOverride.xcconfig` file and rebuild the &nbsp;<span translate="no">Loop</span>&nbsp; app.
+**Solution**: Remove  `REMOTE_OVERRIDES_DISABLED` from  `LoopConfigOverride.xcconfig` file and rebuild the *Loop* app.
 
 ### Incorrect Password (OTP) Error
 
-The references to Caregiver below is the person sending the commands. There are specific &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app insructions that you modify for your authenticator. You must have the &nbsp;<span translate="no">Loop</span>&nbsp; phone with you to troubleshoot this problem.
+The references to Caregiver below is the person sending the commands. There are specific *Loop Caregiver* app insructions that you modify for your authenticator. You must have the *Loop* phone with you to troubleshoot this problem.
 
 * The Apple clock should be set to automatic on both the Looper's phone and Caregiver’s device.
     * If the clock is incorrect, even slightly, remote commands will fail.
-* Check if One-Time Passwords (OTP) align between Caregiver and &nbsp;<span translate="no">Loop</span>.
-    * In &nbsp;<span translate="no">Loop</span>: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>
-    * In &nbsp;<span translate="no">Loop Caregiver</span>: Settings -> Tap on Loopers Name
+* Check if One-Time Passwords (OTP) align between Caregiver and  *Loop*.
+    * In  *Loop*: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>
+    * In *Loop Caregiver* : Settings -> Tap on Loopers Name
     * Observe the 6-digit OTP as they change
 * If the OTP don't match, you can reset it:
     * **Warning**: If there are multiple devices (or people) sending remote commands, this procedure **resets the OTP for all**
-    * <span translate="no">Loop</span>: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>&nbsp; -> One-Time Password -> Tap Reload button
+    * *Loop*: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>&nbsp; -> One-Time Password -> Tap Reload button
         * The QR code is different as soon as you hit `Reload`
-    * <span translate="no">Loop Caregiver</span>: Delete the Looper's profile from &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; and add the Looper again by scanning their new QR code
+    * *Loop Caregiver*: Delete the Looper's profile from *Loop Caregiver* and add the Looper again by scanning their new QR code
     * Authenticators for every device used to send remote commands must be updated
         * Delete the OTP configuration
         * Add the new QR code
@@ -71,29 +71,29 @@ The references to Caregiver below is the person sending the commands. There are 
 Apple Push Notifications will often not make it to an app, either due to your settings or intentional limitations by Apple. This error can appear in various forms:
 
 * Push notification banner never shows on Looper’s device.
-* Push notification banner shows but nothing happens in &nbsp;<span translate="no">Loop</span>&nbsp; (no error or success message afterwards)
+* Push notification banner shows but nothing happens in *Loop* (no error or success message afterwards)
 * Error message shows that Password (OTP) is expired
 
-While &nbsp;<span translate="no">Loop</span>&nbsp; does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding &nbsp;<span translate="no">Loop</span>, &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; or &nbsp;<span translate="no">Nightscout</span>&nbsp; is generally not going to help.
+While *Loop* does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding  *Loop*, *Loop Caregiver* or &nbsp;<span translate="no">Nightscout</span>&nbsp; is generally not going to help.
 
 Check these settings on the Looper’s device, not the Caregivers. Several of these are related to Apple suppressing notifications.
 
 * Notifications
-    * Settings -> Notifications -> &nbsp;<span translate="no">Loop</span>
+    * Settings -> Notifications ->  *Loop*
     * Turn on “Allow Notifications”
     * Turn on “Time Sensitive Notifications”
 * Focus Modes
-    * For all focus modes (ex: Do Not Disturb, Sleep), make sure &nbsp;<span translate="no">Loop</span>&nbsp; is listed as an app allowing Notifications.
+    * For all focus modes (ex: Do Not Disturb, Sleep), make sure *Loop* is listed as an app allowing Notifications.
     * To Adjust
         * Settings -> Focus
         * Select the focus mode (ex: Do Not Disturb, Sleep)
         * Under “Allow Notifications, tap “Apps”
-        * Add “&nbsp;<span translate="no">Loop</span>&nbsp;” to the list.               
+        * Add “ *Loop* ” to the list.               
         * Turn on “Time Sensitive Notifications”.
 * Background App Refresh
     * Settings -> General -> Background App Refresh
     * Select “On” up top
-    * Activate &nbsp;<span translate="no">Loop</span>&nbsp; toggle in list
+    * Activate *Loop* toggle in list
 * Lower Power Mode
     * Turn off if able
 
@@ -105,28 +105,28 @@ Some other things to try on the Looper’s phone:
     * Apple may not deliver notifications on cellular as often as wifi.
 * Charge the phone
     * If the battery is low, iOS may not deliver notifications to save battery life.
-* Limit the number of &nbsp;<span translate="no">Loop</span>&nbsp; commands you send in a short period. Apple may throttle notifications if too many are received. (i.e. no more than 1 or 2 per hour may help).
-* Consider disabling “spammy” notifications from other apps. This is only a theory, but it is possible that other apps can cause the system to throttle all notifications, including &nbsp;<span translate="no">Loop</span>&nbsp;’s.
+* Limit the number of *Loop* commands you send in a short period. Apple may throttle notifications if too many are received. (i.e. no more than 1 or 2 per hour may help).
+* Consider disabling “spammy” notifications from other apps. This is only a theory, but it is possible that other apps can cause the system to throttle all notifications, including *Loop* ’s.
 * Wait 24 hours or so as it often just takes time for the push notification limits to “reset”.
 * iOS 15.3.x: Note there are reports of Remote notifications not being received to the Loopers device for iOS version 15.3 and 15.3.1. This is fixed in iOS version 15.4.
 
 ## How to Ask for Help
 
-This is helpful information to share when requested by helpers. If you are not using &nbsp;<span translate="no">Loop Caregiver</span>, review the response seen on the &nbsp;<span translate="no">Nightscout</span>&nbsp; site.
+This is helpful information to share when requested by helpers. If you are not using *Loop Caregiver*, review the response seen on the &nbsp;<span translate="no">Nightscout</span>&nbsp; site.
 
-1. Activate an override _from within &nbsp;<span translate="no">Loop</span>&nbsp;_. Does &nbsp;<span translate="no">Nightscout</span>&nbsp; show the active override?
-1. Activate an override _from &nbsp;<span translate="no">Nightscout</span>&nbsp;_. Does it change the active override in &nbsp;<span translate="no">Loop</span>?
-1. Do errors show in &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; or &nbsp;<span translate="no">Nightscout</span>&nbsp; Careportal when you send a remote command?
+1. Activate an override _from within *Loop* _. Does &nbsp;<span translate="no">Nightscout</span>&nbsp; show the active override?
+1. Activate an override _from &nbsp;<span translate="no">Nightscout</span>&nbsp;_. Does it change the active override in  *Loop*?
+1. Do errors show in *Loop Caregiver* or &nbsp;<span translate="no">Nightscout</span>&nbsp; Careportal when you send a remote command?
     * Share screenshots of error if any
 1. Do errors show in iOS Notifications on the Looper’s device?
     * Check their Notification history in iOS by swiping down 
     * Share screenshots of errors if any
-1. What &nbsp;<span translate="no">Loop</span>&nbsp; version are you using? Released (main) or development (dev)? Approximately when did you update last?
-    * The minimum version that support remote bolus and carbs is &nbsp;<span translate="no">Loop</span>&nbsp; 3
+1. What *Loop* version are you using? Released (main) or development (dev)? Approximately when did you update last?
+    * The minimum version that support remote bolus and carbs is *Loop* 3
 1. What iOS version is being used on the Looper’s device?
     * Note that iOS 15.3.x had notification issues
     * Update to a newer version
-1. How did you build &nbsp;<span translate="no">Loop</span>?
+1. How did you build  *Loop*?
     * Build with Xcode to device (typical)?
     * Using AppCenter or Diawai? A special environment variable must be set LOOP_PUSH_SERVER_ENVIRONMENT=production
 
@@ -137,8 +137,8 @@ Mention which troubleshooting steps you have completed so we know whether to ask
 
 Once you've set up remote commands, you may encounter errors when trying to run them via &nbsp;<span translate="no">Nightscout</span>&nbsp; or iOS Shortcuts.  Below are the most common and typical solutions.
 
-1. **`Error: <span translate="no">Loop</span>&nbsp; notification failed: Could not find deviceToken in loopSettings`** You might see this in either &nbsp;<span translate="no">Nightscout</span>&nbsp; or Shortcuts.  The error is most commonly caused by &nbsp;<span translate="no">Loop</span>&nbsp; not pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; instance or you haven't yet run an override locally (with the &nbsp;<span translate="no">Loop</span>&nbsp; app) before trying to run one remotely.  
-    **Solution:** Confirm the &nbsp;<span translate="no">Loop</span>&nbsp; app is pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; site (and there are no extra spaces or a slash (`/`) at the end, and always run an override for a few seconds in the &nbsp;<span translate="no">Loop</span>&nbsp; app before you try to run one remotely.
+1. **`Error: *Loop* notification failed: Could not find deviceToken in loopSettings`** You might see this in either &nbsp;<span translate="no">Nightscout</span>&nbsp; or Shortcuts.  The error is most commonly caused by *Loop* not pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; instance or you haven't yet run an override locally (with the *Loop* app) before trying to run one remotely.  
+    **Solution:** Confirm the *Loop* app is pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; site (and there are no extra spaces or a slash (`/`) at the end, and always run an override for a few seconds in the *Loop* app before you try to run one remotely.
 2. **`Error: cannot POST/api/v2/notifications/loop`** You might see this in iOS Shortcuts.  This means &nbsp;<span translate="no">Nightscout</span>&nbsp; is not updated correctly and you are running a version of &nbsp;<span translate="no">Nightscout</span>&nbsp; that doesn't yet support remote overrides.   
    **Solution:** Follow the [Remote Configuration](remote-config.md) documentation.
 3. **`Error: {“status”:401,”message”:”Unauthorized”,”description”:Invalid\\/Missing”}`** You might see this in iOS Shortcuts.  This is caused by having an incorrect `API_SECRET` in the shortcut.  

--- a/docs/nightscout/remote-errors.md
+++ b/docs/nightscout/remote-errors.md
@@ -1,26 +1,26 @@
-## *Loop* data is not showing in &nbsp;<span translate="no">Nightscout</span>
+## *Loop* data is not showing in *Nightscout*
 
-* This is a *Loop* and/or &nbsp;<span translate="no">Nightscout</span>&nbsp; issue, not related to remote configuration
-    * Review the [LoopDocs: <span translate="no">Nightscout</span>&nbsp; with  *Loop*](update-user.md) page
-    * Check out links on the [LoopDocs: <span translate="no">Nightscout</span>&nbsp; Troubleshooting](troubleshoot.md) page
-* Make sure Looper's phone is connected to the internet so it can upload to &nbsp;<span translate="no">Nightscout</span>
+* This is a *Loop* and/or *Nightscout* issue, not related to remote configuration
+    * Review the [LoopDocs: *Nightscout* with  *Loop*](update-user.md) page
+    * Check out links on the [LoopDocs: *Nightscout* Troubleshooting](troubleshoot.md) page
+* Make sure Looper's phone is connected to the internet so it can upload to *Nightscout*
 
 ## Improper Configuration
 
-### <span translate="no">Nightscout</span>&nbsp; Config and *Loop* Build Method
+### *Nightscout* Config and *Loop* Build Method
 
-Ensure your &nbsp;<span translate="no">Nightscout</span>&nbsp; version is at least version 14.2.6.
+Ensure your *Nightscout* version is at least version 14.2.6.
 
-Verify that you performed all the [Remote Configuration](remote-config.md) steps for the &nbsp;<span translate="no">Nightscout</span>&nbsp; site including sending an override from the *Loop* phone to &nbsp;<span translate="no">Nightscout</span>.
+Verify that you performed all the [Remote Configuration](remote-config.md) steps for the *Nightscout* site including sending an override from the *Loop* phone to *Nightscout*.
 
 #### BadDeviceToken
 
-When the &nbsp;<span translate="no">Nightscout</span>&nbsp; config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
+When the *Nightscout* config var LOOP_PUSH_SERVER_ENVIRONMENT does not match the *Loop* app build method; the error message contains the phrase `APNs delivery failed: BadDeviceToken`.
 
-* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have &nbsp;<span translate="no">Nightscout</span>&nbsp; config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
-* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your &nbsp;<span translate="no">Nightscout</span>&nbsp; config vars
+* If *Loop* was installed remotely (typically from TestFlight following GitHub Browser Build), you **must** have *Nightscout* config var `LOOP_PUSH_SERVER_ENVIRONMENT` set to `production`
+* If *Loop* was built using Mac-Xcode, you **cannot** have `LOOP_PUSH_SERVER_ENVIRONMENT` as one of your *Nightscout* config vars
 
-If you attempt to issue a command from &nbsp;<span translate="no">Nightscout</span>&nbsp; Careportal; after you hit submit and then OK, you will see the error message:
+If you attempt to issue a command from *Nightscout* Careportal; after you hit submit and then OK, you will see the error message:
 
 ```
 Error: APNs delivery failed: BadDeviceToken
@@ -54,12 +54,12 @@ The references to Caregiver below is the person sending the commands. There are 
 * The Apple clock should be set to automatic on both the Looper's phone and Caregiver’s device.
     * If the clock is incorrect, even slightly, remote commands will fail.
 * Check if One-Time Passwords (OTP) align between Caregiver and  *Loop*.
-    * In  *Loop*: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>
+    * In  *Loop*: Settings -> Services -> *Nightscout*
     * In *Loop Caregiver* : Settings -> Tap on Loopers Name
     * Observe the 6-digit OTP as they change
 * If the OTP don't match, you can reset it:
     * **Warning**: If there are multiple devices (or people) sending remote commands, this procedure **resets the OTP for all**
-    * *Loop*: Settings -> Services -> &nbsp;<span translate="no">Nightscout</span>&nbsp; -> One-Time Password -> Tap Reload button
+    * *Loop*: Settings -> Services -> *Nightscout* -> One-Time Password -> Tap Reload button
         * The QR code is different as soon as you hit `Reload`
     * *Loop Caregiver*: Delete the Looper's profile from *Loop Caregiver* and add the Looper again by scanning their new QR code
     * Authenticators for every device used to send remote commands must be updated
@@ -74,7 +74,7 @@ Apple Push Notifications will often not make it to an app, either due to your se
 * Push notification banner shows but nothing happens in *Loop* (no error or success message afterwards)
 * Error message shows that Password (OTP) is expired
 
-While *Loop* does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding  *Loop*, *Loop Caregiver* or &nbsp;<span translate="no">Nightscout</span>&nbsp; is generally not going to help.
+While *Loop* does not have control over Push Notification timely delivery, there are things that can be done to mitigate these issues. Note that rebuilding  *Loop*, *Loop Caregiver* or *Nightscout* is generally not going to help.
 
 Check these settings on the Looper’s device, not the Caregivers. Several of these are related to Apple suppressing notifications.
 
@@ -112,11 +112,11 @@ Some other things to try on the Looper’s phone:
 
 ## How to Ask for Help
 
-This is helpful information to share when requested by helpers. If you are not using *Loop Caregiver*, review the response seen on the &nbsp;<span translate="no">Nightscout</span>&nbsp; site.
+This is helpful information to share when requested by helpers. If you are not using *Loop Caregiver*, review the response seen on the *Nightscout* site.
 
-1. Activate an override _from within *Loop* _. Does &nbsp;<span translate="no">Nightscout</span>&nbsp; show the active override?
-1. Activate an override _from &nbsp;<span translate="no">Nightscout</span>&nbsp;_. Does it change the active override in  *Loop*?
-1. Do errors show in *Loop Caregiver* or &nbsp;<span translate="no">Nightscout</span>&nbsp; Careportal when you send a remote command?
+1. Activate an override _from within *Loop* _. Does *Nightscout* show the active override?
+1. Activate an override _from  *Nightscout* _. Does it change the active override in  *Loop*?
+1. Do errors show in *Loop Caregiver* or *Nightscout* Careportal when you send a remote command?
     * Share screenshots of error if any
 1. Do errors show in iOS Notifications on the Looper’s device?
     * Check their Notification history in iOS by swiping down 
@@ -135,13 +135,13 @@ Mention which troubleshooting steps you have completed so we know whether to ask
 
 ## Other Errors
 
-Once you've set up remote commands, you may encounter errors when trying to run them via &nbsp;<span translate="no">Nightscout</span>&nbsp; or iOS Shortcuts.  Below are the most common and typical solutions.
+Once you've set up remote commands, you may encounter errors when trying to run them via *Nightscout* or iOS Shortcuts.  Below are the most common and typical solutions.
 
-1. **`Error: *Loop* notification failed: Could not find deviceToken in loopSettings`** You might see this in either &nbsp;<span translate="no">Nightscout</span>&nbsp; or Shortcuts.  The error is most commonly caused by *Loop* not pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; instance or you haven't yet run an override locally (with the *Loop* app) before trying to run one remotely.  
-    **Solution:** Confirm the *Loop* app is pointing to the right &nbsp;<span translate="no">Nightscout</span>&nbsp; site (and there are no extra spaces or a slash (`/`) at the end, and always run an override for a few seconds in the *Loop* app before you try to run one remotely.
-2. **`Error: cannot POST/api/v2/notifications/loop`** You might see this in iOS Shortcuts.  This means &nbsp;<span translate="no">Nightscout</span>&nbsp; is not updated correctly and you are running a version of &nbsp;<span translate="no">Nightscout</span>&nbsp; that doesn't yet support remote overrides.   
+1. **`Error: *Loop* notification failed: Could not find deviceToken in loopSettings`** You might see this in either *Nightscout* or Shortcuts.  The error is most commonly caused by *Loop* not pointing to the right *Nightscout* instance or you haven't yet run an override locally (with the *Loop* app) before trying to run one remotely.  
+    **Solution:** Confirm the *Loop* app is pointing to the right *Nightscout* site (and there are no extra spaces or a slash (`/`) at the end, and always run an override for a few seconds in the *Loop* app before you try to run one remotely.
+2. **`Error: cannot POST/api/v2/notifications/loop`** You might see this in iOS Shortcuts.  This means *Nightscout* is not updated correctly and you are running a version of *Nightscout* that doesn't yet support remote overrides.   
    **Solution:** Follow the [Remote Configuration](remote-config.md) documentation.
 3. **`Error: {“status”:401,”message”:”Unauthorized”,”description”:Invalid\\/Missing”}`** You might see this in iOS Shortcuts.  This is caused by having an incorrect `API_SECRET` in the shortcut.  
     **Solution:** Double check the `API_SECRET` is correct and that there are no spaces at the end.
-4. **`Error: APNs delivery failed: InvalidProviderToken`** You might see this in either &nbsp;<span translate="no">Nightscout</span>&nbsp; or Shortcuts.  This is caused because your `LOOP_APNS_KEY_ID` and `LOOP_DEVELOPER_TEAM_ID` are swapped in *Heroku*.   
+4. **`Error: APNs delivery failed: InvalidProviderToken`** You might see this in either *Nightscout* or Shortcuts.  This is caused because your `LOOP_APNS_KEY_ID` and `LOOP_DEVELOPER_TEAM_ID` are swapped in *Heroku*.   
    **Solution:** Double check what's listed in your *Apple Developer Account* and compare it to the config variables in *Heroku*. Your `Team_ID` is next to your name in the top right corner.  The other code is your `Key_ID`. Get the IDs in the correct location in *Heroku* to resolve the error.

--- a/docs/nightscout/remote-overview.md
+++ b/docs/nightscout/remote-overview.md
@@ -1,14 +1,14 @@
 ## Remote Caregivers
 
-With &nbsp;<span translate="no">Loop</span>&nbsp; 3, a caregiver can provide remote commands to assist in diabetes care, including modifying overrides, issuing remote bolus commands and adding remote carb entries. With &nbsp;<span translate="no">Loop</span>&nbsp; 2, only overrides can be turned on or off remotely.
+With *Loop* 3, a caregiver can provide remote commands to assist in diabetes care, including modifying overrides, issuing remote bolus commands and adding remote carb entries. With *Loop* 2, only overrides can be turned on or off remotely.
 
-Remote commands to the &nbsp;<span translate="no">Loop</span>&nbsp; phone go through their &nbsp;<span translate="no">Nightscout</span>&nbsp; site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined &nbsp;<span translate="no">Loop</span>&nbsp; and &nbsp;<span translate="no">Nightscout</span>&nbsp; configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The &nbsp;<span translate="no">Loop Caregiver</span>&nbsp; app can be used. It handles authentication requirements and offers a &nbsp;<span translate="no">Loop</span>&nbsp;-like user interface.
+Remote commands to the *Loop* phone go through their &nbsp;<span translate="no">Nightscout</span>&nbsp; site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined *Loop* and &nbsp;<span translate="no">Nightscout</span>&nbsp; configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The *Loop Caregiver* app can be used. It handles authentication requirements and offers a *Loop* -like user interface.
 
 ### Remote Commanding Requirements:
 
-* <span translate="no">Loop</span>&nbsp; version 3.2.0 or newer
+* *Loop* version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
-* <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the &nbsp;<span translate="no">Loop</span>&nbsp; app
+* <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the *Loop* app
 * <span translate="no">Nightscout</span>&nbsp; version 14.2.6 or newer
     * Several configuration variables must be added
 * Ability to generate a One-Time-Password (OTP)
@@ -18,15 +18,15 @@ Remote commands to the &nbsp;<span translate="no">Loop</span>&nbsp; phone go thr
 
     If your &nbsp;<span translate="no">Nightscout</span>&nbsp; site is an older version, you should limit your remote commands to `Overrides`, even with &nbsp;<span translate="no">Loop 3</span>.
 
-!!! tip "&nbsp;<span translate="no">Loop Caregiver</span>"
-    There is a new companion app, &nbsp;[<span translate="no">Loop Caregiver</span>](loop-caregiver.md) that makes remote commands and reviewing status of your looper much easier.
+!!! tip "&nbsp;*Loop Caregiver*"
+    There is a new companion app, &nbsp;[*Loop Caregiver*](loop-caregiver.md) that makes remote commands and reviewing status of your looper much easier.
 
 ## How does this work?
 
-<span translate="no">Loop</span>&nbsp; and &nbsp;<span translate="no">Nightscout</span>&nbsp; work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
+*Loop* and &nbsp;<span translate="no">Nightscout</span>&nbsp; work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
 
-* The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the &nbsp;<span translate="no">Loop</span>&nbsp; app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
-    * If you built &nbsp;<span translate="no">Nightscout</span>&nbsp; and &nbsp;<span translate="no">Loop</span>&nbsp; yourself, follow the directions to set up [Remote Configuration](remote-config.md)
+* The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the *Loop* app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
+    * If you built &nbsp;<span translate="no">Nightscout</span>&nbsp; and *Loop* yourself, follow the directions to set up [Remote Configuration](remote-config.md)
 * Most providers who supply `Nightscout as a service` or `Hosted Nightscout` will assist you, if needed, in getting your APN information added to your &nbsp;<span translate="no">Nightscout</span>&nbsp; variables
     * [Nightscout Docs: New User](https://nightscout.github.io/nightscout/new_user)
     * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)
@@ -42,4 +42,4 @@ There are a number of steps to follow to set this up. Each page is linked below:
 
 ### [Remote Errors](remote-errors.md)
 
-### [<span translate="no">Loop Caregiver</span>&nbsp; App](loop-caregiver.md)
+### [*Loop Caregiver* App](loop-caregiver.md)

--- a/docs/nightscout/remote-overview.md
+++ b/docs/nightscout/remote-overview.md
@@ -6,7 +6,7 @@ Remote commands to the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone go thr
 
 ### Remote Commanding Requirements:
 
-*&nbsp;_<span translate="no">Loop</span>_&nbsp;version 3.2.0 or newer
+* &nbsp;_<span translate="no">Loop</span>_&nbsp;version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
 * <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the&nbsp;_<span translate="no">Loop</span>_&nbsp;app
 * *Nightscout* version 14.2.6 or newer

--- a/docs/nightscout/remote-overview.md
+++ b/docs/nightscout/remote-overview.md
@@ -1,14 +1,14 @@
 ## Remote Caregivers
 
-With *Loop* 3, a caregiver can provide remote commands to assist in diabetes care, including modifying overrides, issuing remote bolus commands and adding remote carb entries. With *Loop* 2, only overrides can be turned on or off remotely.
+With&nbsp;_<span translate="no">Loop</span>_&nbsp;3, a caregiver can provide remote commands to assist in diabetes care, including modifying overrides, issuing remote bolus commands and adding remote carb entries. With&nbsp;_<span translate="no">Loop</span>_&nbsp;2, only overrides can be turned on or off remotely.
 
-Remote commands to the *Loop* phone go through their *Nightscout* site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined *Loop* and *Nightscout* configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The *Loop Caregiver* app can be used. It handles authentication requirements and offers a *Loop* -like user interface.
+Remote commands to the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone go through their *Nightscout* site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined&nbsp;_<span translate="no">Loop</span>_&nbsp;and *Nightscout* configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The *Loop Caregiver* app can be used. It handles authentication requirements and offers a&nbsp;_<span translate="no">Loop</span>_&nbsp;-like user interface.
 
 ### Remote Commanding Requirements:
 
-* *Loop* version 3.2.0 or newer
+*&nbsp;_<span translate="no">Loop</span>_&nbsp;version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
-* <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the *Loop* app
+* <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the&nbsp;_<span translate="no">Loop</span>_&nbsp;app
 * *Nightscout* version 14.2.6 or newer
     * Several configuration variables must be added
 * Ability to generate a One-Time-Password (OTP)
@@ -23,10 +23,10 @@ Remote commands to the *Loop* phone go through their *Nightscout* site. For secu
 
 ## How does this work?
 
-*Loop* and *Nightscout* work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
+_<span translate="no">Loop</span>_&nbsp;and *Nightscout* work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
 
-* The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the *Loop* app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
-    * If you built *Nightscout* and *Loop* yourself, follow the directions to set up [Remote Configuration](remote-config.md)
+* The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the&nbsp;_<span translate="no">Loop</span>_&nbsp;app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
+    * If you built *Nightscout* and&nbsp;_<span translate="no">Loop</span>_&nbsp;yourself, follow the directions to set up [Remote Configuration](remote-config.md)
 * Most providers who supply `Nightscout as a service` or `Hosted Nightscout` will assist you, if needed, in getting your APN information added to your *Nightscout* variables
     * [Nightscout Docs: New User](https://nightscout.github.io/nightscout/new_user)
     * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)

--- a/docs/nightscout/remote-overview.md
+++ b/docs/nightscout/remote-overview.md
@@ -2,32 +2,32 @@
 
 With *Loop* 3, a caregiver can provide remote commands to assist in diabetes care, including modifying overrides, issuing remote bolus commands and adding remote carb entries. With *Loop* 2, only overrides can be turned on or off remotely.
 
-Remote commands to the *Loop* phone go through their &nbsp;<span translate="no">Nightscout</span>&nbsp; site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined *Loop* and &nbsp;<span translate="no">Nightscout</span>&nbsp; configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The *Loop Caregiver* app can be used. It handles authentication requirements and offers a *Loop* -like user interface.
+Remote commands to the *Loop* phone go through their *Nightscout* site. For security, any command to deliver a bolus or add a carb entry requires a one-time-password (OTP) to be used with each remote command. These codes are unique to your combined *Loop* and *Nightscout* configuration. An authentication app needs to be installed on the device sending the remote boluses/carbs. The *Loop Caregiver* app can be used. It handles authentication requirements and offers a *Loop* -like user interface.
 
 ### Remote Commanding Requirements:
 
 * *Loop* version 3.2.0 or newer
     * version 3.0 works but is not recommended for other reasons
 * <span translate="no">Apple Push Notifications</span>&nbsp; (</span>&nbsp;APN</span>&nbsp;) created with the &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; that built the *Loop* app
-* <span translate="no">Nightscout</span>&nbsp; version 14.2.6 or newer
+* *Nightscout* version 14.2.6 or newer
     * Several configuration variables must be added
 * Ability to generate a One-Time-Password (OTP)
 
 !!! question "What about Older Versions?"
     Caregivers for those using older versions of Loop can modify `Overrides` remotely but cannot send remote bolus or carb commands.
 
-    If your &nbsp;<span translate="no">Nightscout</span>&nbsp; site is an older version, you should limit your remote commands to `Overrides`, even with &nbsp;<span translate="no">Loop 3</span>.
+    If your *Nightscout* site is an older version, you should limit your remote commands to `Overrides`, even with &nbsp;<span translate="no">Loop 3</span>.
 
 !!! tip "&nbsp;*Loop Caregiver*"
     There is a new companion app, &nbsp;[*Loop Caregiver*](loop-caregiver.md) that makes remote commands and reviewing status of your looper much easier.
 
 ## How does this work?
 
-*Loop* and &nbsp;<span translate="no">Nightscout</span>&nbsp; work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
+*Loop* and *Nightscout* work using &nbsp;<span translate="no">Apple Push Notifications</span>&nbsp; (APN).
 
 * The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the *Loop* app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
-    * If you built &nbsp;<span translate="no">Nightscout</span>&nbsp; and *Loop* yourself, follow the directions to set up [Remote Configuration](remote-config.md)
-* Most providers who supply `Nightscout as a service` or `Hosted Nightscout` will assist you, if needed, in getting your APN information added to your &nbsp;<span translate="no">Nightscout</span>&nbsp; variables
+    * If you built *Nightscout* and *Loop* yourself, follow the directions to set up [Remote Configuration](remote-config.md)
+* Most providers who supply `Nightscout as a service` or `Hosted Nightscout` will assist you, if needed, in getting your APN information added to your *Nightscout* variables
     * [Nightscout Docs: New User](https://nightscout.github.io/nightscout/new_user)
     * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)
         * **Warning: examine the `Loop remote carbs/bolus` row: subscription refers to a monthly fee**

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -161,7 +161,7 @@ If you want to look at the code, the version (as of 14-Aug-2023) is found in Loo
 
 This feature allows you to save Favorite Foods.
 
-A new row on the &nbsp;<span translate="no">Loop</span>&nbsp; app Settings screen, see graphic below, provides access to create and edit your &nbsp;<span translate="no">Favorite Foods</span>.
+A new row on the *Loop* app Settings screen, see graphic below, provides access to create and edit your &nbsp;<span translate="no">Favorite Foods</span>.
 
 ![favorite foods feature](img/favorite-foods.svg){width="300"}
 {align="center"}
@@ -176,11 +176,11 @@ At this point the meal can be saved by tapping the Continue button, or the user 
 ![carb entry with favorite foods feature](img/favorite-foods-carb-entry.svg){width="500"}
 {align="center"}
 
-### <span translate="no">TestFlight</span>&nbsp; Expiration Warning
+### *TestFlight*  Expiration Warning
 
-The &nbsp;<span translate="no">Loop</span>&nbsp; app has been updated to detect whether the build was uploaded through &nbsp;<span translate="no">TestFlight</span>, which implies a 90-day limit until the app expires.
+The *Loop* app has been updated to detect whether the build was uploaded through  *TestFlight*, which implies a 90-day limit until the app expires.
 
-The usual &nbsp;[<span translate="no">Loop</span>&nbsp; expiration notification system](../operation/features/notifications.md#loop-app-expiration-notification) alerts the user when within 20 days of expiration. In addition to that modal alert, the user can examine the bottom of the Settings screen at any time to see the expected expiration date and time.
+The usual &nbsp;[*Loop* expiration notification system](../operation/features/notifications.md#loop-app-expiration-notification) alerts the user when within 20 days of expiration. In addition to that modal alert, the user can examine the bottom of the Settings screen at any time to see the expected expiration date and time.
 
 ![expiration warning on settings for testflight example](img/expiration-warning-testflight.svg){width="300"}
 {align="center"}
@@ -189,12 +189,12 @@ The usual &nbsp;[<span translate="no">Loop</span>&nbsp; expiration notification 
 
 The dev branch has several updates merged that make it easier to find errors in configuration and that make the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; automatic.
 
-Note that the automatic build feature is opt-out. In other words, unless you take specific steps, the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; for &nbsp;<span translate="no">Loop</span>&nbsp; will:
+Note that the automatic build feature is opt-out. In other words, unless you take specific steps, the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; for *Loop* will:
 
 * Automatically build a new version once a month, with automatic update included
 * Automatically update your fork of LoopWorkspace once a week if updates are available
 
-It is strongly recommended that all users of the released code (main branch), maintain this automatic schedule so they are never without a valid and up-to-date &nbsp;<span translate="no">Loop</span>&nbsp; in their &nbsp;<span translate="no">TestFlight</span>&nbsp; app.
+It is strongly recommended that all users of the released code (main branch), maintain this automatic schedule so they are never without a valid and up-to-date *Loop* in their  *TestFlight*  app.
 
 For users of the dev branch, it is not uncommon to disable the automatic update portion so they can choose when to update their development version, but should probably keep the monthly build portion of the process.
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -161,7 +161,7 @@ If you want to look at the code, the version (as of 14-Aug-2023) is found in Loo
 
 This feature allows you to save Favorite Foods.
 
-A new row on the *Loop* app Settings screen, see graphic below, provides access to create and edit your &nbsp;<span translate="no">Favorite Foods</span>.
+A new row on the&nbsp;_<span translate="no">Loop</span>_&nbsp;app Settings screen, see graphic below, provides access to create and edit your &nbsp;<span translate="no">Favorite Foods</span>.
 
 ![favorite foods feature](img/favorite-foods.svg){width="300"}
 {align="center"}
@@ -178,9 +178,9 @@ At this point the meal can be saved by tapping the Continue button, or the user 
 
 ### *TestFlight*  Expiration Warning
 
-The *Loop* app has been updated to detect whether the build was uploaded through  *TestFlight*, which implies a 90-day limit until the app expires.
+The&nbsp;_<span translate="no">Loop</span>_&nbsp;app has been updated to detect whether the build was uploaded through  *TestFlight*, which implies a 90-day limit until the app expires.
 
-The usual &nbsp;[*Loop* expiration notification system](../operation/features/notifications.md#loop-app-expiration-notification) alerts the user when within 20 days of expiration. In addition to that modal alert, the user can examine the bottom of the Settings screen at any time to see the expected expiration date and time.
+The usual&nbsp;[_<span translate="no">Loop</span>_&nbsp;expiration notification system](../operation/features/notifications.md#loop-app-expiration-notification) alerts the user when within 20 days of expiration. In addition to that modal alert, the user can examine the bottom of the Settings screen at any time to see the expected expiration date and time.
 
 ![expiration warning on settings for testflight example](img/expiration-warning-testflight.svg){width="300"}
 {align="center"}
@@ -189,12 +189,12 @@ The usual &nbsp;[*Loop* expiration notification system](../operation/features/no
 
 The dev branch has several updates merged that make it easier to find errors in configuration and that make the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; automatic.
 
-Note that the automatic build feature is opt-out. In other words, unless you take specific steps, the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; for *Loop* will:
+Note that the automatic build feature is opt-out. In other words, unless you take specific steps, the &nbsp;<span translate="no">GitHub Browser Build</span>&nbsp; for&nbsp;_<span translate="no">Loop</span>_&nbsp;will:
 
 * Automatically build a new version once a month, with automatic update included
 * Automatically update your fork of LoopWorkspace once a week if updates are available
 
-It is strongly recommended that all users of the released code (main branch), maintain this automatic schedule so they are never without a valid and up-to-date *Loop* in their  *TestFlight*  app.
+It is strongly recommended that all users of the released code (main branch), maintain this automatic schedule so they are never without a valid and up-to-date&nbsp;_<span translate="no">Loop</span>_&nbsp;in their  *TestFlight*  app.
 
 For users of the dev branch, it is not uncommon to disable the automatic update portion so they can choose when to update their development version, but should probably keep the monthly build portion of the process.
 


### PR DESCRIPTION
* Update README with more suggestions.
* Attempt to use the new suggestions to update pages where I think the full `<span translate="no> . . . </span>` is not required.
* On the pages touched, be consistent with using italics font.
* Leave a number of instances of `the *Loop* app` phrase to see if it requires the `span` instead
