### PR TITLE
🐛 Fix/ci `deploy` error since python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ MarkupSafe==2.1.2
 mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-htmlproofer-plugin==0.13.1
-mkdocs-material==9.4.3
+mkdocs-material==9.4.6
 mkdocs-material-extensions==1.2
 mkdocs-redirects==1.2.1
 mkdocs-unused-files==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ platformdirs==3.11.0
 Pygments==2.16.1
 pymdown-extensions==10.3
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml_env_tag==0.1
 regex==2022.10.31
 requests==2.31.0


### PR DESCRIPTION
Our _GitHub Actions_ are currently configured to use the latest version of Python.
Yesterday (2023-10-26), GitHub started using  [Python version 3.12](https://www.python.org/downloads/release/python-3120/).

❌ Since then, the `deploy` workflow [has failed](https://github.com/LoopKit/loopdocs/actions/runs/6668704382/job/18124848527#step:4:110) when installing the project's required dependencies (in the `Run pip install -r requirements.txt` step):

> Collecting PyYAML==6.0 (from -r requirements.txt (line 29))
> Downloading PyYAML-6.0.tar.gz (124 kB)
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.0/125.0 kB 14.1 MB/s eta 0:00:00
> Installing build dependencies: started
> Installing build dependencies: finished with status 'done'
> Getting requirements to build wheel: started
> Getting requirements to build wheel: finished with status 'error'
> error: subprocess-exited-with-error

✅ The solution is to upgrade PyYAML to 6.0.1 from 6.0 as [suggested here](https://github.com/yaml/pyyaml/issues/756#issuecomment-1751971477)


