### PR TITLE
🚸  UX Improvement: Open external links in a new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,16 @@ Click here for [When Should You Update?](../faqs/update-faqs.md#when-should-you-
 
 ```
 
+❗️Make **external links open in a new window** by appending the `{: target="_blank" }` suffix to the markdown link, like this
+
+```markdown
+[LoopTips](https://loopkit.github.io/looptips){: target="_blank" }
+```
+
+ℹ️ Note:
+- There is **no space** in between the link and `{: target="_blank" }`. 
+- An *external link* means a link to another website (i.e. not LoopDocs).
+
 ℹ️ **Notice about mkdocs**
 
 > Using absolute paths with links is not officially supported.  

--- a/docs/build/apple-developer.md
+++ b/docs/build/apple-developer.md
@@ -5,10 +5,10 @@
     - up to 2 days to wait for confirmation email that enrollment has been activated
 
 !!! abstract "Summary"
-
+     
     There are two options: Paid ($99/year) or Free (re-build weekly, Xcode only)
-
-    - Paid Developer Account: Go to the [Apple Developer website](https://developer.apple.com/programs/enroll/) to enroll in an individual account.
+    
+    - Paid Developer Account: Go to the [Apple Developer website](https://developer.apple.com/programs/enroll/){: target="_blank" } to enroll in an individual account.
     - Free: No action required at this time.
         * Free requires the [Build with *Mac*](overview.md) method
 
@@ -22,7 +22,7 @@
 The Apple ID is DIFFERENT than the Apple Developer ID.
 
 !!! warning "Apple ID"
-    Parents should set up a **different** Apple ID for each of their looper children and looper children should **not** use the parent Apple ID. Use Apple's Instructions for [Create an Apple ID for your child](https://support.apple.com/en-us/HT201084).
+    Parents should set up a **different** Apple ID for each of their looper children and looper children should **not** use the parent Apple ID. Use Apple's Instructions for [Create an Apple ID for your child](https://support.apple.com/en-us/HT201084){: target="_blank" }.
 
     The Apple Health record is a convenient record of blood glucose, insulin and carbohydrates and should be associated with only one individual.
 
@@ -75,7 +75,7 @@ Once PaidLoop is working, delete the FreeLoop instance from your phone to avoid 
 
 ## Enrolling
 
-To enroll in an individual paid Paid account, go to the Apple's Developer Program website [Apple Developer website](https://developer.apple.com/programs/enroll/).
+To enroll in an individual paid Paid account, go to the Apple's Developer Program website [Apple Developer website](https://developer.apple.com/programs/enroll/){: target="_blank" }.
 
 Be sure to use the credit card already associated with the email you are using for the developer account. If you switch credit cards, it can cause delays.
 

--- a/docs/build/build-app.md
+++ b/docs/build/build-app.md
@@ -18,7 +18,7 @@
 
 ## Build Video
 
-The Loop and Learn team prepared this [YouTube video](https://youtu.be/gddhljzsNkM) showing how to build Loop 2.2.x including the steps required to update if you previously built. The steps are different now. The video may be worth watching, but once you've reviewed it, work through the new build process described on this page.
+The Loop and Learn team prepared this [YouTube video](https://youtu.be/gddhljzsNkM){: target="_blank" } showing how to build Loop 2.2.x including the steps required to update if you previously built. The steps are different now. The video may be worth watching, but once you've reviewed it, work through the new build process described on this page.
 
 If you do watch this video, please note that you no longer are required to delete provisioning profiles as a separate step and the overall building process is streamlined.
 
@@ -39,7 +39,7 @@ You will see a message similar to the next graphic.
 ![phone message if trying to run xcode app without developer mode enabled](img/phone-developer-mode-required.jpeg){width="300"}
 {align="center"}
 
-If you are running iOS 16 or 17 with watchOS 9 or newer, you must enable <code>Developer Mode</code> to run or build Loop directly from Xcode. (This is true for any app created by Xcode directly on your device.) If you want to know more, click on this [Apple Link about <code>Developer Mode</code>](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device).
+If you are running iOS 16 or 17 with watchOS 9 or newer, you must enable <code>Developer Mode</code> to run or build Loop directly from Xcode. (This is true for any app created by Xcode directly on your device.) If you want to know more, click on this [Apple Link about <code>Developer Mode</code>](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device){: target="_blank" }.
 
 ### Prepare your Phone and Watch
 
@@ -105,7 +105,7 @@ These steps have been reported on Facebook and have not been tested in a control
     * Click on the watch and if it connects - you are done
 5. Otherwise manually add the UDID to your Developer Account
 6. Copy UDID (right-click or control-click and choose Copy Identifier)
-7. Go to the [Apple developer website, devices page](https://developer.apple.com/account/resources/devices/list) and manually add the watch (using the UDID)
+7. Go to the [Apple developer website, devices page](https://developer.apple.com/account/resources/devices/list){: target="_blank" } and manually add the watch (using the UDID)
 8. With phone plugged into computer and watch on wrist, follow these steps on the build errors page: [Apple Watch Loop App not running on Watch](build-errors.md#apple-watch-loop-app-not-running-on-watch) to build the watch app directly.
 
 At this point, be sure to reboot the watch.
@@ -132,7 +132,7 @@ These instructions show each step needed to download Loop using the Build Select
 !!! note "New Menu for Build Select Script"
     The Build Select Script has been updated with more menu options. It can do more than just assist in building the Loop app.
     
-    Please review [Loop and Learn: Build Select Script](https://www.loopandlearn.org/build-select/) for more information.
+    Please review [Loop and Learn: Build Select Script](https://www.loopandlearn.org/build-select/){: target="_blank" } for more information.
 
     You may notice some graphics on this page shows red font to emphasize some items. The script now only shows red font for an error. Bold font is used for emphasis. Not all graphics were updated.
 
@@ -453,7 +453,7 @@ If you plan to build again on a backup phone, or want to try a customization, ea
 But wait - there's more.
 
 * Caregivers who help manage a loved-ones diabetes often use other open-source apps that can be built the same way
-* When you are done building and installing the *Loop* app, there are instructions on the *Loop and Learn* website to [Download and Build Related Apps](https://www.loopandlearn.org/build-select/#build-other-apps)
+* When you are done building and installing the *Loop* app, there are instructions on the *Loop and Learn* website to [Download and Build Related Apps](https://www.loopandlearn.org/build-select/#build-other-apps){: target="_blank" }
 
 ## Protect that App
 

--- a/docs/build/build-dev-mac.md
+++ b/docs/build/build-dev-mac.md
@@ -32,13 +32,13 @@ You can use the BuildLoopDev script to build a specific development branch, othe
 
 While Loop-dev is under active development, you should monitor zulipchat and update frequently.
 
-Checking for updates every week is a good idea. Also - subscribe to all the streams on [Loop Zulipchat](https://loop.zulipchat.com) to make sure you don't miss critical information.
+Checking for updates every week is a good idea. Also - subscribe to all the streams on [Loop Zulipchat](https://loop.zulipchat.com){: target="_blank" } to make sure you don't miss critical information.
 
 You may choose to download fresh each time you update. 
 
 You may prefer to use commands to fetch and pull the latest code without making a new clone.
 
-* Some users like to use [GitKraken](https://support.gitkraken.com/) to assist them (link takes you to a tutorial video).
+* Some users like to use [GitKraken](https://support.gitkraken.com/){: target="_blank" } to assist them (link takes you to a tutorial video).
 * Some are comfortable with the command line git commands described on [here](../version/loopworkspace.md#updating-loop-using-loopworkspace).
 
 ## Loop-dev Version

--- a/docs/build/build-errors.md
+++ b/docs/build/build-errors.md
@@ -34,7 +34,7 @@ Before you start trying to resolve your red errors, start with the most obvious 
 
 1. **Did you check that you have the minumum Xcode version for your iOS?** This is critical. If you are updating your Loop app, please review the iOS driven requirements for minimum version of [macOS and Xcode](xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other).
 
-1. **Did you check your Apple developer account for new license agreement?** Periodically, Apple will release a new developer license agreement that you need to sign before you can build new apps. You will get a build failure if there is a pending license agreement to sign. [Login to your Apple developer account](https://developer.apple.com/account) to check if there's a new license agreement.
+1. **Did you check your Apple developer account for new license agreement?** Periodically, Apple will release a new developer license agreement that you need to sign before you can build new apps. You will get a build failure if there is a pending license agreement to sign. [Login to your Apple developer account](https://developer.apple.com/account){: target="_blank" } to check if there's a new license agreement.
 
 1. **Do you have a new computer, never used to build Loop?** Did you [Add Apple ID](xcode-settings.md#add-apple-id) to Xcode?
 
@@ -419,7 +419,7 @@ Or maybe you are trying to build using an old download; some older versions did 
 **Error message:** `The Apple Developer Program License Agreement has been updated,  In order to access certain membership resources, you must accept the latest license agreement`.  
 Or you may see `Unable to process request - PLA Update available. You currently don't have access to this membership resource. To resolve this issue, agree to the latest Program License Agreement in your developer account.`
 
-**Solution:** You'll need to log onto your Apple Developer account at [developer.apple.com](https://developer.apple.com/account/) and accept the latest license agreement.
+**Solution:** You'll need to log onto your Apple Developer account at [developer.apple.com](https://developer.apple.com/account/){: target="_blank" } and accept the latest license agreement.
 
 ![img/license.png](img/license.png){width="750"}
 {align="center"}
@@ -491,7 +491,7 @@ If your problem persists after that, then you might need to do total reset of yo
 ![img/pending_certification_request.jpg](img/pending_certification_request.jpg){width="750"}
 {align="center"}
 
-**Solution:** This error message has recently started to appear for some new Loop builders. To resolve the issue, please log in to your Developer account at [developer.apple.com](https://developer.apple.com) and then click on "Certificates, Identifiers & Profiles".  Under that screen, you will see "Development" under the "Certificates" section in the column on the left.  You will need to click on the certificates, and choose "revoke" from the options that show after you click on the certificate. Confirm the warning message that will appear asking "Do you want to revoke the certificate?"
+**Solution:** This error message has recently started to appear for some new Loop builders. To resolve the issue, please log in to your Developer account at [developer.apple.com](https://developer.apple.com){: target="_blank" } and then click on "Certificates, Identifiers & Profiles".  Under that screen, you will see "Development" under the "Certificates" section in the column on the left.  You will need to click on the certificates, and choose "revoke" from the options that show after you click on the certificate. Confirm the warning message that will appear asking "Do you want to revoke the certificate?"
 
 ![img/revoke1.png](img/revoke1.png){width="750"}
 {align="center"}

--- a/docs/build/cgm.md
+++ b/docs/build/cgm.md
@@ -36,7 +36,7 @@ If the Dexcom app is on the same device as the *Loop* app, your system can funct
 
 !!! warning "Dexcom G5 Support"
 
-    [Dexcom has stopped supporting the G5 system in the US](https://www.dexcom.com/obsolescence). In the US, and some other countries, the G5 is not available for download from the Apple Store. There are countries in which Dexcom does supply and support G5. The G5 capability will continue to be supported in Loop.
+    [Dexcom has stopped supporting the G5 system in the US](https://www.dexcom.com/obsolescence){: target="_blank" }. In the US, and some other countries, the G5 is not available for download from the Apple Store. There are countries in which Dexcom does supply and support G5. The G5 capability will continue to be supported in Loop.
 
     There are third party apps, which interface with G4 and G5 transmitters, supported by some forks of Loop. The version of the *Loop* app supported by these documents only works with the Dexcom apps.
 
@@ -70,10 +70,10 @@ Version 3 or later of the *Loop* app can use Nightscout as a remote source for C
 
 Libre Support (for some Libre sensors) is available with Loop-dev or by adding customizations.
 
-* [Loop dev](../version/build-dev.md) adds [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop)
-* [`Loop and Learn: Loop Customization`](https://www.loopandlearn.org/custom-code/) 
+* [Loop dev](../version/build-dev.md) adds [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" }
+* [`Loop and Learn: Loop Customization`](https://www.loopandlearn.org/custom-code/){: target="_blank" } 
 
-Currently, there are no solutions for *Eversense*, *Guardian* or *Libre 3* CGM to be used directly with the *Loop* app, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/) to Nightscout are available using an Android phone. Version 3 or later of the *Loop* app allows the use of Nightscout as a CGM source.
+Currently, there are no solutions for *Eversense*, *Guardian* or *Libre 3* CGM to be used directly with the *Loop* app, but some [Uploaders](https://nightscout.github.io/uploader/uploaders/){: target="_blank" } to Nightscout are available using an Android phone. Version 3 or later of the *Loop* app allows the use of Nightscout as a CGM source.
 
 ## Next Step
 

--- a/docs/build/community.md
+++ b/docs/build/community.md
@@ -23,7 +23,7 @@ Volunteers provide assistance on building and using the *Loop* app at these site
 
     Note, the *LoopDocs* menus were reorganized after this video was prepared to make it easier to progress through the pages.   
 
-[![img/looped-group.png](img/looped-group.png)](https://youtu.be/_vSN6C-Uo04)
+[![img/looped-group.png](img/looped-group.png)](https://youtu.be/_vSN6C-Uo04){: target="_blank" }
 
 ## Screenshots
 

--- a/docs/build/computer.md
+++ b/docs/build/computer.md
@@ -13,7 +13,7 @@
     If you do not have a Mac, you can build&nbsp;<span translate="no">Loop 3</span>&nbsp;with any computer using a browser. If you want to use that method, review this list and head over to [Build with Browser](../gh-actions/gh-overview.md).
 
     - You need a paid ($99/year)&nbsp;[<span translate="no">Apple Developer Account</span>](apple-developer.md)
-    - You need an account (free) with&nbsp;[<span translate="no">GitHub</span>](https://github.com)
+    - You need an account (free) with&nbsp;[<span translate="no">GitHub</span>](https://github.com){: target="_blank" }
     - You need a [compatible phone](phone.md) to install the app from *TestFlight*
     - You need a [compatible Pump](pump.md) and [CGM](cgm.md) if you want to actually use the app (and not just explore the app)
 
@@ -99,7 +99,7 @@ Ventura is required for building the *Loop* app on a phone running iOS 16.4 or h
 * iMac Pro
 * Mac Studio
 * Mac Pro introduced in 2019 or later
-* get the full list from [Apple for Ventura](https://support.apple.com/kb/HT213264)
+* get the full list from [Apple for Ventura](https://support.apple.com/kb/HT213264){: target="_blank" }
 
 ## Older Macs
 

--- a/docs/build/custom-mac.md
+++ b/docs/build/custom-mac.md
@@ -17,16 +17,16 @@ These customizations require you to modify the code used to build the *Loop* app
 
 Some customizations are the same for everyone and have been prepared for easy use.
 
-The *Loop and Learn* team commit to maintaining these prepared customizations and provide an easy method to add your selection from these customization to your version of *Loop*.
+The *Loop and Learn* team is committed to maintaining these prepared customizations and provides an easy method to add your selection from these customizations to your version of *Loop*.
 
-Please read the documentation for these on the [Loop and Learn: Customization Select Page](https://www.loopandlearn.org/custom-code):
+Please read the documentation for these on the [Loop and Learn: Customization Select Page](https://www.loopandlearn.org/custom-code){: target="_blank" }:
 
-* [List of Customizations Available](https://www.loopandlearn.org/custom-code/#custom-list)
-* [Customization Select Script](https://www.loopandlearn.org/custom-code/#customization-select)
+* [List of Customizations Available](https://www.loopandlearn.org/custom-code/#custom-list){: target="_blank" }
+* [Customization Select Script](https://www.loopandlearn.org/custom-code/#customization-select){: target="_blank" }
 
 ### Add Libre Support to 3.2.3
 
-If you are using `main` branch to build `Loop 3.2.3` and rely on either *xDrip4iOS* or *GlucoseDirect* to read your CGM and transfer the readings to the *Loop* app, you need to review this [section of the *Loop and Learn* customization page](https://www.loopandlearn.org/custom-code/#add-cgm-323).
+If you are using `main` branch to build `Loop 3.2.3` and rely on either *xDrip4iOS* or *GlucoseDirect* to read your CGM and transfer the readings to the *Loop* app, you need to review this [section of the *Loop and Learn* customization page](https://www.loopandlearn.org/custom-code/#add-cgm-323){: target="_blank" }.
 
 Alternatively, you can switch to the `dev` branch, which already supports Libre. [Build Loop dev with Mac](build-dev-mac.md)
 

--- a/docs/build/edit-mac.md
+++ b/docs/build/edit-mac.md
@@ -67,7 +67,7 @@ Each customization will also show Module, Folder and File bullet below the key p
 
 ## Open a Terminal in LoopWorkspace Folder
 
-If you use the [Loop and Learn: Customization Select Script](https://www.loopandlearn.org/custom-code), it automatically locates your most recent download, makes the customization you select in that download and then opens Xcode for you.
+If you use the [Loop and Learn: Customization Select Script](https://www.loopandlearn.org/custom-code){: target="_blank" }, it automatically locates your most recent download, makes the customization you select in that download and then opens Xcode for you.
 
 But sometimes, you need to find your downloaded code and make your own changes in Xcode. This section tells you how to do this.
 

--- a/docs/build/health.md
+++ b/docs/build/health.md
@@ -1,6 +1,6 @@
 ## Health Data
 
-The Loop app uses the Health app to record blood glucose, insulin, and carbohydrate data. The blood glucose, insulin, and carbohydrate data stored in the Health app can also be accessed and uploaded by the [Tidepool](https://tidepool.org) Mobile app which enables display on of your data on the Tidepool web-based display tool. Please review the settings below to ensure you have the proper settings.
+The Loop app uses the Health app to record blood glucose, insulin, and carbohydrate data. The blood glucose, insulin, and carbohydrate data stored in the Health app can also be accessed and uploaded by the [Tidepool](https://tidepool.org){: target="_blank" } Mobile app which enables the display of your data on the Tidepool web-based display tool. Please review the settings below to ensure you have the proper settings.
 
 ## Loop Permissions
 

--- a/docs/build/loop-data.md
+++ b/docs/build/loop-data.md
@@ -26,24 +26,24 @@ Take some time to familiarize yourself with these data options and choose your p
 * [*Apple Health* app](../faqs/apple-health-faqs.md#healthkit-plots)
     * Great resource to view on the Loop phone
     * Not so great for showing your endo
-* [*Tidepool*](https://loopkit.github.io/looptips/data/tidepool/)
+* [*Tidepool*](https://loopkit.github.io/looptips/data/tidepool/){: target="_blank" }
     * Some endo offices will use your *Tidepool* website when you provide them with an invitation
-    * Many users of the mobile app like the note taking ability
+    * Many users of the mobile app like the note-taking ability
         * The mobile app also uploads *Apple HealthKit* data to *Tidepool* when the "Read from *Apple Health*" option is selected
     * With Version 3.2 of the *Loop* app, you can upload directly as a Service within the *Loop* app
-        * If you use the mobile *Tidepool* app on your phone for notetaking, be sure to disable the read from Apple Health option in the the mobile *Tidepool* app settings to avoid duplicate uploads
+        * If you use the mobile *Tidepool* app on your phone for note-taking, be sure to disable the read from Apple Health option in the mobile *Tidepool* app settings to avoid duplicate uploads
         * If you use the mobile *Tidepool* app on your phone for uploading only, then it is no longer needed when you upload directly to *Tidepool* as a Service within the *Loop* app
 * *Nightscout*:
     * [LoopDocs: *Nightscout*](../nightscout/overview.md) section of LoopDocs, has Loop-centric information about *Nightscout*
-    * [LoopTips: *Nightscout*](https://loopkit.github.io/looptips/data/nightscout/) link to LoopTips page on *Nightscout*
-    * [*Nightscout*: Documentation](https://nightscout.github.io/) official *Nightscout* site with lots of information about building and using *Nightscout*
+    * [LoopTips: *Nightscout*](https://loopkit.github.io/looptips/data/nightscout/){: target="_blank" } link to LoopTips page on *Nightscout*
+    * [*Nightscout*: Documentation](https://nightscout.github.io/){: target="_blank" } official *Nightscout* site with lots of information about building and using *Nightscout*
     * *Nightscout* has a lot of useful alarms and alerts, provides a care portal and detailed reports
     * For those who assist someone who is Looping, *Nightscout* enables the caregiver to provide remote commands to the Looper's phone
         * `Loop 2` allows overrides to be enabled or disabled remotely
-        * `Loop 3` allows remote commands for carbs, bolus or overrides
-        * The [*Loop Caregiver*](../nightscout/loop-caregiver.md) app is under development, but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
+        * `Loop 3` allows remote commands for carbs, bolus, or overrides
+        * The [*Loop Caregiver*](../nightscout/loop-caregiver.md) app is under development but already has sufficient capabilities to be useful for caregivers to monitor and provide remote commands to their Looper's phone
 
-*Nightscout* options include free or nominal cost sites you build yourself or there are several *Nightscout* as a Service vendors who provide turn-key sites for a monthly fee. Links to the options are found in the [*Nightscout*: Documentation](https://nightscout.github.io/) - note that link takes you to a different site.
+*Nightscout* options include free or nominal cost sites you build yourself or there are several *Nightscout* as a Service vendors who provide turn-key sites for a monthly fee. Links to the options are found in the [*Nightscout*: Documentation](https://nightscout.github.io/){: target="_blank" } - note that link takes you to a different site.
 
 *Nightscout* provides a secure, real-time Dashboard with status of the *Loop* app visible to anyone with access codes and the internet. It is required for remote commanding.
 

--- a/docs/build/phone.md
+++ b/docs/build/phone.md
@@ -4,7 +4,7 @@
     - 5 minutes, to check your device and *iOS*
     - 20 minutes, if need to update your compatible device to a new *iOS*
     - 10 minutes, if you need to order a [compatible device](phone.md#compatible-devices)
-    - 0 minutes, if you own an Android and will not use *Apple* products; check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/)
+    - 0 minutes, if you own an Android and will not use *Apple* products; check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/){: target="_blank" }
 
 !!! abstract "Summary"
     - Check your iPhone against the device compatibility list
@@ -13,7 +13,7 @@
     - Turn off automatic updates
 
 !!! question "FAQs"
-    - **"Can I use an android?"** No. Check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/).
+    - **"Can I use an android?"** No. Check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/){: target="_blank" }.
     - **"Can I use an iPad?"** No. Older iPads do not support *Apple Health* which is required for the *Loop* app. It may be possible with newer iPads and newer *iOS*, but this has not been tested.
     - **"Does my iPhone need a cell plan?"** No. The *Loop* app works using communication on your phone with your CGM and your pump; no internet connection required. However, if access to *Dexcom Follow* or <code>Nightscout</code> monitoring of the *Loop* app is a priority, then a cell plan may be desired.
     - **What watches work with the *Loop* app?** Only *Apple* watches work with the *Loop* app. With `Loop 3`, some of the older *Apple* watch series are no longer compatible. See: [Watch Hardware and OS Requirements](../operation/features/watch.md#watch-hardware-and-os-requirements)
@@ -61,7 +61,7 @@ Do not use any of the beta *iOS* versions. (If you are uncertain what that means
 
 > When you build the *Loop* app using [Build with Browser](../gh-actions/gh-overview.md), you are not required to enable Developer Mode on the phone or watch.
 
-With *iOS* 16 or newer and *watchOS* 9 or newer, *Apple* added a feature. If you want to know more, click on this [Apple Link about Developer Mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device).
+With *iOS* 16 or newer and *watchOS* 9 or newer, *Apple* added a feature. If you want to know more, click on this [Apple Link about Developer Mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device){: target="_blank" }.
 
 When you build the *Loop* app on your phone from *Xcode* directly and then transition to or start with *iOS* 16 or newer, you need to have Developer Mode enabled. This is also a requirement to use the *Loop* app on a watch paired to your phone running *watchOS* 9 or newer. You will be told to enable it in the [Build the *Loop* App: Prepare your Phone and Watch](build-app.md#prepare-your-phone-and-watch) instructions.
 
@@ -79,10 +79,10 @@ When you build the *Loop* app on your phone from *Xcode* directly and then trans
 Make sure the battery on your phone is solid. Your phone will become a critical health device - you want it to keep working.
 
 * Make sure a charger and cord are in your diabetes supplies
-* Consider buying a battery pack, keep it charged and add it to your travel bag
+* Consider buying a battery pack, keep it charged, and add it to your travel bag
 
 !!! tip "Low Power Mode"
-    With newer *iOS*, some people have reported the *Loop* app continues working in the background (phone locked) even in [Low Power Mode](https://support.apple.com/en-us/HT205234). Others, have reported they still get red loops. You can experiment to determine if your phone/iOS/app is able to maintain green loops in low power mode. Otherwise, best practice is to avoid Low Power Mode.
+    With newer *iOS*, some people have reported the *Loop* app continues working in the background (phone locked) even in [Low Power Mode](https://support.apple.com/en-us/HT205234){: target="_blank" }. Others have reported they still get red loops. You can experiment to determine if your phone/iOS/app is able to maintain green loops in low-power mode. Otherwise, the best practice is to avoid Low Power Mode.
 
 ## Use Automatic Time
 
@@ -107,9 +107,9 @@ If a limitation on your *Mac* prevents you from updating your phone to the lates
 * Turn off automatic updates so you can choose when to update your phone and avoid being caught without your *Loop* app
 * Google the instructions for your device:
     1. Configure your phone to automatically download the updates
-    1. Choose to perform the installation of the updates manually
+    1. Choose to install the updates manually
 
-When *iOS* updates are released, the [_<span translate="no">Loop and Learn</span>_ Version Updates](https://www.loopandlearn.org/version-updates) page is typically updated faster than LoopDocs. Check to see if a new update is causing an issue with the *Loop* app or your CGM before accepting the update from *Apple*.
+When *iOS* updates are released, the [_<span translate="no">Loop and Learn</span>_ Version Updates](https://www.loopandlearn.org/version-updates){: target="_blank" } page is typically updated faster than LoopDocs. Check to see if a new update is causing an issue with the *Loop* app or your CGM before accepting the update from *Apple*.
 
 Within a few days, the "All-Clear" or (very rare) the "WAIT there is a problem" message will be posted.
 

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -13,7 +13,7 @@
     - **"How can I find a compatible Medtronic pump?"** Refer to [Finding a Medtronic Pump](#finding-a-medtronic-pump).
     - **"What are the differences between Medtronic pump models?"** This question is answered in the [Extra Details](#extra-details-on-medtronic) section.
     - **"But what about the other types of pumps?"** No other pumps work with the *Loop* app at this time.
-        - There are other open-source closed loop options such as [AAPS: Android Artificial Pancreas System](https://androidaps.readthedocs.io/en/latest/index.html) and [OpenAPS](https://openaps.readthedocs.io/en/latest/) that support other pumps
+        - There are other open-source closed loop options such as [AAPS: Android Artificial Pancreas System](https://androidaps.readthedocs.io/en/latest/index.html){: target="_blank" } and [OpenAPS](https://openaps.readthedocs.io/en/latest/){: target="_blank" } that support other pumps
     - **"Can I change the firmware of my Medtronic pump?"** No.
 
 ## Pumps Compatible with Loop
@@ -116,7 +116,7 @@ Finding a compatible Medtronic pump is probably the most difficult part for most
 
 * Check out the **HelpAround, NextDoor, OfferUp, and/or LetGo** apps for pumps.
   
-* [Looping in a time of covid](https://www.facebook.com/groups/1087611668259945/)
+* [Looping in a time of covid](https://www.facebook.com/groups/1087611668259945/){: target="_blank" }
 
 The most success appears to come from either one-on-one discussions with fellow diabetics/doctors or using apps (Craigslist, NextDoor, LetGo, HelpAround).  If you are using Craigslist, you may wish to use an app on your iPhone to make the searching easier.  There are apps to search multiple cities at once for your keywords and set up alerts.
 
@@ -152,11 +152,11 @@ Medtronic will not typically sell pump supplies directly to customers who have n
 
 !!! warning "Reminder and Disclaimer"
 
-    The use of Omnipod pumps with the *Loop* app is not supported by Insulet, although they are aware it is happening. Do not call Insulet asking for help with your *Loop* app build, setup, or operation. You are fully responsible for your use of the *Loop* app and do so at your own risk. Please read these documents and familiarize yourself with the *Loop* app before using.
+    The use of Omnipod pumps with the *Loop* app is not supported by Insulet, although they are aware it is happening. Do not call Insulet asking for help with your *Loop* app build, setup, or operation. You are fully responsible for your use of the *Loop* app and do so at your own risk. Please read these documents and familiarize yourself with the *Loop* app before using it.
 
 ### Omnipod Eros
 
-Eros pods (also known as Gen 3) were launched in 2013 and continue to be sold by Insulet. Insulet has announced they will stop providing Eros pods in the US in December 2023. As far as we know, there are no timelines announced for the discontinuation of Eros pods for other countries. Insulet doesn't specifically call these "Eros" anymore, they just use the term "omnipod system". For clarity, from [Insulet's webpage](https://www.omnipod.com/discontinuation):
+Eros pods (also known as Gen 3) were launched in 2013 and continue to be sold by Insulet. Insulet has announced they will stop providing Eros pods in the US in December 2023. As far as we know, there are no timelines announced for the discontinuation of Eros pods for other countries. Insulet doesn't specifically call these "Eros" anymore, they just use the term "omnipod system". For clarity, from [Insulet's webpage](https://www.omnipod.com/discontinuation){: target="_blank" }:
 
 !!! info "Alternative Names for Omnipod Eros Pump and Pods"
 

--- a/docs/build/rileylink.md
+++ b/docs/build/rileylink.md
@@ -11,10 +11,10 @@
     - Order your compatible device
 
 !!! question "FAQs"
-    - **What is a RileyLink Compatible Device?** RileyLink refers to both the communication protocol and the name of the original device. Other DIY Loopers have created [RileyLink Compatible Devices](rileylink.md#rileylink-compatible-devices) that use the RileyLink protocol. At the current time, RileyLink, OrangeLink and EmaLink devices are available for purchase and all can be used interchangeably with the *Loop* app.
+    - **What is a RileyLink Compatible Device?** RileyLink refers to both the communication protocol and the name of the original device. Other DIY Loopers have created [RileyLink Compatible Devices](rileylink.md#rileylink-compatible-devices) that use the RileyLink protocol. At the current time, RileyLink, OrangeLink, and EmaLink devices are available for purchase and all can be used interchangeably with the *Loop* app.
     - **Do I have to buy one?** These are open-source hardware devices, but it takes special skills to build them yourself. It is recommended you buy one (or two). **Not needed for DASH**
-    - **"What happens if I lose my RileyLink compatible device or walk away from it?"** Within a half hour, your pump returns to normal scheduled basal rate
-    - **"Can I swap out RileyLink compatible devices at any time?"** Yes, you can. You do not need to start a new pod or rebuild the *Loop* app. Tap on the pump menu in settings to search for new devices. You can swap between RileyLink, OrangeLink, EmaLink or some future RileyLink compatible device.
+    - **"What happens if I lose my RileyLink compatible device or walk away from it?"** Within a half hour, your pump returns to the normal scheduled basal rate
+    - **"Can I swap out RileyLink compatible devices at any time?"** Yes, you can. You do not need to start a new pod or rebuild the *Loop* app. Tap on the pump menu in settings to search for new devices. You can swap between RileyLink, OrangeLink, EmaLink, or some future RileyLink compatible device.
     - **"How close does the RileyLink compatible device need to be to me? Do I have to carry it with me?"** See [RileyLink Compatible Device Range](../faqs/rileylink-faqs.md#range).
 
 
@@ -34,32 +34,32 @@ The RileyLink compatible device is required to allow your phone to talk to compa
 
 ## RileyLink Compatible Devices
 
-The RileyLink protocol defines a specific bluetooth interface and way of opening a Sub-GHz radio channel to pumps. All RileyLink compatible devices follow the RileyLink protocol.
+The RileyLink protocol defines a specific Bluetooth interface and way of opening a Sub-GHz radio channel to pumps. All RileyLink compatible devices follow the RileyLink protocol.
 
 There used to be just one option, the original RileyLink. Now there are more options, so you have to make a decision. Depending on your choice, be sure to have the correct charger and cables or batteries handy and add spare compatible supplies to your diabetes go-bag.
 
-- A [Comparison Chart](https://getrileylink.org/rileylink-compatible-hardware-comparison-chart?fbclid=IwAR2vHbOzla-zmM-cSp4NkOB_23k3spgnaYvCIGRcACcIQ25FJAU_7HRkH2A) is provided by the GetRileyLink organization for all the RileyLink compatible devices listed below
+- A [Comparison Chart](https://getrileylink.org/rileylink-compatible-hardware-comparison-chart?fbclid=IwAR2vHbOzla-zmM-cSp4NkOB_23k3spgnaYvCIGRcACcIQ25FJAU_7HRkH2A){: target="_blank" } is provided by the GetRileyLink organization for all the RileyLink compatible devices listed below
 - RileyLink
     - Designed by Pete Schwamb
-    - Rechargable battery (max 36 hours per charge)
+    - Rechargeable battery (max 36 hours per charge)
     - No longer available new, check these Facebook Groups for used ones:
-        * [Loop Resale](https://www.facebook.com/groups/301508128131405/)
-        * [Looping in a time of covid](https://www.facebook.com/groups/1087611668259945/)
+        * [Loop Resale](https://www.facebook.com/groups/301508128131405/){: target="_blank" }
+        * [Looping in a time of covid](https://www.facebook.com/groups/1087611668259945/){: target="_blank" }
 - OrangeLink
-    - Designed by Vic Wu, available from [GetRileyLink](https://getrileylink.org)
-    - Uses 2 AAA batteries, batteries typically last weeks or more, depending on batteries/pump type
+    - Designed by Vic Wu, available from [GetRileyLink](https://getrileylink.org){: target="_blank" }
+    - Uses 2 AAA batteries, batteries typically last weeks or more, depending on the batteries/pump type
     - Works with either Omnipod or Medtronic
-    - Uses new chipsets, reported to have longer range
-    - Matches Apple Airpod form factor, so you can use airpod cases
+    - Uses new chipsets, reported to have a longer range
+    - Matches Apple AirPod form factor, so you can use AirPod cases
 - EmaLink
     - Designed by Sorin Kupas-Spunei to increase range, offer smaller sizes
-    - Rechargable battery (various case/battery sizes available)
+    - Rechargeable battery (various case/battery sizes available)
         - Micro/Nano: 2 to 3 days
         - Standard: 6 to 7 days
         - Maxx: 12 to 14 days
     - Must order either Omnipod or Medtronic version
-    - This [EmaLink Information](https://github.com/sks01/EmaLink#emalink) includes photos of various EmaLink configurations as well as photos showing relative sizes of EmaLink, OrangeLink and RileyLink
-    - In North America, available from [EmaLink.us](https://www.emalink.us)
+    - This [EmaLink Information](https://github.com/sks01/EmaLink#emalink){: target="_blank" } includes photos of various EmaLink configurations as well as photos showing relative sizes of EmaLink, OrangeLink and RileyLink
+    - In North America, available from [EmaLink.us](https://www.emalink.us){: target="_blank" }
 
 ## More information
 

--- a/docs/build/test-settings.md
+++ b/docs/build/test-settings.md
@@ -1,9 +1,9 @@
 ## Test Settings
 
 !!! info "Time Estimate"
-    - 2 hours to read the rest of *LoopDocs* (particularly the "Set Up", "Operate", and "FAQs" sections) and [LoopTips](https://loopkit.github.io/looptips/) thoroughly and thoughtfully
+    - 2 hours to read the rest of *LoopDocs* (particularly the "Set Up", "Operate", and "FAQs" sections) and [LoopTips](https://loopkit.github.io/looptips/){: target="_blank" } thoroughly and thoughtfully
     * If you like quizzes, this older quiz has not been updated for version 3 of the *Loop* app and not all the links work (when your answers are scored), but the questions are still really good and the scoring report provides extra insight into why your answer was right or wrong
-        - 15 minutes to take [this quiz](https://docs.google.com/forms/d/e/1FAIpQLSfTkL0pWC-x3a5l_I3aJYBSx3xAS7dtkBbQiiLd348H70TTWg/viewform) to confirm you understand the *Loop* app expected behavior
+        - 15 minutes to take [this quiz](https://docs.google.com/forms/d/e/1FAIpQLSfTkL0pWC-x3a5l_I3aJYBSx3xAS7dtkBbQiiLd348H70TTWg/viewform){: target="_blank" } to confirm you understand the *Loop* app expected behavior
         * New with version 3 of the *Loop* app: 
             * you can remote bolus
             * you can set a manual temp basal rate
@@ -54,11 +54,11 @@ If you are spiking higher than you’d like after a meal, but still coming back 
 
 ## Other Resources
 
-Check the companion site [LoopTips](https://loopkit.github.io/looptips). Several direct links to discussions are provided below:
+Check the companion site [LoopTips](https://loopkit.github.io/looptips){: target="_blank" }. Several direct links to discussions are provided below:
 
-* How to [check settings](https://loopkit.github.io/looptips/settings/settings/) 
-* [Why settings are important](https://loopkit.github.io/looptips/settings/overview/)
-* [What to do when you need to change settings](https://loopkit.github.io/looptips/settings/adjust/) which covers short term and long term reasons
+* How to [check settings](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" } 
+* [Why settings are important](https://loopkit.github.io/looptips/settings/overview/){: target="_blank" }
+* [What to do when you need to change settings](https://loopkit.github.io/looptips/settings/adjust/){: target="_blank" } which covers short term and long term reasons
 
 If you’re fascinated by this topic, read the book *'Think Like A Pancreas'* by Gary Scheiner for a really great discussion.
 

--- a/docs/build/testflight-xcode.md
+++ b/docs/build/testflight-xcode.md
@@ -69,7 +69,7 @@ If this is the first time you're creating a TestFlight for Loop, enter the follo
 * **Name:** Enter a name that is unique. Most people just use "Loop" followed by their initials, so James Kirk would use "LoopJK". If he gets an error that the name is already taken, he might try something like "LoopJTK" or "Loop_JTK_1701".
 * **SKU:** This can be anything, but it can't be the same SKU that you've used for a different app that you've created a TestFlight for. Ideally, just leave it as the autofilled bundle id.
 * **Primary Language:** Set this to your primary language.
-* **Bundle Identifier:** This should already be autofilled. If it's not, it should be "com.YOUR_TEAM_ID.loopkit.Loop". Make sure you replace YOUR_TEAM_ID with your actual TEAM ID, which you can find at [developer.apple.com/account](https://developer.apple.com/account).
+* **Bundle Identifier:** This should already be autofilled. If it's not, it should be "com.YOUR_TEAM_ID.loopkit.Loop". Make sure you replace YOUR_TEAM_ID with your actual TEAM ID, which you can find at [developer.apple.com/account](https://developer.apple.com/account){: target="_blank" }.
 
 ![Preparing app record page](img/tf06.png){width="700"}
     {align="center"}
@@ -98,12 +98,12 @@ Wait until uploading is finished. Don't be alarmed if you see the following scre
 
 ## Deploy App
 
-Now that it's uploaded to TestFlight, it will take a little bit before it finishes processing and becomes available for installation on your iPhone. You can check [appstoreconnect.apple.com/apps](https://appstoreconnect.apple.com/apps) to find it's progress by clicking **Test Flight** and then **iOS** under **Builds** in the upper left. Once it no longer says "Processing" and instead says "Ready to Submit" next to the build's number, it should be available and ready to install on your iPhone.
+Now that it's uploaded to TestFlight, it will take a little bit before it finishes processing and becomes available for installation on your iPhone. You can check [appstoreconnect.apple.com/apps](https://appstoreconnect.apple.com/apps){: target="_blank" } to find it's progress by clicking **Test Flight** and then **iOS** under **Builds** in the upper left. Once it no longer says "Processing" and instead says "Ready to Submit" next to the build's number, it should be available and ready to install on your iPhone.
 
 ![App Store TestFlight page](img/tf11.png){width="700"}
     {align="center"}
 
-To install Loop from TestFlight onto your iPhone, follow the instructions on the [GitHub Deploy](https://loopkit.github.io/loopdocs/gh-actions/gh-deploy/) page.
+To install Loop from TestFlight onto your iPhone, follow the instructions on the [GitHub Deploy](../gh-actions/gh-deploy.md) page.
 
 ## Update App
 

--- a/docs/build/updating.md
+++ b/docs/build/updating.md
@@ -120,7 +120,7 @@ Make sure your new computer has the macOS and Xcode required by your phone iOS. 
 
 ## Check your Developer Account
 
-Apple updates its License Agreement for the Developer Program frequently. You need to login to your [developer account](https://developer.apple.com/account/) to manually check if there is a new agreeement to accept.  If you see a big red or orange banner across the top of your Developer Account announcing a new license agreement like shown below...please read and accept it before building Loop.
+Apple updates its License Agreement for the Developer Program frequently. You need to login to your [developer account](https://developer.apple.com/account/){: target="_blank" } to manually check if there is a new agreement to accept.  If you see a big red or orange banner across the top of your Developer Account announcing a new license agreement like shown below...please read and accept it before building Loop.
 
 ![Screenshot: Account - Apple Developer](img/license.png)
 
@@ -136,7 +136,7 @@ This step is optional, but if your computer is low on space, it helps to clean u
 
 There is an easy way to do this. The Build Select Script used to download and build Loop provides Maintenance Utilities to help free up disk space.
     
-Please review [Loop and Learn: Build Select Script](https://www.loopandlearn.org/build-select/) for more information.
+Please review [Loop and Learn: Build Select Script](https://www.loopandlearn.org/build-select/){: target="_blank" } for more information.
 
 Copy the line below that starts with `/bin/bash` by hovering the mouse near the bottom right side of the text and clicking the copy icon (should say `Copy to Clipboard` when you hover over it). When you click the icon, a message that says `Copied to Clipboard` will appear on your screen.
 
@@ -195,7 +195,7 @@ More information is shown in the orange box below.
 
     1. You might get this if you logged in as a different user, have a new computer or if your computer had to undergo a factory reset
         * You can transfer your keychain to your new computer (or just revoke and keep going)
-        * To transfer your keychain, check this [Apple Documentation Link](https://help.apple.com/xcode/mac/current/#/dev8a2822e0b)
+        * To transfer your keychain, check this [Apple Documentation Link](https://help.apple.com/xcode/mac/current/#/dev8a2822e0b){: target="_blank" }
     1. Your version of Xcode is way out-of-date
         * Mentors have seen this with people trying to build with Xcode 11.4 or earlier
         * Update [Xcode](xcode-version.md) to the most recent version
@@ -211,11 +211,11 @@ More information is shown in the orange box below.
 
 ## Direct Download of Xcode
 
-Many people find updating Xcode from the App Store to be incredibly slow - especially when a new version has just been released.  This method still takes time and enough space on your disk, but is faster than going through the App Store.  Depending on your internet speed, this download can be done in about an hour. Then once it is downloaded, expect another fifteen minutes to several hours (depending on the speed of your computer) for the "xip" file to "expand".
+Many people find updating Xcode from the App Store to be incredibly slow - especially when a new version has just been released.  This method still takes time and enough space on your disk but is faster than going through the App Store.  Depending on your internet speed, this download can be done in about an hour. Then once it is downloaded, expect another fifteen minutes to several hours (depending on the speed of your computer) for the "xip" file to "expand".
 
 The instructions do not hold your hand.
 
-* Your macOS must be at the minimum verion (or newer) to support the version of Xcode you're about the download
+* Your macOS must be at the minimum version (or newer) to support the version of Xcode you're about the download
 * You need to know how to log into your Apple Developer account and navigate those menus
 * You need to know how to use Finder to navigate to Downloads
 * You need to know how to drag the Xcode icon into your Applications folder (after download and expand completes)
@@ -226,10 +226,10 @@ The instructions do not hold your hand.
         - Install fresh
         - After you use the App Store for a download, then Updates will show in the future
 
-Here are the different steps you need to follow doing the Direct Download instead of the App Store method:
+Here are the different steps you need to follow when doing the Direct Download instead of the App Store method:
 
-1. [Login to your Apple developer account](https://developer.apple.com/account)
-    - Examine the menus (on my computer there are buttons on the left hand side)
+1. [Login to your Apple developer account](https://developer.apple.com/account){: target="_blank" }
+    - Examine the menus (on my computer there are buttons on the left-hand side)
     - Click on Downloads (under Additional Resources)
     - Look at menu items (on my computer there are buttons at the top) that say Beta, Release, Profiles and Logs, and More
     - Click on More

--- a/docs/build/xcode-version.md
+++ b/docs/build/xcode-version.md
@@ -97,7 +97,7 @@ Find your phone iOS in the table below. If your iOS is not listed, e.g., 16.6, c
 
 This graphic (copied from Wikipedia and last updated March 2023) is not updated with every iOS update - use it as a map to read the minimum requirements.  Every attempt will be made to update the words in the [Minimum Version List](#how-do-all-the-minimum-versions-relate-to-each-other) promptly - that's much easier than updating a graphic.
 
-Follow this link to [Wikipedia](https://en.wikipedia.org/wiki/Xcode) and scroll down to the the current version of this figure - the graphic shown below is a map of how to read the current version of this figure at Wikipedia.
+Follow this link to [Wikipedia](https://en.wikipedia.org/wiki/Xcode){: target="_blank" } and scroll down to the current version of this figure - the graphic shown below is a map of how to read the current version of this figure at Wikipedia.
 
 ![Screenshot: Wikipedia Xcode example; Clip from Wiki with Xcode versions 13.x - 14.x showing relationship for iOS, Xcode, macOS; highlights how to read current graphic](img/xcode_vs_13-14.svg){width="750"}
 {align="center"}

--- a/docs/faqs/FAQs.md
+++ b/docs/faqs/FAQs.md
@@ -14,7 +14,7 @@ If you have any questions, use the [Search](../intro/loopdocs-how-to.md#website-
 
 Loop requires an Apple device. Older iPads do not support Apple Health which is required for Loop. It may be possible with newer iPads and newer iOS, but this has not been tested.
 
-There is open source software that runs on Android phones. Check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/).
+There is open source software that runs on Android phones. Check out [AndroidAPS Documention](https://androidaps.readthedocs.io/en/latest/){: target="_blank" }.
 
 ## Do I have to be "tech-smart" to build Loop?
 
@@ -24,7 +24,7 @@ Often times the non-tech people do better than the tech people in building Loop.
 
 ## Is there a cheat sheet for a school nurse to use?
 
-Sure, you can give this one a try. [School nurse's cheat sheet download](https://github.com/Kdisimone/images/raw/master/school_nurse.pdf)
+Sure, you can give this one a try. [School nurse's cheat sheet download](https://github.com/Kdisimone/images/raw/master/school_nurse.pdf){: target="_blank" }
 
 ## How long does it take to build Loop?
 
@@ -47,7 +47,7 @@ There are no other costs, ongoing or initial, to use Loop beyond what you alread
 
 This is not required for DASH users.
 
-There are several options for the [RileyLink Compatible Devices](../build/rileylink.md#rileylink-compatible-devices) at this time.  They typically cost around $150. This is a one-time cost and the devices should last for years (unless it goes swimming, goes through the wash, gets run over by a car, etc.). It's fine to buy one device and make sure you want to Loop, but if you can afford it, go on and get two or get two different kinds. Once you Loop, you'll want a backup. Because some of the newer versions have features some people prefer, you may find posts on [The Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup) offering to sell their RileyLink for a reduced cost.
+There are several options for the [RileyLink Compatible Devices](../build/rileylink.md#rileylink-compatible-devices) at this time.  They typically cost around $150. This is a one-time cost and the devices should last for years (unless it goes swimming, goes through the wash, gets run over by a car, etc.). It's fine to buy one device and make sure you want to Loop, but if you can afford it, go on and get two or get two different kinds. Once you Loop, you'll want a backup. Because some of the newer versions have features some people prefer, you may find posts on [The Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } offering to sell their RileyLink for a reduced cost.
 
 ## Free Developer Account Options
 
@@ -59,13 +59,13 @@ You no longer need to own an Apple computer - see [Build with Browser](../gh-act
 
 If you chose [Build with *Mac*](../build/overview.md), then you still don't **have** to own an Apple computer, but you do need to at least borrow one - or you can build using a virtual Mac if you have a PC with Intel chips (see next section).
 
-If you are borrowing an Apple computer, look at the required minimum settings associated with your iPhone [Compatible Computer](../build/computer.md#macos) and [Xcode Version](../build/xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other). It would be really good to have longer term ability to borrow that computer again for [updating Loop](../build/updating.md#when-to-update) later, when needed.
+If you are borrowing an Apple computer, look at the required minimum settings associated with your iPhone [Compatible Computer](../build/computer.md#macos) and [Xcode Version](../build/xcode-version.md#how-do-all-the-minimum-versions-relate-to-each-other). It would be really good to have the longer-term ability to borrow that computer again for [updating Loop](../build/updating.md#when-to-update) later when needed.
 
 ## Can I use a PC or Windows computer to build?
 
 You can build Loop using just a browser on any device: [Build with Browser](../gh-actions/gh-overview.md).
 
-If you want to use [Build with *Mac*](../build/overview.md), there is a hacked way of installing macOS on a Windows computer called a **Virtual Machine**. [This link](https://macosvmware.tech.blog/) provides some helpful information. This **Virtual Machine** method will not work on PCs that have AMD processors, only Intel. Double check that your computer uses an Intel processor before attempting the virtual machine method. If you want to try this, there are mentors on [The Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup) who can assist.
+If you want to use [Build with *Mac*](../build/overview.md), there is a hacked way of installing macOS on a Windows computer called a **Virtual Machine**. [This link](https://macosvmware.tech.blog/){: target="_blank" } provides some helpful information. This **Virtual Machine** method will not work on PCs that have AMD processors, only Intel. Double-check that your computer uses an Intel processor before attempting the virtual machine method. If you want to try this, there are mentors on [The Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } who can assist.
 
 ## How often do I need to get on the computer for Loop?
 
@@ -176,7 +176,7 @@ One exception - if you've chosen to use a CGM source that does require the inter
 
 ## What happened to FreeAPS?
 
-[FreeAPS](https://www.loopandlearn.org/freeapsdoc) hasn't really had an owner to develop it for several years, but many depended on it. Because of that, the *Loop and Learn* team kept it on life-support. It was updated in early 2023 to include DASH, but that was the last improvement. It is strongly recommended people switch to `Loop 3` or `iAPS`. Do not use an application without an owner.
+[FreeAPS](https://www.loopandlearn.org/freeapsdoc){: target="_blank" } hasn't really had an owner to develop it for several years, but many depended on it. Because of that, the *Loop and Learn* team kept it on life-support. It was updated in early 2023 to include DASH, but that was the last improvement. It is strongly recommended people switch to `Loop 3` or `iAPS`. Do not use an application without an owner.
 
 Many features people used with FreeAPS are now included in `Loop 3` or can be added with customization. The `dev` branch has Libre support, see [Build Loop Dev](../version/build-dev.md).
 

--- a/docs/faqs/algorithm-faqs.md
+++ b/docs/faqs/algorithm-faqs.md
@@ -17,7 +17,7 @@ No in that:
     * Loop does not adjust or "learn" the [Therapy Settings](../loop-3/therapy-settings.md) portion of Loop parameters directly
         * It keeps those fixed and user controlled, separate from the dynamic part of the Loop algorithm, which does learn based on short-term patterns
         * If outside factors (such as hormones, illness, exercise, medications, etc) affect your underlying Therapy Settings you may need to manually adjust those settings.
-* This LoopTips 3-page section on [Settings](https://loopkit.github.io/looptips/settings/overview/) is recommended.
+* This LoopTips 3-page section on [Settings](https://loopkit.github.io/looptips/settings/overview/){: target="_blank" } is recommended.
 
 
 Perhaps in subsequent versions of Loop, auto-adjustment of settings or machine learning could be incorporated. Until then, you will need to tell Loop if your underlying settings change or make temporary adjustments for short term issues.
@@ -28,7 +28,7 @@ The use of [Overrides](../operation/features/overrides.md) can be quite helpful 
 
 When Loop withholds or suspends some of your scheduled basal insulin, that starts an accumulation of insulin deficit. If you have a kinked cannula and insulin is not delivered, you'd call yourself "lacking insulin" (negative IOB).
 
-When Loop reports negative IOB, it is a sign that Loop has been actively helping you prevent a low blood sugar. If you find significant negative IOB regularly, you probably need to [adjust/test your settings](https://loopkit.github.io/looptips/settings/settings/). Glucose that continues to decrease (away from a meal) when IOB goes negative is typically a sign that the scheduled basal rate is too high.
+When Loop reports negative IOB, it is a sign that Loop has been actively helping you prevent a low blood sugar. If you find significant negative IOB regularly, you probably need to [adjust/test your settings](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" }. Glucose that continues to decrease (away from a meal) when IOB goes negative is typically a sign that the scheduled basal rate is too high.
 
 !!! abstract "Developer Notes"
     Scheduled basal rates are meant to counteract your endogenous glucose production. Another way of saying this is that Loop expects your body to be producing an amount of glucose at a rate that is handled by your basal insulin settings.

--- a/docs/faqs/apple-health-faqs.md
+++ b/docs/faqs/apple-health-faqs.md
@@ -123,7 +123,7 @@ A simple example to illustrate this - for a pump with smallest insulin delivery 
 
 ### *Tidepool* and *Apple* HealthKit
 
-If you have a [*Tidepool*](https://tidepool.org) account and use the *Tidepool* uploader on your *Loop* phone, the data in Health is uploaded to your *Tidepool* database where you can view displays with the [*Tidepool* web browser tool](https://loopkit.github.io/looptips/data/tidepool/).
+If you have a [*Tidepool*](https://tidepool.org/){: target="_blank" } account and use the *Tidepool* uploader on your *Loop* phone, the data in Health is uploaded to your *Tidepool* database where you can view displays with the [*Tidepool* web browser tool](https://loopkit.github.io/looptips/data/tidepool/){: target="_blank" }.
 
 ## How Do I Modify *Apple* HealthKit Permissions
 
@@ -163,13 +163,13 @@ If you happen to wear a *Dexcom* G6 and G7 sensor at the same time, then startin
 
 There are several choices for reading *Libre* sensors.
 
-With `Loop dev` (will be `Loop 3.4.x` after release), [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop) is integrated with the `Loop` app.
+With `Loop dev` (will be `Loop 3.4.x` after release), [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" } is integrated with the `Loop` app.
 
 The frequent updates (1-minute glucose data) provided by *Libre* did cause some issues with released versions (`Loop 3.0` and `Loop 3.2.x` with customizations that use various third-party apps to read the *Libre*). These were fixed initially by modifying the third-party apps to limit how frequently they supplied glucose data.
 
 With `Loop dev` (will be `Loop 3.4.x` after release), the Loop app only initiates a closed-loop cycle automatically following a new glucose value if it has been more than 4.2 minutes since the last one.
 
-`Loop 3.0` and `Loop 3.2.x` versions do not have that limitation on how frequently Loop responds to a new glucose reading. There is a [Customization](https://www.loopandlearn.org/custom-code#loop-cycle-time) that incorporates the 4.2 minute interval check which can be applied to Loop 3.2.2.
+`Loop 3.0` and `Loop 3.2.x` versions do not have that limitation on how frequently Loop responds to a new glucose reading. There is a [Customization](https://www.loopandlearn.org/custom-code#loop-cycle-time){: target="_blank" } that incorporates the 4.2 minute interval check which can be applied to Loop 3.2.2.
 
 ##  How Do I Change Glucose Units?
 

--- a/docs/faqs/cgm-faqs.md
+++ b/docs/faqs/cgm-faqs.md
@@ -6,8 +6,8 @@ Loop 3 supports G5, G6, G7, Dexcom ONE, Dexcom Share, Nightscout and the Medtron
 
 Libre Support (for some Libre sensors):
 
-* [Loop dev](../version/build-dev.md) adds [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop)
-* [Loop and Learn: Loop Customization](https://www.loopandlearn.org/custom-code) 
+* [Loop dev](../version/build-dev.md) adds [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" }
+* [Loop and Learn: Loop Customization](https://www.loopandlearn.org/custom-code){: target="_blank" }
 
 Loop 2.2.x supports Dexcom G4 with share, G5, G6, Dexcom ONE, Dexcom Share and the Medtronic CGM systems compatible with Looping pumps.
 
@@ -87,7 +87,7 @@ sequenceDiagram
 
 ## Can I use Libre sensors with a reader like Miao Miao?
 
-If you use Loop dev code, then any Libre sensor supported by [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop) can be used with Loop.
+If you use Loop dev code, then any Libre sensor supported by [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" } can be used with Loop.
 
 See [What CGMs does Loop work with?](#what-cgms-does-loop-work-with).
 
@@ -105,8 +105,8 @@ The older Loop 2.2.x does not read CGM data from Nightscout.
 
 ## What other CGM apps can be used to Loop?
 
-If you are willing to build a development version of Loop, the dev branch incorporates [LibreTransmitter](https://github.com/dabear/LibreTransmitter/blob/main/readme.md) into the Loop app itself. Please read about [Loop Development](../version/development.md) before [building dev](../version/build-dev.md) and using the dev app.
+If you are willing to build a development version of Loop, the dev branch incorporates [LibreTransmitter](https://github.com/dabear/LibreTransmitter/blob/main/readme.md){: target="_blank" } into the Loop app itself. Please read about [Loop Development](../version/development.md) before [building dev](../version/build-dev.md) and using the dev app.
 
 You can add xDrip4iOS and GlucoseDirect as a CGM option to Loop by applying a code customization.
 
-Please read the docs for [xDrip4iOS](https://xdrip4ios.readthedocs.io/en/latest/) and [Glucose Direct](https://github.com/creepymonster/GlucoseDirect#readme). You must build these apps yourself to Loop; you cannot use the TestFlight pre-built versions.
+Please read the docs for [xDrip4iOS](https://xdrip4ios.readthedocs.io/en/latest/){: target="_blank" } and [Glucose Direct](https://github.com/creepymonster/GlucoseDirect#readme){: target="_blank" }. You must build these apps yourself to Loop; you cannot use the TestFlight pre-built versions.

--- a/docs/faqs/new-phone.md
+++ b/docs/faqs/new-phone.md
@@ -46,8 +46,8 @@ Update your old phone to the latest iOS the hardware supports - this simplifies 
     * [Use the Old Phone](#use-the-old-phone-until-ready) until it is convenient to switch to the new phone
 1. Transfer your information to your new phone
     * Let the new phone vendor help you
-    * Use an [iCloud back-up](https://support.apple.com/en-us/HT210217) for the transfer
-    * Use both devices with [Quick Start](https://support.apple.com/en-us/HT210216) to transfer from the old to the new phone
+    * Use an [iCloud back-up](https://support.apple.com/en-us/HT210217){: target="_blank" } for the transfer
+    * Use both devices with [Quick Start](https://support.apple.com/en-us/HT210216){: target="_blank" } to transfer from the old to the new phone
 
 ### Use the Old Phone until Ready
 

--- a/docs/faqs/omnipod-faqs.md
+++ b/docs/faqs/omnipod-faqs.md
@@ -23,14 +23,14 @@ Omnipod 5 is not supported by any version of Loop.
 
 ## What about Tidepool Loop?
 
-Tidepool Loop was approved by the FDA in Jan 2023, but at the current time there are no announced pump or CGM partners. What does this mean?
+Tidepool Loop was approved by the FDA in Jan 2023, but at the current time, there are no announced pump or CGM partners. What does this mean?
 
 Tidepool Loop, cleared by the FDA, is the first:
 
 * App that provides automated insulin dosing **and** is configured to be fully interoperable with pump and CGM partners
-* App that originated as a patient-led intiative
+* App that originated as a patient-led initiative
 
-With this approval, there is now an FDA approved pathway for independent selection of an app, a pump and a CGM. Stay tuned for updates at [https://tidepool.org/tidepool-loop](https://tidepool.org/tidepool-loop).
+With this approval, there is now an FDA-approved pathway for independent selection of an app, a pump, and a CGM. Stay tuned for updates at [https://tidepool.org/tidepool-loop](https://tidepool.org/tidepool-loop){: target="_blank" }.
 
 ## Do I still need a PDM with Omnipod Loop?
 

--- a/docs/faqs/rileylink-faqs.md
+++ b/docs/faqs/rileylink-faqs.md
@@ -94,7 +94,7 @@ If several power cycles do not make the correct firmware show up, contact the ma
 
 The OrangeLink devices allow the user to update the firmware on the device using an app on the phone itself (available for iPhone 7 and later devices).
 
-* [OrangeLink Firmware Update](https://getrileylink.org/orangelink-firmware)
+* [OrangeLink Firmware Update](https://getrileylink.org/orangelink-firmware){: target="_blank" }
 
 A number of OrangeLink Pro devices were shipped with FW2.6 and for people who already had OrangeLink devices, a version of FW2.6 was offered for download. However, this firmware did not work well with Loop (or AndroidAPS).  
 
@@ -117,7 +117,7 @@ The EmaLink features were not added with Loop 2.2.x. The patch listed below adds
 
 A patch was developed to update the RileyLink screen of the Loop app that detects the OrangeLink hardware for all versions of the OrangeLink firmware and adds the battery level reporting and notification to the EmaLink screen. Click on the link below. There are detailed instructions on how to use this patch for Loop 2.2.x.
 
-* [EmaLink and OrangeLink Patch](https://github.com/ps2/rileylink_ios/issues/686)
+* [EmaLink and OrangeLink Patch](https://github.com/ps2/rileylink_ios/issues/686){: target="_blank" }
 
 ## RileyLink Information
 
@@ -138,9 +138,9 @@ Make sure the LiPo battery is well-plugged into the connection. Line up the litt
 
 Loose battery cable on left. Proper battery cable on right
 
-Finally, the board and the battery fit into the slim case fairly tightly as well. Click on the image below to watch a helpful [assembly video](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be).
+Finally, the board and the battery fit into the slim case fairly tightly as well. Click on the image below to watch a helpful [assembly video](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be){: target="_blank" }.
 
-[![frame for video on how to insert RileyLink into slim case, follow link for video](img/slimcase.png)](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be)
+[![frame for video on how to insert RileyLink into slim case, follow link for video](img/slimcase.png)](https://www.youtube.com/watch?v=-GHxxEJMCZc&feature=youtu.be){: target="_blank" }
 
 ## RileyLink Lights
 
@@ -164,7 +164,7 @@ If your blue light remains on despite trying a restart, it is time to pull out y
 
 The battery that comes with RileyLink is not charged completely when it is shipped, so be sure to charge it up before initial use. RileyLink takes about 2 hours to fully charge (the red light will turn off when fully charged, read note above about red light patterns) and should easily last at least a full day of constant Loop use. Typically, it can go into the 30-hour range without any problems. Most people charge their RileyLink each night when they are sleeping. You don't have to worry about leaving the RileyLink plugged in "too long" for charging. It will automatically stop charging the battery when it is fully charged.
 
-Since the best practice is to charge your RileyLink overnight while you sleep, and the battery lasts safely over 24 hours, there is no battery level indicator for the RileyLink. The RileyLink's charge level is not viewable on Nightscout, nor within the Loop app. If you forget to charge your RileyLink overnight, you can recharge it with a portable USB battery in a pinch. A [short mini-USB cable](https://www.adafruit.com/product/899) could be a good addition to a small gear bag.
+Since the best practice is to charge your RileyLink overnight while you sleep, and the battery lasts safely over 24 hours, there is no battery level indicator for the RileyLink. The RileyLink's charge level is not viewable on Nightscout, nor within the Loop app. If you forget to charge your RileyLink overnight, you can recharge it with a portable USB battery in a pinch. A [short mini-USB cable](https://www.adafruit.com/product/899){: target="_blank" } could be a good addition to a small gear bag.
 
 ### What are the differences between the RileyLink Medtronic and Omnipod Antennas?
 
@@ -200,10 +200,10 @@ After a year of use (and a year of being dropped), the antenna may no longer be 
 
 ### RileyLink Battery
 
-Keep your RileyLink and its Lithium-ion Polymer (LiPo) battery protected from damage. LiPo batteries are unsafe when damaged or punctured, so the case is an important part of safe Looping. If your battery is damaged in some way, please disconnect it immediately, and dispose of it (they should be recycled). You can order new RileyLink batteries on the [GetRileyLink website](http://getrileylink.org/)
+Keep your RileyLink and its Lithium-ion Polymer (LiPo) battery protected from damage. LiPo batteries are unsafe when damaged or punctured, so the case is an important part of safe Looping. If your battery is damaged in some way, please disconnect it immediately, and dispose of it (it should be recycled). You can order new RileyLink batteries on the [GetRileyLink website](https://getrileylink.org/){: target="_blank" }
 
 ## RileyLink Battery Removal
 
-To remove the LiPo battery from the RileyLink, please do so slowly and patiently. Work the battery connection side to side slowly to loosen it from the plug. Some people have reported success using small, curved needle-nose pliers such as hemostats. Others have used small flathead screwdrivers as shown in [this video](https://youtu.be/s2qNPLpfwww).
+To remove the LiPo battery from the RileyLink, please do so slowly and patiently. Work the battery connection side to side slowly to loosen it from the plug. Some people have reported success using small, curved needle-nose pliers such as hemostats. Others have used small flathead screwdrivers as shown in [this video](https://youtu.be/s2qNPLpfwww){: target="_blank" }.
 
-[![frame from video showing how to remove battery from RileyLink, follow link for video](img/rileylink_battery_removal.png)](https://youtu.be/s2qNPLpfwww)
+[![frame from video showing how to remove battery from RileyLink, follow link for video](img/rileylink_battery_removal.png)](https://youtu.be/s2qNPLpfwww){: target="_blank" }

--- a/docs/faqs/safety-faqs.md
+++ b/docs/faqs/safety-faqs.md
@@ -4,11 +4,11 @@ Do not enter settings that you are unsure of. For example, if you haven't any id
 
 ## iOS *Focus* Notifications
 
-iPhones have [*Focus* modes](https://support.apple.com/en-us/108302) to enable maximum flexibility for notifications. These modes must be configured by each user to allow important notifications from your diabetes apps.
+iPhones have [*Focus* modes](https://support.apple.com/en-us/108302){: target="_blank" } to enable maximum flexibility for notifications. These modes must be configured by each user to allow important notifications from your diabetes apps.
 
 **Set up every *Focus* mode you use to allow glucose alerts or you will not get them.**
 
-Critical notifications, for example urgent low from Dexcom, are enabled regardless of your *Focus* settings. But regular low and high glucose notifications might be suppressed. Open source apps, like the *Loop* app, can only be allowed to notify during a *Focus* mode when configured by the user.
+Critical notifications, for example, urgent low from Dexcom, are enabled regardless of your *Focus* settings. But regular low and high glucose notifications might be suppressed. Open source apps, like the *Loop* app, can only be allowed to notify during a *Focus* mode when configured by the user.
 
 Under iOS Settings, select *Focus*, then choose the *Focus* mode you want to adjust.
 
@@ -16,7 +16,7 @@ The graphic below has numbered highlights to follow along for configuring Sleep 
 
 1. Enable Time Sensitive Notifications (disabled by default)
 2. Tap on the &plus; sign to add Apps that are allowed to notify in this mode
-3. Use search feature to find apps of interest
+3. Use the search feature to find apps of interest
 4. Tap on the radio button to select apps of interest, the check mark means that app will be added
     * If you use additional apps to provide alerts, be sure to add them to *Focus* as well
 
@@ -73,7 +73,7 @@ Users often reach out if the glucose prediction shown on the *Loop* app screen i
 
 ### Scenario 1: Extreme Override
 
-It is pretty common for new users to think a 10% override setting should behave similar to a 10% temporary basal rate setting on a manual pump. This is not true.
+It is pretty common for new users to think a 10% override setting should behave similarly to a 10% temporary basal rate setting on a manual pump. This is not true.
 
 Read this section on the override page for information: [Avoid Extreme Insulin Needs Setting](../operation/features/overrides.md#avoid-extreme-insulin-needs-setting)
 

--- a/docs/faqs/time-faqs.md
+++ b/docs/faqs/time-faqs.md
@@ -23,13 +23,13 @@ If you have future glucose from a manual time change or just entering something 
 
 * You **MUST** go into Apple Health and remove any glucose values in the future
 * Loop 2.2.x will use those future readings.
-    * If you want to know more, check out this link: [Request: Detect Future Glucose](https://github.com/LoopKit/Loop/issues/1890)
+    * If you want to know more, check out this link: [Request: Detect Future Glucose](https://github.com/LoopKit/Loop/issues/1890){: target="_blank" }
 * Loop 3 detects the future glucose and stops looping
     * It might not be completely obvious why Loop stopped, but you will get a red loop within 15 minutes and Loop is not Looping notifications starting a 20 minutes
     * If you tap on the bolus icon, Loop informs you it detected invalid future glucose
     * If you tap on the glucose icon - it takes you to your CGM which probably has a very different number from that shown on the main Loop screen
 * If you also use Nightscout **and** have the upload CGM readings enabled in Loop, those future glucose values will appear in Nightscout
-    * To fix this problem (after you fix Apple Health), use the [Admin Tools in Nightscout](https://nightscout.github.io/nightscout/admin_tools/) to remove future treatments and future entries
+    * To fix this problem (after you fix Apple Health), use the [Admin Tools in Nightscout](https://nightscout.github.io/nightscout/admin_tools/){: target="_blank" } to remove future treatments and future entries
 
 One added improvement with Loop 3 is it very aggressive at warning you if you make this mistake. you will get a notification - even when you are in a different app. The graphic below shows the alert when you next open Loop after turning off automatic time and changing the time. Even if you respond right away, you may have at least one glucose reading in the future when you see this alert. Please [Remove Future Glucose](#remove-future-glucose).
 

--- a/docs/faqs/update-faqs.md
+++ b/docs/faqs/update-faqs.md
@@ -12,7 +12,7 @@ In both cases, you build the code to install over an existing app on your phone 
 !!! important "Check *Apple* Developer Account"
     If you have an updated agreement, be sure to accept it before you update or rebuild.
 
-    * [<code>Apple Program License Agreement</code>](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement)
+    * [<code>Apple Program License Agreement</code>](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement){: target="_blank" }
 
 * If you use the Browser build method:
     * Follow the steps on [Update/Rebuild with Browser](../gh-actions/gh-update.md)
@@ -27,9 +27,9 @@ In both cases, you build the code to install over an existing app on your phone 
     If you have a very slow download speed or if you do a lot of customizations, it may be worth your time to decide if you need a new download.
 
     * Use Finder to check the date of your last download by looking in the Downloads/BuildLoop folder
-    * Check the date of the last release at [*GitHub* `LoopKit/Loop releases`](https://github.com/LoopKit/Loop/releases)
+    * Check the date of the last release at [*GitHub* `LoopKit/Loop releases`](https://github.com/LoopKit/Loop/releases){: target="_blank" }
     * If the date in Finder is after the release date, follow [Find my Downloaded *Loop* Code](../build/edit-mac.md#find-my-downloaded-loop-code)
-        * Double click on the Loop.xcworkspace file in that folder
+        * Double-click on the Loop.xcworkspace file in that folder
         * This opens Xcode and you can just plug in your phone and build with your existing download
 
 ## What if I'm changing phones?
@@ -72,9 +72,9 @@ Updating the *Loop* app is the same idea as what happens to your other apps on y
 
 ### Check your Developer Account
 
-Regardless of build method, always check your *Apple* Developer Account status.
+Regardless of the build method, always check your *Apple* Developer Account status.
 
-*Apple* updates its License Agreement for the Developer Program frequently. You need to login to your [developer account](https://developer.apple.com/account/) to manually check if there is a new agreeement to accept.  If you see a big red or orange banner across the top of your Developer Account announcing a new license agreement like shown below...please read and accept it before building Loop.
+*Apple* updates its License Agreement for the Developer Program frequently. You need to log in to your [developer account](https://developer.apple.com/account/){: target="_blank" } to manually check if there is a new agreement to accept.  If you see a big red or orange banner across the top of your Developer Account announcing a new license agreement like shown below...please read and accept it before building Loop.
 
 ![Screenshot: Account - Apple Developer](../build/img/license.png)
 

--- a/docs/gh-actions/automatic.md
+++ b/docs/gh-actions/automatic.md
@@ -63,7 +63,7 @@ Your build will run on the following conditions:
 
 To enable the scheduled build and sync, the `GH_PAT` must hold the `workflow` permission scopes. This permission serves as the enabler for automatic and scheduled builds with browser build. To disable this, follow these steps:
 
-1. Go to your [FastLane Access Token](https://github.com/settings/tokens)
+1. Go to your [FastLane Access Token](https://github.com/settings/tokens){: target="_blank" }
 1. If it says `repo`, `workflow` next to the `FastLane Access Token` link, then automatic building is enabled
 1. To disable automatic update and build, click on the link to open the token detail view
     * Click to uncheck the `workflow` box
@@ -82,7 +82,7 @@ What if I decide I don't want the automatic building feature?
     * Otherwise, you may see the dreaded "Loop Beta has expired" message, have a Loop that won't open and not have a version ready to go in TestFlight that you can install within a few seconds
 
 * If you are taking a break from Loop and want to stop monthly Build emails, consider disabling actions for the `Build Loop` action for your app.
-    * [GitHub Directions to Disable and Enable a Workflow](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow)
+    * [GitHub Directions to Disable and Enable a Workflow](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow){: target="_blank" }
     * It is the Build action that kicks off the update and build steps, so simply disabling the one action is sufficient
 
 * If you are done with Loop, you can delete the whole repository; but you should be sure about this because you'll need to start over with [Configure to Use Browser](gh-first-time.md) to restore ability to build Loop with GitHub.

--- a/docs/gh-actions/build-dev-browser.md
+++ b/docs/gh-actions/build-dev-browser.md
@@ -111,7 +111,7 @@ All other identifiers should be already set up. If they are not, please go throu
 |-------|------------|
 | `Loop Widget Extension` | `com.TEAMID.loopkit.Loop.LoopWidgetExtension` |
 
-* Open the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) page.
+* Open the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } page.
 * Click on the "`LoopWidgetExtension`" identifier
 * Edit the App Group to include `group.com.TEAMID.loopkit.LoopGroup` where you use your `TEAMID`
 

--- a/docs/gh-actions/custom-browser.md
+++ b/docs/gh-actions/custom-browser.md
@@ -17,20 +17,20 @@ These customizations require you to modify the code used to build the *Loop* app
 
 Some customizations are the same for everyone and have been prepared for easy use.
 
-The *Loop and Learn* team commit to maintaining these prepared customizations and provide an easy method to add your selection from these customization to your version of *Loop*.
+The *Loop and Learn* team commits to maintaining these prepared customizations and provides an easy method to add your selection from these customizations to your version of *Loop*.
 
-Please read the documentation for these on the [Loop and Learn: Customization Select Page](https://www.loopandlearn.org/custom-code):
+Please read the documentation for these on the [Loop and Learn: Customization Select Page](https://www.loopandlearn.org/custom-code){: target="_blank" }:
 
-* [List of Customizations Available](https://www.loopandlearn.org/custom-code#custom-list)
-* When building using a browser you will be modifying one of the special files that enables the *GitHub* action to build the *Loop* app. This file is called the build_loop.yml file and can be located at your `fork` of your `LoopWorkspace` repository. There are several sections you need to review on the *Loop and Learn* page:
-    * [Overview](https://www.loopandlearn.org/custom-code/#github-intro) of how to modify the build_loop.yml file
-    * You will copy a template that you paste into that file and then edit to keep just the customizations you want
-    * [Template for `main`](https://www.loopandlearn.org/custom-code#template)
-    * [Template for `dev`](https://www.loopandlearn.org/custom-code#template-dev)
+* [List of Customizations Available](https://www.loopandlearn.org/custom-code#custom-list){: target="_blank" }
+* When building using a browser you will be modifying one of the special files that enable the *GitHub* action to build the *Loop* app. This file is called the build_loop.yml file and can be located at your `fork` of your `LoopWorkspace` repository. There are several sections you need to review on the *Loop and Learn* page:
+    * [Overview](https://www.loopandlearn.org/custom-code/#github-intro){: target="_blank" } of how to modify the build_loop.yml file
+    * You will copy a template that you paste into that file and then edit it to keep just the customizations you want
+    * [Template for `main`](https://www.loopandlearn.org/custom-code#template){: target="_blank" }
+    * [Template for `dev`](https://www.loopandlearn.org/custom-code#template-dev){: target="_blank" }
 
 ### Add Libre Support to 3.2.3
 
-If you are using `main` branch to build `Loop 3.2.3` and rely on either *xDrip4iOS* or *GlucoseDirect* to read your CGM and transfer the readings to the *Loop* app, you need to review this [section of the *Loop and Learn* customization page](https://www.loopandlearn.org/custom-code#add-cgm-323-browser).
+If you are using `main` branch to build `Loop 3.2.3` and rely on either *xDrip4iOS* or *GlucoseDirect* to read your CGM and transfer the readings to the *Loop* app, you need to review this [section of the *Loop and Learn* customization page](https://www.loopandlearn.org/custom-code#add-cgm-323-browser){: target="_blank" }.
 
 Alternatively, you can switch to the `dev` branch, which already supports Libre. [Build Loop dev with Browser](build-dev-browser.md)
 

--- a/docs/gh-actions/edit-browser.md
+++ b/docs/gh-actions/edit-browser.md
@@ -1,7 +1,7 @@
 ## Hot Topics
 
 !!! tip "Pro Tip"
-    The method on this page allows you to create a set of personalized customizations that you can use in addition to the [Loop and Learn: Prepared Customizations](https://www.loopandlearn.org/custom-code#prepared-custom-list). You can use (and re-use) your customizations with either Browser Build or *Mac* builds so you don't have to repeat the customization with every update.
+    The method on this page allows you to create a set of personalized customizations that you can use in addition to the [Loop and Learn: Prepared Customizations](https://www.loopandlearn.org/custom-code#prepared-custom-list){: target="_blank" }. You can use (and re-use) your customizations with either Browser Build or *Mac* builds so you don't have to repeat the customization with every update.
 
     * If you are building with *Mac* method, you can use the same lines prepared for Build with Browser method and simply paste them in your terminal at the&nbsp;<span translate="no">LoopWorkspace</span>&nbsp;folder to customize your code
     * You can often use the same customization for several releases
@@ -45,7 +45,7 @@
         * If there is an update (new release) and the customization applies with no errors, then you do NOT need to create an update
         * It is a good idea to test each customization as soon as you install the new build on your phone
     * LoopDocs: Decide on Modules to modify using the [LoopDocs: Code Customization](../version/code-custom-edits.md) page
-        * You only need to create your own customization if what you want is not provided at [Loop and Learn: Customization List](https://www.loopandlearn.org/custom-code#custom-list)
+        * You only need to create your own customization if what you want is not provided at [Loop and Learn: Customization List](https://www.loopandlearn.org/custom-code#custom-list){: target="_blank" }
     * *GitHub* (each Module):
         1. Copy Module (if needed) - this is your copy where you will make changes
         1. Sync the Module (if needed)
@@ -104,7 +104,7 @@ This is fairly rare, but it can happen. A user got this error when editing a fil
 ![GitHub screen with rejected commit](img/gh-email-error.png){width="600"}
 {align="center"}
 
-The solution was to make sure the email address in their GitHub profile was correct. See [GitHub Discussions](https://github.com/orgs/community/discussions/62507) for more information.
+The solution was to make sure the email address in their GitHub profile was correct. See [GitHub Discussions](https://github.com/orgs/community/discussions/62507){: target="_blank" } for more information.
 
 ## Create your Copy for Selected Module
 
@@ -133,7 +133,7 @@ Choose your link:
 If you want a modification that uses a particular Module, you must make a copy of that module to your account in *GitHub*. You will repeat the Copy and Modify steps for each module.
 
 1. Log into your *GitHub* account
-1. Right click (or control click) on the URL in the [Module Table](#module-table)
+1. Click the URL in the [Module Table](#module-table)
 1. This opens a new browser tab at the URL of the module you need to copy
 1. Click on&nbsp;<span translate="no">Fork</span>, your copy will show up in the browser
 
@@ -143,10 +143,10 @@ This table lists all the modules referred to on the Code Customization page link
 
 | Module | Copy From |
 | --- | --- |
-| <span translate="no">Loop</span> | [<span translate="no">https://github.com/LoopKit/Loop</span>](https://github.com/LoopKit/Loop) |
-| <span translate="no">LoopKit</span> | [<span translate="no">https://github.com/LoopKit/LoopKit</span>](https://github.com/LoopKit/LoopKit) |
-| <span translate="no">OmniBLE (for DASH)</span> | [<span translate="no">https://github.com/LoopKit/OmniBLE</span>](https://github.com/LoopKit/OmniBLE) |
-| <span translate="no">OmniKit (for Eros)</span> | [<span translate="no">https://github.com/LoopKit/OmniKit</span>](https://github.com/LoopKit/OmniKit) |
+| <span translate="no">Loop</span> | [<span translate="no">https://github.com/LoopKit/Loop</span>](https://github.com/LoopKit/Loop){: target="_blank" } |
+| <span translate="no">LoopKit</span> | [<span translate="no">https://github.com/LoopKit/LoopKit</span>](https://github.com/LoopKit/LoopKit){: target="_blank" } |
+| <span translate="no">OmniBLE (for DASH)</span> | [<span translate="no">https://github.com/LoopKit/OmniBLE</span>](https://github.com/LoopKit/OmniBLE){: target="_blank" } |
+| <span translate="no">OmniKit (for Eros)</span> | [<span translate="no">https://github.com/LoopKit/OmniKit</span>](https://github.com/LoopKit/OmniKit){: target="_blank" } |
 
 Remember - you can only have a single copy of a given&nbsp;<span translate="no">GitHub repository</span>. If you already have a copy, you don't need another one; but it must be a linked to the URL listed the [Module Table](#module-table).
 
@@ -189,7 +189,7 @@ You will be using the "pencil" tool in the browser display for your copy.
 !!! question "Are there detailed instructions?"
     For more information about editing with *GitHub*:
 
-    * [*GitHub* Docs: Editing Files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
+    * [*GitHub* Docs: Editing Files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files){: target="_blank" }
 
 The bullets below go with Frame 1 of the [GIF](#example-gif) above:
 
@@ -395,7 +395,7 @@ What if you already have a copy of one of the modules?
 * If you know this is a copy you do not care about, you can delete the <code>repository</code>.
 * If you care about this copy, you are probably experienced enough to know how to solve the issue.
 
-Instructions to delete a <code>repository</code> are found at&nbsp;[*GitHub* Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
+Instructions to delete a <code>repository</code> are found at&nbsp;[*GitHub* Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository){: target="_blank" }
 
 Once deleted, go to [Create Your Copy for Selected Module](#create-your-copy-for-selected-module).
 

--- a/docs/gh-actions/gh-deploy.md
+++ b/docs/gh-actions/gh-deploy.md
@@ -115,7 +115,7 @@ Suppose you really don't like the name you picked initially for the&nbsp;_<span 
 
 You can change it.
 
-Open this link: [App Store Connect Apps](https://appstoreconnect.apple.com/apps) and log in as needed.
+Open this link: [App Store Connect Apps](https://appstoreconnect.apple.com/apps){: target="_blank" } and log in as needed.
 
 * Click on your app name.
 * Click on App Information on the left side (make browser wider if you don't see this).

--- a/docs/gh-actions/gh-errors.md
+++ b/docs/gh-actions/gh-errors.md
@@ -42,7 +42,7 @@ If there are *Apple* Developer agreements you have not accepted, you may get err
 * If you previously built successfully - it is almost certainly the agreement
 * It can take 15 minutes to an hour after the agreement is signed before it can be used
 
-If you need detailed instructions, click on this [<code>Apple Program License Agreement</code> Help Page](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement).
+If you need detailed instructions, click on this [<code>Apple Program License Agreement</code> Help Page](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement){: target="_blank" }.
 
 You can also get this message if the credit card used to purchase the Developer account is not current, e.g., no longer valid or expiration date has passed.
 
@@ -91,7 +91,7 @@ Click on the top link to view the record of the failed action as shown in the gr
 
     -  either in the URL of your fork of `Loopworkspace`, after `github.com` in between the forward slashes (`/`).
        https://github.com/==username==/Loopworkspace
-    - or on the [*GitHub* website](https://github.com)
+    - or on the [*GitHub* website](https://github.com){: target="_blank" }
 
         ![Find your GitHub username step 1](img/github-username-1.svg)
         ![Find your GitHub username step 2](img/github-username-2.svg){width="200"}
@@ -183,7 +183,7 @@ Follow these steps:
     - It is fine to just ignore identifiers with the wrong <code>TEAMID</code>, but do not use them
 
 1. Enter your `TEAMID` correctly in the repository `Secrets`
-    - Make sure you use copy and paste from your [Apple Developer Membership](https://developer.apple.com/account/#!/membership) page for that `TEAMID`.
+    - Make sure you use copy and paste from your [Apple Developer Membership](https://developer.apple.com/account/#!/membership){: target="_blank" } page for that `TEAMID`.
     - Follow the update instructions here (this example is for `GH_PAT`, you'll do the same but for `TEAMID`) [Update Secrets](gh-update.md#update-secrets)
 
 1. Run Action: [Configure to Use Browser: `Add Identifiers`](gh-first-time.md#add-identifiers) again
@@ -196,7 +196,7 @@ You will remove that app and create a new one.
 
 #### Remove App with Incorrect `TEAMID`
 
-Go to [`App Store Connect / Apps`](https://appstoreconnect.apple.com/apps) and follow the numbered steps in the graphic below.
+Go to [`App Store Connect / Apps`](https://appstoreconnect.apple.com/apps){: target="_blank" } and follow the numbered steps in the graphic below.
 
 1. Find the *Loop* app you created earlier and click on it
 2. On the left side, under `General`, click on `App Information`
@@ -246,7 +246,7 @@ If you see this phrase, the `fastlane` package that is utilized during the `3. C
 
 To fix this error:
 
-- Open this link: [https://github.com/settings/tokens/](https://github.com/settings/tokens/)
+- Open this link: [https://github.com/settings/tokens/](https://github.com/settings/tokens/){: target="_blank" }
   - Here you will see your personal access token (`Fastlane Access Token`) that was created during [Configure to Use Browser: Setup *GitHub*: Create `GitHub Personal Access Token`](../gh-actions/gh-first-time.md#create-github-personal-access-token)
   - Note that `Tokens (classic)` is highlighted in the menu on the left
   - Click on the token name (should be bold, blue **`Fastlane Access Token`** ) to open its detail page
@@ -280,7 +280,7 @@ These steps are needed to make room for a `Certificate`:
 
 1. Delete an old `Distribution Certificate`
     * *Apple* limits you to two `Distribution Certificates`
-    * Use this link to view your [Apple Developer Certificates](https://developer.apple.com/account/resources/certificates/list)
+    * Use this link to view your [Apple Developer Certificates](https://developer.apple.com/account/resources/certificates/list){: target="_blank" }
         * Carefully examine the `Type` column - do **not** delete a `Development` `Certificate`
         * If you accidentally delete a `Development` `Type` certificate associated with an Xcode build for your Loop app - it will stop working and you will be very sad
     * Click on the oldest `Distribution` `Certificate` and revoke it
@@ -340,7 +340,7 @@ If that phrase is found, then:
 
 
 * This can also be caused if you correctly created the *Loop* App but entered an incorrect value for the `TEAMID`.
-    * If you have the incorrect `TEAMID`, check this link: [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) for entries with the incorrect `TEAMID` embedded
+    * If you have the incorrect `TEAMID`, check this link: [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } for entries with the incorrect `TEAMID` embedded
     * For example, if your `TEAMID` is `0123456789`, but you entered `000123`, you may see both of these in your identifiers list
         * `com.0123456789.loopkit.Loop`
         * `com.000123.loopkit.Loop`
@@ -404,7 +404,7 @@ This tells you, the `Bundle ID` you selected in [First-Time: Create Loop App in 
 
 Once you have created an app in the *App Store* that is not based on your `TEAMID`, you cannot delete it, but you can Remove it (i.e. hide it so that it is no longer visible on this page and you don't accidentally click on it).
 
-1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps) to view your apps; log in if needed.
+1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps){: target="_blank" } to view your apps; log in if needed.
 1. Find the App with the wrong `Bundle ID` and click on it
 1. On the left-hand side, click on `App Information` (under `General`)
     * Confirm the `Bundle ID` listed does not include your `TEAMID`
@@ -425,7 +425,7 @@ Use the [Examine the Error](#examine-the-error) instructions to find your error 
 
 Assuming you have successfully built using the Browser-Build / *GitHub* method before:
 
-* If the details show this message, `Could not install WWDR certificate`, make sure your [*Apple developer* account](https://developer.apple.com) is in good standing and that there are no agreements that need to be accepted
+* If the details show this message, `Could not install WWDR certificate`, make sure your [*Apple developer* account](https://developer.apple.com){: target="_blank" } is in good standing and that there are no agreements that need to be accepted
 * Sometimes this is a sign that *Apple* did not respond to a request, this failure happens in the first few minutes
     * Repeat the build and it should be fine the next time
 
@@ -445,7 +445,7 @@ There might be several reasons to do this:
 These steps are needed to reset your `Match-Secrets`:
 
 1. Delete your `Match-Secrets` Repository
-    * Instructions to delete a repository are found at [GitHub Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
+    * Instructions to delete a repository are found at [GitHub Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository){: target="_blank" }
 1. Create a new private `Match-Secrets` *Repository*
     * main branch: follow the directions [First-Time: Create `Match-Secrets`](gh-first-time.md#create-match-secrets)
     * dev branch: the `Action`: `Validate Secrets` automatically creates a new private `Match-Secrets` repository if you don't have one

--- a/docs/gh-actions/gh-first-time.md
+++ b/docs/gh-actions/gh-first-time.md
@@ -16,7 +16,7 @@
 
     A narrated video is available:
 
-    * [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8)
+    * [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8){: target="_blank" }
 
     Once you have *Apple Developer* and *GitHub* accounts, the steps below are a high-level summary with links to the detailed section of this LoopDocs page.
 
@@ -51,7 +51,7 @@
     - **Isn't it hard to build every 90 days?** The initial setup and installation take a lot of your focused time. But once you build once, subsequent builds take very little of your time to start the build. The rest is done automatically.
     - **Can I use this for my child?** You, as the adult, can install using *TestFlight* on your child's phone. The explicit steps are provided at [Install on Phone: *TestFlight* for a Child](gh-deploy.md#testflight-for-a-child).
     - **Can I still use my customizations?** Yes. [Customize using Browser](custom-browser.md)
-    - **Is there a build video?** Yes. [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8)
+    - **Is there a build video?** Yes. [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8){: target="_blank" }
 
 ## Tips and Tricks
 
@@ -63,19 +63,19 @@ Some sections have a Section Summary:
 * If the summary is all you need, use the `skip forward` symbol (<span class="loop-big">:material-skip-forward:</span>) to skip to the next instruction
 * Or follow the detailed instructions below the summary
 
-As you configure for Browser Build, you go back and forth between *GitHub* and *Apple Developer* webpages. Use right-click to open a new tab or copy a link address, as appropriate, while proceeding.
+As you configure for Browser Build, you go back and forth between *GitHub* and *Apple Developer* webpages. Use click to open a new tab or copy a link address, as appropriate, while proceeding.
 
 An automatic table of contents (TOC) should appear for each page on the right side of your browser (if the browser is "wide" enough). If not, tap on the hamburger menu (upper left) and then this page name to see the TOC.
 
-For sparse instructions, right-click on the link below:
+For sparse instructions, click on the link below:
 
-* [LoopWorkspace Build Instructions](https://github.com/LoopKit/LoopWorkspace/blob/main/fastlane/testflight.md)
+* [LoopWorkspace Build Instructions](https://github.com/LoopKit/LoopWorkspace/blob/main/fastlane/testflight.md){: target="_blank" }
 
 ### How-to Video to Build with a Browser
 
 In addition to this page, there is a narrated video of each step needed to build using a browser.
 
-* [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8)
+* [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8){: target="_blank" }
 
 Click in the comments for a full index of topics.  If you have issues with a step, use the index to  advance to the relevant part of the video. Subtitles are  in English. You can choose a different language but the automatic translation feature may provide translations that are not completely accurate.
 
@@ -110,7 +110,7 @@ If this summary of terms is confusing, finish reviewing the whole page and then 
 
 * `Actions`: available in your *GitHub* account to build your app (once you follow the instructions on this page)
     * With `Loop 3`, the actions: `Validate Secrets`, <code>Add Identifiers</code>, `Create Certificates`, and `Build Loop` enable users to build the *Loop* app from a browser on any computer
-    * If <code>*GitHub* Browser Build</code> Actions are not operating as you expect, check [*GitHub* Status](https://www.githubstatus.com/) to see if it is *GitHub* problem.
+    * If <code>*GitHub* Browser Build</code> Actions are not operating as you expect, check [*GitHub* Status](https://www.githubstatus.com/){: target="_blank" } to see if it is *GitHub* problem.
 * <code>Secrets</code>: are required to enable *GitHub* to build the *Loop* app using *GitHub* Actions
     * Six <code>Secrets</code> must be added to your fork of LoopWorkspace
     * These <code>Secrets</code> work for any branch in your fork (`main` or `dev`, for example)
@@ -129,7 +129,7 @@ If this summary of terms is confusing, finish reviewing the whole page and then 
     * The `Identifier` screen, has **`NAME`** and **`IDENTIFIER`** columns
         * If you previously built with Xcode, the items in the **`NAME`** column may start with `XC`
         * The items under the **`IDENTIFIER`** column match the table in [Add `App Group` to Identifiers](#add-app-group-to-identifiers)
-* [`App Store Connect`](https://appstoreconnect.apple.com): a website available for *Apple Developer*s to review apps build with your *Apple Developer* account
+* [`App Store Connect`](https://appstoreconnect.apple.com){: target="_blank" }: a website available for *Apple Developer*s to review apps build with your *Apple Developer* account
     * Once you purchase an *Apple Developer* annual account, you are an *Apple Developer* and have access to this site
     * Most Loopers will not have an App until using the <code>*GitHub* Browser Build</code>
     * The instructions walk you through creating and naming your app: [Create Loop App in App Store Connect](#create-loop-app-in-app-store-connect)
@@ -213,11 +213,11 @@ You need to save your information digitally, so you can copy and paste. The info
 ??? abstract "Section Summary (click to open/close)"
     You will be saving 4 <code>Secrets</code> from your *Apple* Account in this step.
 
-    1. Sign in to the [*Apple Developer* portal page](https://developer.apple.com/account).
+    1. Sign in to the [*Apple Developer* portal page](https://developer.apple.com/account){: target="_blank" }.
     1. If you need to accept a new agreement (happens about twice a year), be sure to do so now
         * Need help? Look at this section on the update page: [Accept Agreements](gh-update.md#accept-agreements)
     1. Copy the Team ID from the upper right of the screen. [Record this as your `TEAMID`](#find-teamid).
-    1. Go to the [App Store Connect](https://appstoreconnect.apple.com/access/api) interface, click the "Keys" tab, and create a new key with "Admin" access. Give it the name: ["`FastLane API Key`"](#generate-api-key).
+    1. Go to the [App Store Connect](https://appstoreconnect.apple.com/access/api){: target="_blank" } interface, click the "Keys" tab, and create a new key with "Admin" access. Give it the name: ["`FastLane API Key`"](#generate-api-key).
     1. [Record three more secrets](#copy-api-key-secrets)
         * Record the issuer id; this will be used for `FASTLANE_ISSUER_ID`.
         * Record the key id; this will be used for `FASTLANE_KEY_ID`.
@@ -241,11 +241,11 @@ This section provides detailed instructions for the four <code>Secrets</code> as
 If not, you need to purchase one ($99 annual fee). It may take a few days for the account to be enabled.
 
 * LoopDocs has an [*Apple Developer* Program](../build/apple-developer.md) page that explains in detail how to sign up for an account
-* This link takes you straight to [*Apple Developer* account](https://developer.apple.com) to sign up
+* This link takes you straight to [*Apple Developer* account](https://developer.apple.com){: target="_blank" } to sign up
 
 ### Find <code>TEAMID</code>
 
-Sign in to your *Apple Developer* account at this link: [*Apple Developer* portal page](https://developer.apple.com/account).
+Sign in to your *Apple Developer* account at this link: [*Apple Developer* portal page](https://developer.apple.com/account){: target="_blank" }.
 
 1. Click `Account` in the top menu bar
 1. If you need to accept a new agreement (happens about twice a year), be sure to do so now
@@ -279,7 +279,7 @@ Record this for use as <code>TEAMID</code> in your <code>Secrets</code> file. Yo
 
     If you are waiting for *Apple* to enable your account, you can skip ahead to create a [New *GitHub* Account](#new-github-account) and [Create *GitHub* `Personal Access Token`](#create-github-personal-access-token). You then pause at [Configure <code>Secrets</code>](#configure-secrets) until your *Apple* account is active.
 
-1. Right-click to open this link in a new tab: [`App Store Connect/Access/API`](https://appstoreconnect.apple.com/access/api)
+1. Click this link in a new tab: [`App Store Connect/Access/API`](https://appstoreconnect.apple.com/access/api){: target="_blank" }
 
     * The top of the display is shown in the graphic below
 
@@ -376,7 +376,7 @@ If you do not already have a *GitHub* account, you need to create one. Be sure t
 
 Decide on a couple of usernames that you will be happy with - this will get embedded into your *GitHub* URL. Your first choice might not be available, so be prepared with several candidates. Your personal URL will be: `https://github.com/username`.
 
-* Click on this link to sign up for a free account: [*GitHub* account signup](https://github.com/signup)
+* Click on this link to sign up for a free account: [*GitHub* account signup](https://github.com/signup){: target="_blank" }
     * You will need to enter the **email** you want associated your *GitHub* account
     * You will be asked to enter a **password**
     * You will be asked to enter a **username**
@@ -395,7 +395,7 @@ The free level comes with plenty of storage and compute time to build the *Loop*
 ??? abstract "Section Summary (click to open/close)"
     Log into your *GitHub* account to create a personal access token, which you will save as <code>GH_PAT</code>.
 
-    (Right-click on link) to create a [new `personal access token`](https://github.com/settings/tokens/new):
+     Click to create a [new `personal access token`](https://github.com/settings/tokens/new){: target="_blank" }:
 
     * Enter a name for your token, use "`FastLane Access Token`"
     * Change the Expiration selection to `No expiration`
@@ -409,7 +409,7 @@ The free level comes with plenty of storage and compute time to build the *Loop*
 You must be logged into your *GitHub* account before starting this step. If you are continuing, you are already logged in.
 
 1. You will be creating a new *GitHub* `Personal Access Token` and giving it the name "`FastLane Access Token`"
-1. Open this link: [https://github.com/settings/tokens/new](https://github.com/settings/tokens/new)
+1. Open this link: [https://github.com/settings/tokens/new](https://github.com/settings/tokens/new){: target="_blank" }
     * Referring to the graphic
         * Note that `Tokens (classic)` is highlighted
         * Most Looper will use the `classic Token`
@@ -444,7 +444,7 @@ If you have not already made up a password, do it now and record it as <code>MAT
 ??? abstract "Section Summary (click to open/close)"
     The creation of the <code>Match-Secrets</code> repository is a common step for all <code>*GitHub* Browser Builds</code>; do this step only once. You must be logged into your *GitHub* account.
 
-    (Right-click on the link) to create a [new empty repository](https://github.com/new) titled <code>Match-Secrets</code>. It should be private.
+    Click on the link to create a [new empty repository](https://github.com/new){: target="_blank" } titled <code>Match-Secrets</code>. It should be private.
 
     Once created, you will not take any direct actions with this repository; it needs to be there for *GitHub* to use as you progress through the steps.
 
@@ -455,7 +455,7 @@ Open your github.com URL (this is `https://github.com/username`), (`username` is
 
 Create a new private repository - you can either click on the link below or follow the instructions with the first graphic:
 
-* Click on this link: [(https://github.com/new)](https://github.com/new)
+* Click on this link: [https://github.com/new](https://github.com/new){: target="_blank" }
 
 or
 
@@ -486,14 +486,14 @@ You will not directly interact with your `Match-Secrets` repository.
 ### Fork LoopWorkspace
 
 ??? abstract "Section Summary (click to open/close)"
-    Fork [https://github.com/LoopKit/LoopWorkspace](https://github.com/LoopKit/LoopWorkspace) into your account.
+    Fork [https://github.com/LoopKit/LoopWorkspace](https://github.com/LoopKit/LoopWorkspace){: target="_blank" } into your account.
 
     [<span class="loop-bigger">:material-skip-forward:</span>](#configure-secrets) To skip the detailed instructions, click on [Configure <code>Secrets</code>](#configure-secrets)
 
 !!! warning "Existing Fork"
     If you already have a fork of <code>LoopWorkspace</code>, click on [Already Have LoopWorkspace](#already-haveloopworkspace) to decide what to do. That section provides links to return you to these instructions.
 
-1. Open this link [https://github.com/LoopKit/LoopWorkspace](https://github.com/LoopKit/LoopWorkspace) to open the <code>LoopWorkspace</code> repository owned by `LoopKit`.
+1. Open this link [https://github.com/LoopKit/LoopWorkspace](https://github.com/LoopKit/LoopWorkspace){: target="_blank" } to open the <code>LoopWorkspace</code> repository owned by `LoopKit`.
 1. Review the highlighted locations of the graphic below (yours won't look quite like this yet, but the `Fork` button is in the same place)
 1. At the upper right side of the screen, click on the word `Fork`
     * If you already have a fork, you cannot proceed, see [Already Have LoopWorkspace](#already-haveloopworkspace)
@@ -734,7 +734,7 @@ Please read carefully to avoid confusion.
 ??? abstract "Section Summary (click to open/close)"
     [<span class="loop-bigger">:material-skip-forward:</span>](#previous-xcode-builders) If you have already built the *Loop* app via Xcode using this *Apple* ID, skip ahead to [Previous Xcode Builders](#previous-xcode-builders).
 
-    1. Go to [Register an `App Group`](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/) on the *Apple Developer* site.
+    1. Go to [Register an `App Group`](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/){: target="_blank" } on the *Apple Developer* site.
     1. For Description, use "Loop App Group".
     1. For Identifier, enter "group.com.TEAMID.loopkit.LoopGroup", substituting your team id for `TEAMID`.
     1. Click "Continue" and then "Register".
@@ -745,7 +745,7 @@ The `Loop` *App Group* already exists if you previously built the *Loop* app usi
 
 If you have never built the *Loop* app with *Xcode* using your `TEAMID`, you need to create an *App Group* associated with your `TEAMID`.
 
-1. Open this link: [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/) on the *Apple Developer* site.
+1. Open this link: [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/){: target="_blank" } on the *Apple Developer* site.
 1. For **`Description`**, use `Loop App Group`.
 1. For **`Identifier`**, enter `group.com.TEAMID.loopkit.LoopGroup`, substituting your team id for `TEAMID`.
 1. Double-check the spelling - your `TEAMID` must be correct and the `Loop` *App Group* must match the format shown in the previous step
@@ -758,7 +758,7 @@ If you have never built the *Loop* app with *Xcode* using your `TEAMID`, you nee
 
 #### New Builders
 
-Right-click to open this link in a new tab: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list) on the *Apple Developer* site.
+Click this link: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the *Apple Developer* site.
 
 If you never built using *Xcode*, then after the <code>Add Identifiers</code> *Action*, you will see the six items under **`NAME`** in the table below with the associated **`IDENTIFIER`** information. Your `Developer ID` replaces the `TEAMID` in the identifier.
 
@@ -766,7 +766,7 @@ If you never built using *Xcode*, then after the <code>Add Identifiers</code> *A
 
 #### Previous Xcode Builders
 
-Right-click to open this link in a new tab: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list) on the *Apple Developer* site.
+Click this link: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the *Apple Developer* site.
 
 Because you built the *Loop* app using *Xcode*, then the **`NAME`** associated with at least the `Loop identifier` will appear as `XC com.TEAMID.loopkit.Loop` under the **`NAME`** column. Ignore the **`NAME`** column and key off what you see under the **`IDENTIFIER`** column of the table. Only the six listed in the table below need to appear when building `Loop 3`.
 
@@ -793,7 +793,7 @@ Because you built the *Loop* app using *Xcode*, then the **`NAME`** associated w
 
     Note 2 - Depending on your build history, you may find some of the Identifiers are already configured - and you are just verifying the status; but in other cases, you will need to configure the Identifiers.
 
-    1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the *Apple Developer* site.
+    1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the *Apple Developer* site.
     1. For each of the following identifier names:
         * `Loop`
         * `Loop Intent Extension`
@@ -811,7 +811,7 @@ Because you built the *Loop* app using *Xcode*, then the **`NAME`** associated w
 
     [<span class="loop-bigger">:material-skip-forward:</span>](#create-loop-app-in-app-store-connect) To skip the detailed instructions, click on [Create Loop App in App Store Connect](#create-loop-app-in-app-store-connect)
 
-Find and click on the row for the `Loop identifier` on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) page. Look in the **`IDENTIFIER`** column to find `com.TEAMID.loopkit.Loop`. The name in the **`NAME`** column may be different than Loop.
+Find and click on the row for the `Loop identifier` on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } page. Look in the **`IDENTIFIER`** column to find `com.TEAMID.loopkit.Loop`. The name in the **`NAME`** column may be different than Loop.
 
 | `NAME` | `IDENTIFIER` |
 |-------|------------|
@@ -876,7 +876,7 @@ If you are building the dev branch, the `Small Status Widget` was renamed. Look 
 
 #### Back to How-to Instruction for main or dev
 
-Find and click on a given identifier row on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) page.
+Find and click on a given identifier row on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } page.
 
 The `Edit Your App ID Configuration` screen will open. Take one action for each of these three identifiers.
 
@@ -905,7 +905,7 @@ The full list of Identifiers should be displayed again.
 ??? abstract "Section Summary (click to open/close)"
     If you have created a Loop app in App Store Connect before, skip ahead to [Create Certificates](#create-certificates).
 
-    1. Right-click on the link [apps list](https://appstoreconnect.apple.com/apps) to open App Store Connect and click the blue "plus" icon to create a New App.
+    1. Click on the link [apps list](https://appstoreconnect.apple.com/apps){: target="_blank" } to open App Store Connect and click the blue "plus" icon to create a New App.
         * Select "iOS".
         * Select a name: this will have to be unique, so you may have to try a few different names here, but it will not be the name you see on your phone, so it's not that important.
         * Select your primary language.
@@ -920,9 +920,9 @@ The full list of Identifiers should be displayed again.
 
 If you have created a `Loop app` in *App Store Connect* before, skip ahead to [Create Certificates](#create-certificates).
 
-If have previously used some kind of remote build, like `diawi` or `TestFlight`, you may have your Loop in the *App Store* but can't see it. Don't worry - there are instructions for this case.
+If you have previously used some kind of remote build, like `diawi` or `TestFlight`, you may have your Loop in the *App Store* but can't see it. Don't worry - there are instructions for this case.
 
-1. Open this link: [`App Store Connect / Apps`](https://appstoreconnect.apple.com/apps) to view your apps; log in if needed.
+1. Open this link: [`App Store Connect / Apps`](https://appstoreconnect.apple.com/apps){: target="_blank" } to view your apps; log in if needed.
     * If you have never added an app to *App Store Connect*, you will not see the icons inside the red rectangle and should keep going, although some people report the search icon shows up for them
     *  If you have an app that is not shown, you will see a search icon and the `All Statuses` dropdown. If you get to step 3 and cannot find your `com.TEAMID.loopkit.Loop` in the *Bundle ID* drop-down, this means you need to follow [Find My Loop](#find-my-loop).
 
@@ -968,7 +968,7 @@ There are two possible reasons:
 
 You may have no memory of ever setting up `Loop` in *App Store Connect*. If you previously used some kind of remote build, like `diawi`, your `Loop` may be there as a *Removed App*.
 
-* Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps), look for the `All Statuses` dropdown indicator, and select `Removed Apps`
+* Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps){: target="_blank" }, look for the `All Statuses` dropdown indicator, and select `Removed Apps`
 
     ![app store connect with deleted apps](img/01-app-store-connect.png){width="600"}
     {align="center"}
@@ -1030,9 +1030,9 @@ Refer to the graphic below for the numbered steps:
         * one says the build succeeded (or failed)
         * one says *TestFlight* is ready (typically half-hour after the build succeeds)
         * Ignore the one that says you need to fix "issues" in your app. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
-    1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps).
+    1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps){: target="_blank" }.
     1. For each phone/person you would like to support:
-        * Add them in [Users and Access](https://appstoreconnect.apple.com/access/users) on App Store Connect.
+        * Add them in [Users and Access](https://appstoreconnect.apple.com/access/users){: target="_blank" } on App Store Connect.
         * Add them to your *TestFlight* Internal Testing group.
 
     [<span class="loop-bigger">:material-skip-forward:</span>](#set-up-users-and-access-testflight) To skip the detailed instructions, click on [Set Up Users and Access (TestFlight)](#set-up-users-and-access-testflight).
@@ -1060,7 +1060,7 @@ Refer to the graphic below for the first four steps:
     * one says the build succeeded (or failed)
     * one says *TestFlight* is ready (typically half-hour after the build succeeds)
     * Ignore the one that says you need to fix "issues" in your app. You are not selling the app in the app store; so no action is required. The app you built is for personal use for you or a family member.
-1. Your app should eventually appear on [`App Store Connect`](https://appstoreconnect.apple.com/apps).
+1. Your app should eventually appear on [`App Store Connect`](https://appstoreconnect.apple.com/apps){: target="_blank" }.
 
 ## Build Failed?
 
@@ -1094,14 +1094,14 @@ You are configuring a private capability for your family using an Internal Testi
 
 1. First you need to add the email address(es) to your *App Store Connect* Access Users list:
 
-    * Open this link: [Users and Access](https://appstoreconnect.apple.com/access/users)
+    * Open this link: [Users and Access](https://appstoreconnect.apple.com/access/users){: target="_blank" }
         * You must provide a role for each person - `Customer Support` is a good choice
         * Once you have added them here, you'll be able to select them in the `TestFlight` group for your app
 
     ![add email and role for your users](img/add-users.png){width="700"}
     {align="center"}
 
-1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps) to view your apps; log in if needed. Then select your *Loop* app. Click on the `TestFlight` tab then click the blue plus button (<font color="#2997FF">:material-plus-circle:</font>) next to `Internal Testing` to add a group.
+1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps){: target="_blank" } to view your apps; log in if needed. Then select your *Loop* app. Click on the `TestFlight` tab then click the blue plus button (<font color="#2997FF">:material-plus-circle:</font>) next to `Internal Testing` to add a group.
 
     ![open TestFlight tab for your app](img/setup-testflight-01.png){width="700"}
     {align="center"}
@@ -1154,7 +1154,7 @@ If your copy is from `LoopKit`:
 If your fork is not from `LoopKit`:
 
 * Delete your LoopWorkspace repository
-    * Instructions to delete a repository are found at [*GitHub* Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
+    * Instructions to delete a repository are found at [*GitHub* Docs](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository){: target="_blank" }
 * Return to [Fork LoopWorkspace](#fork-loopworkspace) and follow all the instructions
 
 ### Delete Identifiers
@@ -1168,7 +1168,7 @@ The `Identifier` that is associated with the `Loop` identifier cannot be deleted
 
 To make it easy when configuring the identifiers, go through and delete as many as you can.
 
-* Open this link: [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) on the *Apple Developer* site.
+* Open this link: [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the *Apple Developer* site.
 * Use the graphic below as a guide to removing identifiers
 * Keep repeating the steps until you've removed all the identifiers you can (or want to) delete
 * It is OK to delete an identifier even if it does have your correct `TEAMID`

--- a/docs/gh-actions/gh-other-apps.md
+++ b/docs/gh-actions/gh-other-apps.md
@@ -40,7 +40,7 @@ The same technique is used and the same six <code>Secrets</code> are applied to 
 
 ### Multiple Copies of `Loop Follow`
 
-For the convenience of caregivers who use `Loop Follow` to monitor multiple people, updates were added in v2.1.2 to make this more convenient. This works regardless of the build method. (Build with Browser or [Build with *Mac*](https://www.loopandlearn.org/loop-follow#lf-script)).
+For the convenience of caregivers who use `Loop Follow` to monitor multiple people, updates were added in v2.1.2 to make this more convenient. This works regardless of the build method. (Build with Browser or [Build with *Mac*](https://www.loopandlearn.org/loop-follow#lf-script){: target="_blank" }).
 
 * Build up to three instances of `Loop Follow`
 * Customize the name of the app that appears on your phone
@@ -73,15 +73,15 @@ For the convenience of caregivers who use `Loop Follow` to monitor multiple peop
 
 | App | Fork from this Address | Documentation |
 |---|---|---|
-| <span translate="no">Loop Caregiver</span> | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver) | [LoopDocs: <span translate="no">Loop Caregiver</span>](../nightscout/loop-caregiver.md) |
-| <span translate="no">Loop Follow</span> | [https://github.com/loopandlearn/LoopFollow](https://github.com/loopandlearn/LoopFollow) | [<span translate="no">Loop Follow</span>](https://www.loopandlearn.org/loop-follow)|
+| <span translate="no">Loop Caregiver</span> | [https://github.com/LoopKit/LoopCaregiver](https://github.com/LoopKit/LoopCaregiver){: target="_blank" } | [LoopDocs: <span translate="no">Loop Caregiver</span>](../nightscout/loop-caregiver.md) |
+| <span translate="no">Loop Follow</span> | [https://github.com/loopandlearn/LoopFollow](https://github.com/loopandlearn/LoopFollow){: target="_blank" } | [<span translate="no">Loop Follow</span>](https://www.loopandlearn.org/loop-follow){: target="_blank" }|
 
 The two repositories below are only if you need to follow a second or third looper. All others should use just the table above. The instructions for the second and third looper are otherwise identical to the first looper. Note that `LoopCaregiver` can follow multiple Loopers; you select the person inside the app.
 
 | Special Case | Fork from this Address |
 |---|---|
-| <span translate="no">Loop Follow for a Second Looper</span> | [https://github.com/loopandlearn/LoopFollow_Second](https://github.com/loopandlearn/LoopFollow_Second) |
-| <span translate="no">Loop Follow for a Third Looper</span> | [https://github.com/loopandlearn/LoopFollow_Third](https://github.com/loopandlearn/LoopFollow_Third) |
+| <span translate="no">Loop Follow for a Second Looper</span> | [https://github.com/loopandlearn/LoopFollow_Second](https://github.com/loopandlearn/LoopFollow_Second){: target="_blank" } |
+| <span translate="no">Loop Follow for a Third Looper</span> | [https://github.com/loopandlearn/LoopFollow_Third](https://github.com/loopandlearn/LoopFollow_Third){: target="_blank" } |
 
 ## Update the `Repository`
 
@@ -204,7 +204,7 @@ The `Add Identifier` &nbsp;<span class=notranslate>Action</span>&nbsp; should su
 
 ## Review App Identifier
 
-Open this link: [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) on the apple developer site.
+Open this link: [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the apple developer site.
 
 After successfully performing the `Add Identifiers Action`, you will see the identifier for your app with a Name and Bundle ID matching that in the table below. You will see your unique TEAMID embedded in the identifier. (If you previously built this App with Xcode, the name may start with XC but the ending should match.)
 
@@ -225,14 +225,14 @@ As of 2023 December 8, the *Loop Caregiver* app requires the addition of an `App
 
 ### Check if `App Group` Exists
 
-Open this link to view your `applicationGroup` `Identifiers`: [`App Group Identifiers`](https://developer.apple.com/account/resources/identifiers/list/applicationGroup)
+Open this link to view your `applicationGroup` `Identifiers`: [`App Group Identifiers`](https://developer.apple.com/account/resources/identifiers/list/applicationGroup){: target="_blank" }
 
 * No action is required if there is already an identifier with the `NAME` of `LoopCaregiver App Group` and the `IDENTIFIER` contains your `TEAMID` in this format: `group.com.TEAMID.loopkit.LoopCaregiverGroup`
 * In that case, you can skip ahead to [Add `App Group` to `Identifiers`](#add-app-group-to-identifiers)
 
 ### Create `App Group` for the *Loop Caregiver* App
 
-Open this link: [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/) on the *Apple Developer* site.
+Open this link: [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/){: target="_blank" } on the *Apple Developer* site.
 
 1. For **`Description`**, use `LoopCaregiver App Group`
 1. For **`Identifier`**, enter `group.com.TEAMID.loopkit.LoopCaregiverGroup`, substituting your team id for `TEAMID`.
@@ -242,7 +242,7 @@ Open this link: [Register an App Group](https://developer.apple.com/account/reso
 
 ### Add `App Group` to `Identifiers`
 
-Right-click to open this link in a new tab: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list) on the *Apple Developer* site.
+Click to open this link in a new tab: [`Certificates, Identifiers & Profiles: Identifiers List`](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } on the *Apple Developer* site.
 
 
 #### Table with Name and Identifier for `LoopCaregiver`
@@ -261,7 +261,7 @@ If you do not see them, please sync your `LoopCaregiver` repository and then run
 
 ### Add `LoopCaregiverGroup` to each Identifier
 
-Find and click on the row for the `LoopCaregiver` on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list) page. Look in the **`IDENTIFIER`** column to find `com.TEAMID.loopkit.LoopCaregiver`. The **`NAME`** might begin with an `XC` if you previously built with Xcode. However, the **`IDENTIFIER`** column value should match.
+Find and click on the row for the `LoopCaregiver` on the [Certificates, Identifiers & Profiles: Identifiers List](https://developer.apple.com/account/resources/identifiers/list){: target="_blank" } page. Look in the **`IDENTIFIER`** column to find `com.TEAMID.loopkit.LoopCaregiver`. The **`NAME`** might begin with an `XC` if you previously built with Xcode. However, the **`IDENTIFIER`** column value should match.
 
 | `NAME` | `IDENTIFIER` |
 |-------|------------|
@@ -312,7 +312,7 @@ This requires you to provide some information. Examine the table below for the b
 
 > If you build from a second or third `repository` for `Loop Follow`, the Bundle ID will have `.Second` or `.Third` at the end.
 
-1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps) to view your apps; log in if needed. 
+1. Open this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps){: target="_blank" } to view your apps; log in if needed. 
 
 1. If this App already exists, you can continue to [Create Certificates](#create-certificates)
 1. Click the Add Apps button or the blue "plus" icon and select New App as shown in the graphic below
@@ -399,7 +399,7 @@ Refer to the graphic below for the first four steps:
         * Create Certificates
         * Build Loop
 1. If the process appears to be happening without an error, go do something else for a while. The build should take about 20-30 minutes.
-1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps).
+1. Your app should eventually appear on [App Store Connect](https://appstoreconnect.apple.com/apps){: target="_blank" }.
 
 ## Add Users to *TestFlight* for App
 
@@ -424,7 +424,7 @@ Prerequisite: You need a personal *GitHub* account.
 In the instructions below, use your *GitHub* username instead of `my-name`.
 
 1. Follow the directions below to create a new *GitHub* organization account with a username of `my-name-org` (of course naming is up to you)
-    * There is documentation at this link, [New *GitHub* Organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch), or you can follow the bullets below
+    * There is documentation at this link, [New *GitHub* Organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch){: target="_blank" }, or you can follow the bullets below
     * Log into `my-name` and click on your icon (at upper right) and choose Settings
     * On the left side-bar, click on Organizations
     * In the new view, click on New Organization and choose Free for the plan by clicking on  `Create a free organization`.
@@ -511,7 +511,7 @@ You can delete the DIY repositories from your personal account
     * Select `Your Repositories`
     * Notice the github address now says `my-name` instead of `my-name-org`
     * Select the repository you wish to delete and follow these instructions
-    * [GitHub Docs: Delete a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository)
+    * [GitHub Docs: Delete a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/deleting-a-repository){: target="_blank" }
 
 
 #### Option 2: Disable Build Action
@@ -525,5 +525,5 @@ You can disable the build actions from the repositories in your personal account
     * Select `Your Repositories`
     * Notice the github address now says `my-name` instead of `my-name-org`
     * Select the repository you wish to disable build actions for and follow these instructions
-    * [GitHub Directions to Disable and Enable a Workflow](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow)
+    * [GitHub Directions to Disable and Enable a Workflow](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow){: target="_blank" }
     * It is the Build action that kicks off the update and build steps, so simply disabling the one action is sufficient

--- a/docs/gh-actions/gh-overview.md
+++ b/docs/gh-actions/gh-overview.md
@@ -55,7 +55,7 @@ This is a very long page because there are a lot of steps and each step is expla
 
 In addition to the webpage linked above, there is a narrated video of each step needed to build using a browser.
 
-* [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8)
+* [How to Build the *Loop* App With a Web Browser](https://www.youtube.com/watch?v=kiu5ho0MTW8){: target="_blank" }
 
 Click in the comments for a full index of topics.  If you have issues with a step, use the index to  advance to the relevant part of the video. Subtitles are  in English. You can choose a different language but the automatic translation feature may provide translations that are not completely accurate.
 

--- a/docs/gh-actions/gh-update.md
+++ b/docs/gh-actions/gh-update.md
@@ -65,12 +65,12 @@ Under ordinary circumstances, you do not *have to* rebuild or update your *Loop*
 
 ### Accept Agreements
 
-Sign in to your [Apple Developer account](https://developer.apple.com/account). If there are agreements you have not accepted, you will get errors when you try to Build that indicate your *Apple* <code>Secrets</code> are incorrect - that is very unlikely. You may also need to update your credit card information if it has changed, for example, if there is a new expiration date.
+Sign in to your [Apple Developer account](https://developer.apple.com/account){: target="_blank" }. If there are agreements you have not accepted, you will get errors when you try to Build that indicate your *Apple* <code>Secrets</code> are incorrect - that is very unlikely. You may also need to update your credit card information if it has changed, for example, if there is a new expiration date.
 
 * For an update, you do not need to modify the <code>FASTLANE_ISSUER_ID</code>, <code>FASTLANE_KEY_ID</code> or <code>FASTLANE_KEY</code>
 * Check your *Apple* Developer account for agreements, then continue
 
-If you need detailed instructions, click on this [<code>Apple Program License Agreement</code> Help Page](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement).
+If you need detailed instructions, click on this [<code>Apple Program License Agreement</code> Help Page](https://support.pushpay.com/s/article/Accepting-the-Apple-Program-License-Agreement){: target="_blank" }.
 
 * Accept the `Apple Program License Agreement` (only)
     * You do NOT need to accept anything related to the `Paid Applications Schedule Agreement`
@@ -104,7 +104,7 @@ If you need detailed instructions, click on this [<code>Apple Program License Ag
 
 #### Manual Steps to Renew Your `Distribution Certificate`
 
-1. Use this link to view your [Apple Developer Certificates](https://developer.apple.com/account/resources/certificates/list)
+1. Use this link to view your [Apple Developer Certificates](https://developer.apple.com/account/resources/certificates/list){: target="_blank" }
     * Carefully examine the `Type` column - do **not** delete a `Development Certificate`
     * Click each row that has a `Distribution Certificate` and revoke it
     * You will get an email informing you the certificate was revoked
@@ -232,7 +232,7 @@ This section covers two topics.
 
 ### Add Test Details
 
-About half an hour after the build action completes, the new build will appear in the TestFlight screen at this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps)
+About half an hour after the build action completes, the new build will appear in the TestFlight screen at this link: [App Store Connect / Apps](https://appstoreconnect.apple.com/apps){: target="_blank" }
 
 * Log in if needed
 * Select your *Loop* app
@@ -306,7 +306,7 @@ If your `Personal Access Token` has not expired but does not have the correct pe
 
 Click on the link to view your token and compare it to the graphic below.
 
-* [Link to access your *GitHub* `Personal Access Token`](https://github.com/settings/tokens)
+* [Link to access your *GitHub* `Personal Access Token`](https://github.com/settings/tokens){: target="_blank" }
 
 ![access token with correct permissions](img/gh-token-correct-permission.png){width="600"}
 {align="center"}
@@ -332,9 +332,9 @@ If your `Personal Access Token` has expired or has an expiration date, you can r
 !!! tip "Update new GH_PAT to <code>Secrets</code>"
     After you get your new token, immediately add it to your <code>Secrets</code> for any app you build with this method. You don't have to rebuild the app, but it's a good idea to at least run `Action 1. Validate Secrets` for each repository to make sure you did not make a mistake.
 
-You can regenerate your *GitHub* `Personal Access Token` at any time by clicking on the link below. (Right-click, control-click to open in a new browser tab.)
+You can regenerate your *GitHub* `Personal Access Token` at any time by clicking on the link below. (it will open in a new browser tab.)
 
-* [Link to access your *GitHub* Personal Access Token](https://github.com/settings/tokens)
+* [Link to access your *GitHub* Personal Access Token](https://github.com/settings/tokens){: target="_blank" }
 
 The `FastLane Access Token` is a clickable link.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ After building the *Loop* app:
 If you have never used the *Loop* app, click on links below for an introduction.
 
 !!! success "&nbsp;_<span translate="no">Loop</span>_&nbsp;Video"
-    * This [What is&nbsp;_<span translate="no">Loop</span>_](https://youtu.be/64qhgnmkyAE) video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf) was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
+    * This [What is&nbsp;_<span translate="no">Loop</span>_](https://youtu.be/64qhgnmkyAE){: target="_blank" } video with associated [pdf deck](http://www.loopandlearn.org/wp-content/uploads/2021/05/What-is-Loop.pdf){: target="_blank" } was created by the&nbsp;<span translate="no">Loop and Learn</span>&nbsp;team
     * Special thanks to Tina and Reese Hammer for the terrific video
     * Special thanks to Matthew Fouse for the generous use of his beautiful graphics
 

--- a/docs/intro/loopdocs-how-to.md
+++ b/docs/intro/loopdocs-how-to.md
@@ -6,27 +6,27 @@ Every tooltip definition is also found in the [Glossary](../faqs/glossary.md) - 
 
 ## How to Find Help
 
-Volunteers generously provide support for Loop via online platforms. You have a number of options for joining conversations on Loop and asking for help.  Links to the main platforms are listed below.  Non-US Loop users in Italy, Australia, and several other countries have also formed Facebook (FB) groups.
+Volunteers generously provide support for Loop via online platforms. You have several options for joining conversations on Loop and asking for help.  Links to the main platforms are listed below.  Non-US Loop users in Italy, Australia, and several other countries have also formed Facebook (FB) groups.
 
-* The [Looped Group](https://www.facebook.com/groups/TheLoopedGroup) on Facebook. Looped Group is the original FB group for DIY looping systems. There are lot of active members there with an excellent history of helping people.
+* The [Looped Group](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } on Facebook. Looped Group is the original FB group for DIY looping systems. There are a lot of active members there with an excellent history of helping people.
 * Loop and Learn is a community that provides Loop-centric information, a T1D Speaker Series covering many topics of general diabetes interest as well as Loop-specific chats, alerts whenever there is an update to iOS and Xcode, Quick Tips and articles written by mentors providing their Loop experience.
-    * [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN)
-    * [LoopandLearn Website](https://www.loopandlearn.org)
-    * [LoopandLearn YouTube Channel](https://youtube.com/loopandlearn)
-* The [LoopTips](https://loopkit.github.io/looptips/) website provides non-build information that is helpful once you are looping, e.g., how to print endo reports, find Loop data, deal with therapy settings changes, etc.
-* Many Loopers use a companion app called Nightscout. Nightscout help can be found in the [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud) Facebook group.
-* For those interested in what is coming next for Loop and those who prefer not to use Facebook, join [Loop Zulipchat](https://loop.zulipchat.com) and be sure to subscribe to all the streams or you'll miss some interesting conversations.
-* Loop has an instagram account @diy.loop where some updates are shared.
+    * [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN){: target="_blank" }
+    * [LoopandLearn Website](https://www.loopandlearn.org){: target="_blank" }
+    * [LoopandLearn YouTube Channel](https://youtube.com/loopandlearn){: target="_blank" }
+* The [LoopTips](https://loopkit.github.io/looptips/){: target="_blank" } website provides non-build information that is helpful once you are looping, e.g., how to print endo reports, find Loop data, deal with therapy settings changes, etc.
+* Many Loopers use a companion app called Nightscout. Nightscout help can be found in the [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud){: target="_blank" } Facebook group.
+* For those interested in what is coming next for Loop and those who prefer not to use Facebook, join [Loop Zulipchat](https://loop.zulipchat.com){: target="_blank" } and be sure to subscribe to all the streams or you'll miss some interesting conversations.
+* Loop has an Instagram account @diy.loop where some updates are shared.
 
 ### How to Ask for Help
 
 If you are having trouble building or using your Loop app, there are some important steps to get responses to your question, while also being considerate of our volunteers' time.
 
 1. Always search in **both** [LoopDocs](#website-search) and your favorite [support group](#how-to-find-help). 
-    * Confused on how to search in a Facebook group? [Here is a video](https://www.youtube.com/watch?v=_vSN6C-Uo04) to help.
-2.  If you use Facebook, click on the Featured posts (at top of page); many posts asking for help are already answered there.
+    * Confused about how to search in a Facebook group? [Here is a video](https://www.youtube.com/watch?v=_vSN6C-Uo04){: target="_blank" } to help.
+2.  If you use Facebook, click on the Featured posts (at the top of the page); many posts asking for help are already answered there.
 3.  Don't post a duplicate question in multiple groups (mentors monitor many groups). Only post to a different group if you have had no responses for several hours.
-4.  If a LoopDocs search, FB or zulipchat search, and a check of Looped Group featured posts pinned to top of the page haven't answered your question, then post for help. Review the [tips for how to post for help](../build/community.md) so that our volunteers get all the information they'll need to help you, without needing to ask 40 questions first.    
+4.  If a LoopDocs search, FB or Zulipchat search, and a check of Looped Group featured posts pinned to the top of the page haven't answered your question, then post for help. Review the [tips for how to post for help](../build/community.md) so that our volunteers get all the information they'll need to help you, without needing to ask 40 questions first.    
 5.  Leave your question posted even after you've gotten an answer, but edit the original post to add the word **RESOLVED** at the beginning of the original post. 
     * This helps other Loopers who have the same question
     * This helps mentors know they don't need to respond to help you
@@ -91,10 +91,10 @@ Please submit suggestions for updates and improvements to this documentation. Th
 
 ### Pull Requests and Issues
 
-If you decide to do a GitHub Pull Request (PR) or create an Issue, first look to see if someone has already opened a [PR](https://github.com/LoopKit/loopdocs/pulls) or [Issue](https://github.com/LoopKit/loopdocs/issues) on the topic so you don't create a duplicate.
+If you decide to do a GitHub Pull Request (PR) or create an Issue, first look to see if someone has already opened a [PR](https://github.com/LoopKit/loopdocs/pulls){: target="_blank" } or [Issue](https://github.com/LoopKit/loopdocs/issues){: target="_blank" } on the topic so you don't create a duplicate.
 
 * If a PR or Issue on the topic is open, feel free to add your comments (don't be shy), but please don't create a duplicate
-* If a PR doesn't exist, watch this [LoopDocs Pull Request video](https://youtu.be/6qSppvgGxpg) on how to create one (it's easy, video is less than 5 minutes)
+* If a PR doesn't exist, watch this [LoopDocs Pull Request video](https://youtu.be/6qSppvgGxpg){: target="_blank" } on how to create one (it's easy, video is less than 5 minutes)
 * If your Issue is new, please add it by clicking on the `New Issue` button
     * Give the Issue a descriptive title
     * Indicate which page or pages need updating , along with a brief description of the problem(s)
@@ -102,6 +102,6 @@ If you decide to do a GitHub Pull Request (PR) or create an Issue, first look to
 ### Facebook or Zulipchat
 Helpful tips for providing LoopDocs feedback through Facebook and/or Zulipchat:
 
-* In [Looped Group](https://www.facebook.com/groups/TheLoopedGroup) - make sure your post is clear that you have a comment about LoopDocs in particular.
-* In Loop Zulipchat, please use the [documentation stream, Loopdocs Issue](https://loop.zulipchat.com/#narrow/stream/270362-documentation/topic/Loopdocs.20Issue) channel.
+* In [Looped Group](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } - make sure your post is clear that you have a comment about LoopDocs in particular.
+* In Loop Zulipchat, please use the [documentation stream, Loopdocs Issue](https://loop.zulipchat.com/#narrow/stream/270362-documentation/topic/Loopdocs.20Issue){: target="_blank" } channel.
 

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -14,7 +14,7 @@ The&nbsp;<span translate="no">LoopDocs</span>&nbsp;website is organized as follo
 * [Operate](../operation/loop/open-loop.md): How to use the&nbsp;<span translate="no">Loop</span>&nbsp;app
 * [Troubleshoot](../troubleshooting/overview.md): What to do if you're having trouble with the&nbsp;<span translate="no">Loop</span>&nbsp;app
 * [Version](../version/overview-version.md): Information about&nbsp;<span translate="no">Loop</span>&nbsp;versions, code customization and development
-* [<span translate="no">Nightscout</span>](../nightscout/overview.md): <span translate="no">Loop</span>-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/) is an open-source cloud application used by people with diabetes and their caregivers
+* [<span translate="no">Nightscout</span>](../nightscout/overview.md): <span translate="no">Loop</span>-specific&nbsp;<span translate="no">Nightscout</span>&nbsp;details; [<span translate="no">Nightscout</span>](https://nightscout.github.io/){: target="_blank" } is an open-source cloud application used by people with diabetes and their caregivers
     * [Remote Overview](../nightscout/remote-overview.md): Overview on issuing commands remotely to a&nbsp;<span translate="no">Loop</span>&nbsp;app using&nbsp;<span translate="no">Nightscout</span>&nbsp;and Apple Push Notifications
     * [Loop Caregiver](../nightscout/loop-caregiver.md): Companion app useful for remote commands
 * [FAQs](../faqs/overview-faqs.md): Pages with safety tips, frequently asked questions and the Glossary
@@ -61,11 +61,11 @@ Some techniques are specific to&nbsp;<span translate="no">Loop</span>, but the g
 Here are development history links to other resources for you to explore.
 
 * The early history of&nbsp;<span translate="no">Loop</span>&nbsp;development:
-    * [History of&nbsp;<span translate="no">Loop</span>&nbsp;and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805), written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Nate Racklyeft
+    * [History of&nbsp;<span translate="no">Loop</span>&nbsp;and&nbsp;<span translate="no">LoopKit</span>](https://medium.com/@loudnate/the-history-of-loop-and-loopkit-59b3caf13805){: target="_blank" }, written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Nate Racklyeft
 
 * The early days and the many advances brought about by the `#We Are Not Waiting` diabetes community:
-    * [The Artificial Pancreas Book](https://www.artificialpancreasbook.com/) written by Dana Lewis and check out her website [DIYPS](https://diyps.org).
+    * [The Artificial Pancreas Book](https://www.artificialpancreasbook.com/){: target="_blank" } written by Dana Lewis and check out her website [DIYPS](https://diyps.org){: target="_blank" }.
 
 * How the Omnipod Eros pods were cracked to work with&nbsp;<span translate="no">Loop</span>:
-    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Pete Schwamb
-    * [Deep Dip Teardown of Tubeless Insulin Pump](https://arxiv.org/ftp/arxiv/papers/1709/1709.06026.pdf) by Sergei Skorobogatov
+    * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2){: target="_blank" } written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Pete Schwamb
+    * [Deep Dip Teardown of Tubeless Insulin Pump](https://arxiv.org/ftp/arxiv/papers/1709/1709.06026.pdf){: target="_blank" } by Sergei Skorobogatov

--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -17,7 +17,7 @@ Loop can be connected to the following CGMs:
         * Medtronic Pump only
         * **You must [add pump](add-pump.md) first**
             * If Enlite is connected to Medtronic pump and that pump is connected to Loop, then an option for Enlite shows up when choosing a CGM, _not visible in graphic below_
-    * Libre: [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop) was added to the dev branch (and thus will be supported in the next release of Loop)
+    * Libre: [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" } was added to the dev branch (and thus will be supported in the next release of Loop)
         * Only some Libre sensors are supported; some have encryption that limits DIY use
         * No details for using Libre will show up on this page until the next release - please read [Build Loop-dev](../version/build-dev.md) and follow the links to understand what you are doing if you choose a development branch
 * CGMs that require active internet (WiFi or Cell)
@@ -164,7 +164,7 @@ In addition to the risks of missing data if the internet is not reliable, you mu
 
     If you decide to use Nightscout as a CGM source, make sure the data stored in Nightscout is reliable. If the app you choose uploads bad results to Nightscout, you don't want Loop to use that bad data.
     
-    _Sensors that can be added to Nightscout via other apps include Dexcom, some Libre and some Medtronic sensors. Please refer to [Nightscout Docs: Configure your Uploader](https://nightscout.github.io/uploader/setup/)._
+    _Sensors that can be added to Nightscout via other apps include Dexcom, some Libre and some Medtronic sensors. Please refer to [Nightscout Docs: Configure your Uploader](https://nightscout.github.io/uploader/setup/){: target="_blank" }._
     
     There are third party apps that bring Libre data to your Loop phone and there are customization instructions starting at [Libre Support for Loop 3.2.x Code](../version/code-custom-edits.md#libre-support-for-loop-32x-code) that explain how to modify Loop 3 to use one of those apps. Please use these steps to get a version of Loop that does not rely on internet access to work.
     

--- a/docs/loop-3/add-pump.md
+++ b/docs/loop-3/add-pump.md
@@ -128,7 +128,7 @@ At this point - you should hit `Cancel` (upper right of screen) and review the [
 
     If you are not ready to fill and attach a pod with insulin, try filling a pod with water and let it drip into a ziplock bag to test running Loop on the pod. (Be sure the pod is not near anything when you hit "Insert Cannula".)
 
-    You may enjoy reading [Rufus the Bear](https://www.loopandlearn.org/sl-rufus/).
+    You may enjoy reading [Rufus the Bear](https://www.loopandlearn.org/sl-rufus/){: target="_blank" }.
 
 ## Medtronic
 

--- a/docs/loop-3/features.md
+++ b/docs/loop-3/features.md
@@ -148,11 +148,11 @@ The two graphics below are examples of manual bolus screens.
 
 Loop 3 has a Remote Carb and Remote Bolus feature to enable remote caregivers to better assist the person who needs support managing with Loop.
 
-The author of this feature wrote this [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM) documentation. Please read carefully and use with the appropriate level of caution.
+The author of this feature wrote a documentation [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM){: target="_blank" } documentation. Please read carefully and use with the appropriate level of caution.
 
 !!! warning "WARNING"
 
-    You will be using this feature at  your own risk, like any other Loop code you build. It is very important you completely read and re-read the [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM) before getting started. 
+    You will be using this feature at  your own risk, like any other Loop code you build. It is very important you completely read and re-read the [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM){: target="_blank" } before getting started. 
     
     There are validation and troubleshooting steps for each section of the guide. 
     

--- a/docs/loop-3/features.md
+++ b/docs/loop-3/features.md
@@ -148,7 +148,7 @@ The two graphics below are examples of manual bolus screens.
 
 Loop 3 has a Remote Carb and Remote Bolus feature to enable remote caregivers to better assist the person who needs support managing with Loop.
 
-The author of this feature wrote a documentation [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM){: target="_blank" } documentation. Please read carefully and use with the appropriate level of caution.
+The author of this feature wrote this [Remote Carb/Bolus Guide](https://docs.google.com/document/d/1wPpCljo9NuwllltjhImf7YZReIgqP9yF05PN7E6hphM){: target="_blank" } documentation. Please read carefully and use with the appropriate level of caution.
 
 !!! warning "WARNING"
 

--- a/docs/loop-3/omnipod.md
+++ b/docs/loop-3/omnipod.md
@@ -10,7 +10,7 @@ The information and user interface for Omnipod (Eros) and DASH pods is the same,
     If you overfill the pods, you may get a pod fault right after priming.
 
 !!! info "Pod Filling and Insertion"
-    The Pod filling and insertion instructions are the same with the Loop app as they are for the PDM.  These videos: [Filling a Pod with Insulin](https://youtu.be/qJBN6rlvn_Y) and [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI), may be useful.
+    The Pod filling and insertion instructions are the same with the Loop app as they are for the PDM.  These videos: [Filling a Pod with Insulin](https://youtu.be/qJBN6rlvn_Y){: target="_blank" } and [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI){: target="_blank" }, may be useful.
 
     For DASH Pods:
 
@@ -36,13 +36,13 @@ Graphic below shows the Pair Pod screen for Omnipod (left) and Omnipod DASH (rig
 
     It makes sure you are really ready to do the insertion.
 
-    Please watch the [video of the *Loop* app screen when pairing a DASH pod](https://drive.google.com/file/d/1mN5s8-oorvoa-gbjAaYbnUnl_-vvuhNC/view?usp=sharing) to see the full process before pairing your first pod. In this video, once the pod starts priming, you may want to skip forward (it takes about a minute to prime).
+    Please watch the [video of the *Loop* app screen when pairing a DASH pod](https://drive.google.com/file/d/1mN5s8-oorvoa-gbjAaYbnUnl_-vvuhNC/view?usp=sharing){: target="_blank" } to see the full process before pairing your first pod. In this video, once the pod starts priming, you may want to skip forward (it takes about a minute to prime).
 
 !!! danger "Keep Gear Close"
-    * Make sure phone (and RileyLink if using one) are close to the pod before you tap Pair Pod
+    * Make sure the phone (and RileyLink if using one) are close to the pod before you tap Pair Pod
         * Do NOT move devices away from the pod until you see the blue check mark and the `Continue` button on the phone screen
         * You can then move away to attach the pod to your body
-    * Make sure phone (and RileyLink if using one) are close to the pod before you tap `Insert Cannula`
+    * Make sure the phone (and RileyLink if using one) are close to the pod before you tap `Insert Cannula`
         * Do NOT move devices away from the pod until you see the blue check mark and the `Continue` button on the phone screen
 
 ### Insert Cannula Slider

--- a/docs/loop-3/onboarding.md
+++ b/docs/loop-3/onboarding.md
@@ -41,7 +41,7 @@ Each onboarding step is presented in order on this page. Please follow this docu
 !!! abstract "Settings Help"
     Please stay in Open Loop until you verify that your settings (basal rates, insulin sensitivity, carb ratio, etc) are properly adjusted to work with the Loop algorithm. You may need time to evaluate and perhaps identify settings to adjust.
 
-    If you need help with your settings adjustment, you may find useful tips in the companion website, LoopTips at this link: [LoopTips: Settings](https://loopkit.github.io/looptips/settings/settings/) tab.
+    If you need help with your settings adjustment, you may find useful tips in the companion website, LoopTips at this link: [LoopTips: Settings](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" } tab.
 
 ### Welcome to Loop
 
@@ -239,9 +239,9 @@ If you will be connecting a Medtronic pump after onboarding:
 
 #### Maximum Basal Rate
 
-[Maximum Basal Rate](therapy-settings.md#maximum-basal-rate) will cap the the maximum temporary basal rate that Loop issues to meet your correction range when you are in Closed Loop with a [Dosing Strategy](settings.md#dosing-strategy) of Temp Basal Only.
+[Maximum Basal Rate](therapy-settings.md#maximum-basal-rate) will cap the maximum temporary basal rate that Loop issues to meet your correction range when you are in Closed Loop with a [Dosing Strategy](settings.md#dosing-strategy) of Temp Basal Only.
 
-For safety, new loopers should start with max basal set 2-3 times their highest scheduled basal rate. If you choose 2 times your highest scheduled basal, you may get a message informing you this is "lower than typical." Ignore this to put safety first as a new looper.
+For safety, new loopers should start with a max basal set 2-3 times their highest scheduled basal rate. If you choose 2 times your highest scheduled basal, you may get a message informing you this is "lower than typical." Ignore this to put safety first as a new looper.
 
 Experienced loopers typically set their maximum basal rate around 3-4 times their highest scheduled basal rate. Loop 3 app will not allow you to exceed 6.4 times your highest scheduled rate.
 
@@ -260,9 +260,9 @@ Your [Insulin Sensitivity Factor](therapy-settings.md#insulin-sensitivities) is 
 * At least one insulin sensitivity factor (ISF) must be entered
 * A daily schedule with varying ISF can be entered
 
-Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/) your ISF settings for accuracy. Insulin sensitivities can change for many reasons including waiting too long to change your infusion set. Loop will not auto-detect changes in ISF.
+Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" } your ISF settings for accuracy. Insulin sensitivities can change for many reasons including waiting too long to change your infusion set. Loop will not auto-detect changes in ISF.
 
-Incorrectly set ISF is a common cause of roller coaster glucoses for new Loop users. You may need to raise (increase) your ISF value/number to help smooth a roller coaster glucose trend. You can read about that topic more over in LoopTips [here](https://loopkit.github.io/looptips/settings/settings/#insulin-sensitivity-factor).
+Incorrectly set ISF is a common cause of roller coaster glucoses for new Loop users. You may need to raise (increase) your ISF value/number to help smooth a roller coaster glucose trend. You can read about that topic more over in LoopTips [here](https://loopkit.github.io/looptips/settings/settings/#insulin-sensitivity-factor){: target="_blank" }.
 
 
 ### Therapy Settings Review

--- a/docs/loop-3/services.md
+++ b/docs/loop-3/services.md
@@ -14,7 +14,7 @@ The services are added by tapping on the &plus; sign and choosing the service fr
 
 ## Nightscout
 
-There is a whole section in LoopDocs about Nightscout. Please follow this link to the [Using Nightscout with Loop](../nightscout/overview.md) section of LoopDocs. That also has the links you might need to the official [Nightscout Documentation](https://nightscout.github.io/) (different website).
+There is a whole section in LoopDocs about Nightscout. Please follow this link to the [Using Nightscout with Loop](../nightscout/overview.md) section of LoopDocs. That also has the links you might need to the official [Nightscout Documentation](https://nightscout.github.io/){: target="_blank" } (different website).
 
 If you have an existing Nightscout site, it's still a good idea to review that section, but here's the quick summary of how to add your Site URL and API_SECRET to have your Loop data transmitted to your Nightscout site. If you can’t remember your API_SECRET, it can be found under Settings, Reveal Config Vars for Heroku sites (or Application Settings, Connection Strings for Azure sites).
 
@@ -39,11 +39,11 @@ With Loop 3.2.x and newer versions, data can be directly uploaded from Loop to T
         * Even if you turn off access of the Tidepool Mobile uploader to Apple Health, there will still be 7-days of overlap with Loop that will display as duplicated data (think 2x carbs, insulin etc in your Tidepool Web display) when you enable Loop Tidepool service as the uploader
 
 
-Please refer to the [LoopTips: Data: Tidepool](https://loopkit.github.io/looptips/data/tidepool/) page for more information about Tidepool. The Tidepool display browser is undergoing some updates; the information on these pages will be updated after changes happen.
+Please refer to the [LoopTips: Data: Tidepool](https://loopkit.github.io/looptips/data/tidepool/){: target="_blank" } page for more information about Tidepool. The Tidepool display browser is undergoing some updates; the information on these pages will be updated after changes happen.
 
 The Tidepool Mobile app serves 2 purposes:
 
-1.  Allow notes to be recorded with associated glucose, carbs and insulin record for a snap shot in time
+1.  Allow notes to be recorded with associated glucose, carbs, and insulin record for a snap shot in time
 1.  Upload Loop data stored in Health to the Tidepool database for display in their browser tool; when the Connect to Health feature is enabled
 
 With the new Loop Service to upload to Tidepool, additional information that is not stored in Health can be made available to Tidepool. However, this is a work in progress.
@@ -67,14 +67,14 @@ Tidepool Support is available to help troubleshoot issues or answer questions ab
 
 ## Loggly
 
-[Loggly](https://loggly.com) is a free logging service. If you sign up for an account, you'll need to go under Source Setup and then Customer Tokens. Copy and paste your customer token into your Loop App settings for Loggly.
+[Loggly](https://loggly.com){: target="_blank" } is a free logging service. If you sign up for an account, you'll need to go under Source Setup and then Customer Tokens. Copy and paste your customer token into your Loop App settings for Loggly.
 
 ![img/loggly.png](img/loggly.png){width="500"}
 {align="center"}
 
 ## Amplitude
 
-[Amplitude](https://amplitude.com) is a remote event monitoring service and can be used to quickly identify errors and events with Loop. Amplitude stores the events and allows you to view those events as points in time. To retrieve the details of the events you will need to look at corresponding mLab data entries to get a complete picture of the issues. If you sign up for a free account with Amplitude, you will be given an API Key that you can enter here to have Loop integration setup.
+[Amplitude](https://amplitude.com){: target="_blank" } is a remote event monitoring service and can be used to quickly identify errors and events with Loop. Amplitude stores the events and allows you to view those events as points in time. To retrieve the details of the events you will need to look at corresponding mLab data entries to get a complete picture of the issues. If you sign up for a free account with Amplitude, you will be given an API Key that you can enter here to have Loop integration setup.
 
 ![img/amplitude.png](img/amplitude.png){width="500"}
 {align="center"}

--- a/docs/loop-3/settings.md
+++ b/docs/loop-3/settings.md
@@ -36,7 +36,7 @@ Based on this prediction, Loop calculates a modification to insulin dosing to br
 * When in Open Loop, no automated action is taken.
 * When in Closed Loop, automated action is taken based on the selected Dosing Strategy.
 
-If you find this confusing, read how to [Think Like a Loop](https://loopkit.github.io/looptips/how-to/think-like-loop/) on the LoopTips website.
+If you find this confusing, read how to [Think Like a Loop](https://loopkit.github.io/looptips/how-to/think-like-loop/){: target="_blank" } on the LoopTips website.
 
 ## Dosing Strategy
 

--- a/docs/nightscout/loop-caregiver.md
+++ b/docs/nightscout/loop-caregiver.md
@@ -28,7 +28,7 @@ The *Loop Caregiver* app is under development to make remote commands easier to 
     * Please take the time to update your *Nightscout* site to `master`
     * *Nightscout* 14.2.6 was released 30-Sep-2022 as `Classic Liquorice`
 
-If you use *Loop Caregiver*, please join [*Loop Caregiver* App](https://loop.zulipchat.com/#narrow/stream/358458-Loop-Caregiver-App) *Zulipchat* stream.
+If you use *Loop Caregiver*, please join [*Loop Caregiver* App](https://loop.zulipchat.com/#narrow/stream/358458-Loop-Caregiver-App){: target="_blank" } *Zulipchat* stream.
 
 **As with all development code, monitor *Zulipchat* for announcements, report any problems you experience, be prepared to build frequently, and pay attention.**
 

--- a/docs/nightscout/new-user.md
+++ b/docs/nightscout/new-user.md
@@ -15,14 +15,14 @@
 
 ## Setup Nightscout
 
-Please visit [Nightscout: Documentation](https://nightscout.github.io) to read about Nightscout. There are several options, mentioned in that documentation, for setting up your Nightscout site.
+Please visit [Nightscout: Documentation](https://nightscout.github.io){: target="_blank" } to read about Nightscout. There are several options, mentioned in that documentation, for setting up your Nightscout site.
 
 * You can choose one of many free (except for your time) DIY methods
 * You can choose one of many DIY methods where you pay a monthly fee for data storage
 * You can choose a managed site (for a monthly fee) that creates your site, keeps the software up to date and provides data storage
 * Social Media sites for announcements, help and discussion:
-    * [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud) Facebook group
-    * [Nightscout Discord Channel](https://discord.gg/zg7CvCQ)
+    * [CGM in the Cloud](https://www.facebook.com/groups/CGMinthecloud){: target="_blank" } Facebook group
+    * [Nightscout Discord Channel](https://discord.gg/zg7CvCQ){: target="_blank" }
 
 
 Once your Nightscout site is operational and you've read the information about using your site, return to LoopDocs to follow the directions on the [LoopDocs: Nightscout with Loop](update-user.md) page.

--- a/docs/nightscout/ns-crossref.md
+++ b/docs/nightscout/ns-crossref.md
@@ -2,34 +2,34 @@
 
 A number of pages that used to be in LoopDocs have been moved to the Nightscout documentation. To prevent duplication and inconsistency, those pages have been removed from LoopDocs.  A cross-reference to the Nightscout pages is provided below.
 
-* You can always use the search function of [Nightscout: Documentation](https://nightscout.github.io/) to find any topic
+* You can always use the search function of [Nightscout: Documentation](https://nightscout.github.io/){: target="_blank" } to find any topic
 
 ## Remote Notifications
 
 While the Loop app sends notifications locally on the Loop user's iPhone, parents and caregivers may want those messages on their phones, too.  We can achieve this functionality through a combination of Nightscout, IFTTT, Google, and Pushover.
 
 * Please see
-      * [Nightscout: Configurations: Pushover](https://nightscout.github.io/nightscout/setup_variables/#pushover)
-      * [Nightscout: Remote Notifications](https://nightscout.github.io/nightscout/pushover/)
+      * [Nightscout: Configurations: Pushover](https://nightscout.github.io/nightscout/setup_variables/#pushover){: target="_blank" }
+      * [Nightscout: Remote Notifications](https://nightscout.github.io/nightscout/pushover/){: target="_blank" }
 
 ### Loop Follow
 
 Loop Follow was created by Jon Fawcett who took ideas from multiple other apps to create a single app to assist in his caregiving role. It is popular with Loopers who like the display and notifications as well as Loop caregivers. It can work with just the Dexcom Share credentials and/or the Nightscout URL and allows for easy customization of alerts and alarms. Jon handed over maintenance of this app to the Loop and Learn team.
 
 * Please see
-    * [Loop and Learn: Loop Follow page](https://www.loopandlearn.org/loop-follow)
-    * [Loop and Learn Facebook group](https://www.facebook.com/groups/loopandlearn)
+    * [Loop and Learn: Loop Follow page](https://www.loopandlearn.org/loop-follow){: target="_blank" }
+    * [Loop and Learn Facebook group](https://www.facebook.com/groups/loopandlearn){: target="_blank" }
 
 ## Pebble Watch
 
 LoopDocs had a page specifically about the Pebble Watchface called `SkyLoop Predict`, which is no longer being supported. The Nightscout Documentation provides information about many methods for displaying your Nightscout data on a variety of wearable devices.
 
 * Please see
-    * [Nightscout: On Your Watch](https://nightscout.github.io/nightscout/wearable/)
+    * [Nightscout: On Your Watch](https://nightscout.github.io/nightscout/wearable/){: target="_blank" }
 
 ## Reports
 
 Nightscout offers some fantastic data-crunching report tools.
 
 * Please see
-    * [Nightscout: Reports](https://nightscout.github.io/nightscout/reports/)
+    * [Nightscout: Reports](https://nightscout.github.io/nightscout/reports/){: target="_blank" }

--- a/docs/nightscout/overview.md
+++ b/docs/nightscout/overview.md
@@ -13,9 +13,9 @@ For caregivers, *Nightscout* enables remote monitoring and even the ability to i
         * Overrides can be enabled and disabled
         * Carbs can be entered
         * Boluses can be commanded
-        * *Loop Caregiver* app (under development, iOS only) enables the following from the caregiver phone
+        * *Loop Caregiver* app (under development, iOS only) enables the following from the caregiver's phone
             * monitor *Loop*
-            * issue remote commands for carbs, bolus and overrides
+            * issue remote commands for carbs, bolus, and overrides
 
     If you plan to use remote commanding with *Nightscout*, please read these links with additional information:
 
@@ -25,7 +25,7 @@ For caregivers, *Nightscout* enables remote monitoring and even the ability to i
 
 *Nightscout* is useful for many who use *Loop*. Adults who take care of themselves find the reports and analysis methods from *Nightscout* provide effective tools to monitor their settings and provide reports for their health care provider. It also stores *Loop* configurations so they can be reviewed. With *Loop 3*, the saved *Nightscout* profiles can be downloaded to a new *Loop* installation or a new phone for quick onboarding, should you ever need to start fresh.
 
-Setting up a *Nightscout* site is described in a separate web site: [*Nightscout*: Documentation](https://nightscout.github.io).
+Setting up a *Nightscout* site is described in a separate web site: [*Nightscout*: Documentation](https://nightscout.github.io){: target="_blank" }.
 
 There are *Nightscout* apps in your iPhone App Store that allow you to view the *Nightscout* site after you've configured it, or you can use a web browser to view the data. The app alone is not enough - you need to follow the steps to configure your own *Nightscout* site and obtain your specific *Nightscout* URL.
 
@@ -35,29 +35,29 @@ There are *Nightscout* apps in your iPhone App Store that allow you to view the 
 
 ## *Nightscout* Documentation
 
-There used to be a lot of *Nightscout* information found only in *LoopDocs*, but that was transferred and subsequently updated in [*Nightscout*: Documentation](https://nightscout.github.io). The information that remains in *LoopDocs* about *Nightscout* is *Loop* specific. So you may be jumping back and forth between the two sets of documents.
+There used to be a lot of *Nightscout* information found only in *LoopDocs*, but that was transferred and subsequently updated in [*Nightscout*: Documentation](https://nightscout.github.io){: target="_blank" }. The information that remains in *LoopDocs* about *Nightscout* is *Loop* specific. So you may be jumping back and forth between the two sets of documents.
 
 !!! info ""
 
     * If you see the *Nightscout* Owl logo in upper left you are in the *Nightscout* website
     * If you see the *LoopDocs* green-loop logo in upper left you are in the *LoopDocs* website
     * While in the *Nightscout* tab of *LoopDocs*, most links have a *Nightscout* or *LoopDocs* in the link name
-    * Suggestion: open the [*Nightscout*: Documentation](https://nightscout.github.io) in a separate tab or window of your browser for easy access to both websites
+    * Suggestion: open the [*Nightscout*: Documentation](https://nightscout.github.io){: target="_blank" } in a separate tab or window of your browser for easy access to both websites
 
 
 ## *Nightscout* with *Loop*
 
-This page provides general discussion about the *Nightscout* display, as well as some *Loop*-specific display information. Over time, interactions between *Loop* and *Nightscout* were improved. The information on this page has been updated for *Loop 3* and *Nightscout* version 14.2.6 (or later). Older versions may exhibit some differences in display of *Loop* information on the *Nightscout* site.
+This page provides a general discussion about the *Nightscout* display, as well as some *Loop*-specific display information. Over time, interactions between *Loop* and *Nightscout* were improved. The information on this page has been updated for *Loop 3* and *Nightscout* version 14.2.6 (or later). Older versions may exhibit some differences in the display of *Loop* information on the *Nightscout* site.
 
 ### *Loop* Uploads to *Nightscout*
 
 The *Nightscout* display updates when the *Loop* phone is connected to the internet via WiFi or cellular service. When the uploads stop, the *Loop* *pill* becomes "stale" (cannot open it) after 15 minutes.
 
-*Pills* are the little information boxes. They are [*Nightscout*: Plugins](https://nightscout.github.io/nightscout/setup_variables/#plugins) that must be enabled with configuration variables and then the display for each *pill* can be turned on or off within your *Nightscout* site.
+*Pills* are the little information boxes. They are [*Nightscout*: Plugins](https://nightscout.github.io/nightscout/setup_variables/#plugins){: target="_blank" } that must be enabled with configuration variables and then the display for each *pill* can be turned on or off within your *Nightscout* site.
 
 If upload to *Nightscout* is interrupted, *Loop 3* stores up to 7 days of *Nightscout* information in a local buffer on the phone, and will attempt to upload later when access is restored. Once access is restored, a stale *Loop* Pill may require 15 minutes before it will open to display additional *Loop* information.
 
-The Carb *pill* on the *Nightscout* site is populated by *Loop* when *Loop* is actively uploading to *Nightscout* - but it may lag the value displayed in the *Loop* *pill* by one loop cycle and it will display 0 COB within 5 to 10 minutes if upload is interrupted. In other words, if the COB *pill* shows 0 unexpectedly and *Loop* *pill* is active, you can believe the value shown in the *Loop* *pill*.
+The Carb *pill* on the *Nightscout* site is populated by *Loop* when *Loop* is actively uploading to *Nightscout* - but it may lag the value displayed in the *Loop* *pill* by one loop cycle and it will display 0 COB within 5 to 10 minutes if the upload is interrupted. In other words, if the COB *pill* shows 0 unexpectedly and *Loop* *pill* is active, you can believe the value shown in the *Loop* *pill*.
 
 ### *Loop 2* Red *Loop* Warning
 
@@ -67,8 +67,8 @@ Step 1: Remove *Nightscout* URL from *Loop* Services
 
 Step 2: Figure out why the *Nightscout* site is not accepting uploads from *Loop* and fix that problem.
 
-* [*Nightscout*: Troubleshooting](https://nightscout.github.io/troubleshoot/troubleshoot)
-* [*Nightscout*: Database Management](https://nightscout.github.io/nightscout/admin_tools/#database-maintenance)
+* [*Nightscout*: Troubleshooting](https://nightscout.github.io/troubleshoot/troubleshoot){: target="_blank" }
+* [*Nightscout*: Database Management](https://nightscout.github.io/nightscout/admin_tools/#database-maintenance){: target="_blank" }
 
 Step 3: Add *Nightscout* URL to *Loop* Services
 

--- a/docs/nightscout/remote-commands.md
+++ b/docs/nightscout/remote-commands.md
@@ -239,14 +239,14 @@ If you want to make your life SUPER AMAZING, check out using the iPhone's Shortc
 
 Click these links on your iPhone and you'll be prompted to download the premade shortcuts (assuming you open the links in Safari browser on iPhone):
 
-[Comprehensive&nbsp;_<span translate="no">Loop</span>_&nbsp;Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut)
+[Comprehensive&nbsp;_<span translate="no">Loop</span>_&nbsp;Shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop.shortcut){: target="_blank" }
  *includes Set Remote Override, Cancel Override, Loop Troubleshooting Tips, Quick Text options, Manual BG entry, Bookmarks to websites, etc.*
 
 And if you want to save one click to get to these one functions more directly: these shortcuts are simplified to offer only one function:
 
-[Set Remote Override only shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop Remote Overrides.shortcut)
+[Set Remote Override only shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Loop Remote Overrides.shortcut){: target="_blank" }
 
-[<span>Cancel Override</span>&nbsp; only shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Cancel Override.shortcut)
+[<span>Cancel Override</span>&nbsp; only shortcut](https://github.com/LoopKit/Loop/raw/4699417/Shortcuts/Cancel Override.shortcut){: target="_blank" }
 
 !!! note "A couple notes about these shortcuts:"
     You need to open those links in the *Safari* browser on your iPhone. A confirmation will show to initiate the download.
@@ -263,6 +263,6 @@ And if you want to save one click to get to these one functions more directly: t
 If you want to walk uphill both ways in the snow carrying bags of uneven groceries, you can also set overrides remotely by using If This, Then That (IFTTT) integration. By using IFTTT, you can have single button presses on your phone that will set an override, log a cannula change, log a sensor change and much more.
 
 * Please see
-    * [Nightscout: Configurations: IFTTT Maker](https://nightscout.github.io/nightscout/setup_variables/#ifttt-maker)
-    * [Nightscout: IFTTT](https://nightscout.github.io/nightscout/ifttt/)
+    * [Nightscout: Configurations: IFTTT Maker](https://nightscout.github.io/nightscout/setup_variables/#ifttt-maker){: target="_blank" }
+    * [Nightscout: IFTTT](https://nightscout.github.io/nightscout/ifttt/){: target="_blank" }
 

--- a/docs/nightscout/remote-config.md
+++ b/docs/nightscout/remote-config.md
@@ -22,7 +22,7 @@ After you complete the configuration, read the entire [Remote Commands](remote-c
     * There are many choices for building your own or paying someone to build a *Nightscout* site
         * The directions for only one of the options is documented on this page
         * Use that as a guide for your site
-    * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)
+    * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table){: target="_blank" }
         * **Warning: examine the `Loop remote carbs/bolus` row: subscription refers to a monthly fee**
         * If a green check is missing, it might just be too new for evaluation
 
@@ -32,7 +32,7 @@ There are several options to pay for a turn-key *Nightscout* service.
 
 * In order to enable remote commanding, your *Nightscout* site must be configured with information associated with the *Apple Developer ID* used to build the *Loop* app
     * Most *Nightscout* options allow you full access to your *Nightscout* configuration variables so you can add the required information
-* Please check out [*Nightscout*: New User](https://nightscout.github.io/nightscout/new_user/) for up-to-date information about your *Nightscout* options
+* Please check out [*Nightscout*: New User](https://nightscout.github.io/nightscout/new_user/){: target="_blank" } for up-to-date information about your *Nightscout* options
     * If you use the wizard, you can see more options when you select No to the question about contributing to research and development
     * If you choose *T1Pal* and want to use remote commands, you must also purchase your *Loop* app from them for an additional monthly fee - contact *T1Pal* for details
 
@@ -62,7 +62,7 @@ The step is required for the *Loop* app to give permissions to your *Nightscout*
 !!! info "Reminder"
     This only works with the **paid** Apple Developer ID.
 
-1. To get started, go to the `Keys` section under Apple Developer's [`Certificates, Identifiers & Profiles`](https://developer.apple.com/account/resources/authkeys/list) and login with the *Apple ID* associated with your developer team that you used to build the *Loop* app.
+1. To get started, go to the `Keys` section under Apple Developer's [`Certificates, Identifiers & Profiles`](https://developer.apple.com/account/resources/authkeys/list){: target="_blank" } and login with the *Apple ID* associated with your developer team that you used to build the *Loop* app.
 2. If not already open in your browser (compare with the below screenshot), 
     - Click on **`Keys`** (located in the left-hand column). 
     - Either click on the blue **`Create a new key`** button **OR** the plus button (<font color="#2997FF">:material-plus-circle:</font>)  to add a new key.
@@ -107,15 +107,15 @@ You'll need to make sure your *Nightscout* site version is version `13.0.1` or n
      - **Scroll** to the very bottom of this menu.
      - The **version** is located in the **`About`** section after the `Settings` section, (below the `Save` button).
 
-This link should be used if you want to [Nightscout: Update](https://nightscout.github.io/update/update/) your *Nightscout* site.
+This link should be used if you want to [Nightscout: Update](https://nightscout.github.io/update/update/){: target="_blank" } your *Nightscout* site.
 
 !!! note "Note for *Google Cloud* Users"
-    The [*Nightscout* with *Google Cloud*](https://navid200.github.io/xDrip/docs/Nightscout/GoogleCloud.html) instructions include information about updating your site.  
+    The [*Nightscout* with *Google Cloud*](https://navid200.github.io/xDrip/docs/Nightscout/GoogleCloud.html){: target="_blank" } instructions include information about updating your site.  
     Scroll down to the line (on that page) that says `Update Nightscout`.
 
 ### Add APN Variables to *Nightscout*
 
-In order to use remote overrides, you must add a couple of new variables. If you don't know how to update your *Nightscout* configuration, review [Nightscout: Setup Variables](https://nightscout.github.io/nightscout/setup_variables/) and then come back.
+In order to use remote overrides, you must add a couple of new variables. If you don't know how to update your *Nightscout* configuration, review [Nightscout: Setup Variables](https://nightscout.github.io/nightscout/setup_variables/){: target="_blank" } and then come back.
 
 The instructions in this section show *Heroku* images. If you are using a different method, you should be able to "translate" the steps.
 
@@ -138,7 +138,7 @@ Scroll down the bottom of the `Config Vars` lines until you find the last blank 
 
 #### Remote Build Config Var Requirement
 
-That last row of the table above is needed if you are using a remote build option such as [LoopDocs: GitHub Build Actions](../gh-actions/gh-overview.md) or downloaded an archived file via [Loop and Learn: Remote Build with Diawi](https://www.loopandlearn.org/remote-build/). If you later return to a direct *Xcode* build to your phone, you must remove that config var or remote commands will not work.
+That last row of the table above is needed if you are using a remote build option such as [LoopDocs: GitHub Build Actions](../gh-actions/gh-overview.md) or downloaded an archived file via [Loop and Learn: Remote Build with Diawi](https://www.loopandlearn.org/remote-build/){: target="_blank" }. If you later return to a direct *Xcode* build to your phone, you must remove that config var or remote commands will not work.
 
 When executed properly, you should have something that looks like this for the three (or four) new variables that you added:
 

--- a/docs/nightscout/remote-errors.md
+++ b/docs/nightscout/remote-errors.md
@@ -12,7 +12,7 @@ This section is for people who were using remote commands and they suddenly stop
 If you are using LoopCaregiver, try the remote command directly from Nightscout to see if they work there. If they are not working there as well, check out your account status first before attempting the fixes on the rest of this page.
 
 * Your *Apple Developer* account must be in good standing for the push notifications to work
-* Log in to your [*Apple Developer* account](https://developer.apple.com/account) and see if there are agreements you need to accept
+* Log in to your [*Apple Developer* account](https://developer.apple.com/account){: target="_blank" } and see if there are agreements you need to accept
 
 ## Improper Configuration
 

--- a/docs/nightscout/remote-overview.md
+++ b/docs/nightscout/remote-overview.md
@@ -19,7 +19,7 @@ Remote commands to the&nbsp;_<span translate="no">Loop</span>_&nbsp;phone go thr
     If your *Nightscout* site is an older version, you should limit your remote commands to `Overrides`, even with &nbsp;<span translate="no">Loop 3</span>.
 
 !!! tip "&nbsp;*Loop Caregiver*"
-    There is a new companion app, &nbsp;[*Loop Caregiver*](loop-caregiver.md) that makes remote commands and reviewing status of your looper much easier.
+    There is a new companion app, &nbsp;[*Loop Caregiver*](loop-caregiver.md) that makes remote commands and reviewing the status of your looper much easier.
 
 ## How does this work?
 
@@ -28,13 +28,13 @@ _<span translate="no">Loop</span>_&nbsp;and *Nightscout* work using &nbsp;<span 
 * The &nbsp;<span translate="no">Apple Developer ID</span>&nbsp; used to build the&nbsp;_<span translate="no">Loop</span>_&nbsp;app must be configured to enable &nbsp;<span translate="no">Apple Push Notifications</span>
     * If you built *Nightscout* and&nbsp;_<span translate="no">Loop</span>_&nbsp;yourself, follow the directions to set up [Remote Configuration](remote-config.md)
 * Most providers who supply `Nightscout as a service` or `Hosted Nightscout` will assist you, if needed, in getting your APN information added to your *Nightscout* variables
-    * [Nightscout Docs: New User](https://nightscout.github.io/nightscout/new_user)
-    * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table)
+    * [Nightscout Docs: New User](https://nightscout.github.io/nightscout/new_user){: target="_blank" }
+    * [Nightscout Docs: Comparison Table](https://nightscout.github.io/nightscout/new_user/#vendors-comparison-table){: target="_blank" }
         * **Warning: examine the `Loop remote carbs/bolus` row: subscription refers to a monthly fee**
 
 ## Next Steps
 
-There are a number of steps to follow to set this up. Each page is linked below:
+There are several steps to follow to set this up. Each page is linked below:
 
 ### [Set Up Remote for Nightscout](remote-config.md)
 

--- a/docs/nightscout/troubleshoot.md
+++ b/docs/nightscout/troubleshoot.md
@@ -1,12 +1,12 @@
 ## Setup Troubleshooting
 
-If you have just tried to set up your Nightscout site and have problems with seeing all your data, please check out the [Nightscout: Troubleshooting](https://nightscout.github.io/troubleshoot/troubleshoot)  page.
+If you have just tried to set up your Nightscout site and have problems with seeing all your data, please check out the [Nightscout: Troubleshooting](https://nightscout.github.io/troubleshoot/troubleshoot){: target="_blank" }  page.
 
 ## Dexcom data not showing
 
-If you use a Dexcom and get your CGM data into Nightscout using Dexcom Share (bridge in Nightscout) and everything was working but the Dexcom data stops showing, please review [Nightscout: Dexcom bridge Troubleshooting](https://nightscout.github.io/troubleshoot/dexcom_bridge/).
+If you use a Dexcom and get your CGM data into Nightscout using Dexcom Share (bridge in Nightscout) and everything is working but the Dexcom data stops showing, please review [Nightscout: Dexcom bridge Troubleshooting](https://nightscout.github.io/troubleshoot/dexcom_bridge/){: target="_blank" }.
 
-As part of that troubleshooting, you may need to remove the Nightscout service credentials from Loop. You may need to remove Dexcom credential from all third-party apps that get data from Dexcom Share. Be sure to add them back after the CGM data to Nightscout is restored.
+As part of that troubleshooting, you may need to remove the Nightscout service credentials from Loop. You may need to remove Dexcom credentials from all third-party apps that get data from Dexcom Share. Be sure to add them back after the CGM data to Nightscout is restored.
 
 You do not need to use Share or bridge with Nightscout. You can choose to have Loop update your CGM readings to Nightscout directly. There's a check box in the Loop CGM setting screen to select this. You must select that check box every time you update your transmitter for Dexcom G5 or G6.
 

--- a/docs/nightscout/update-user.md
+++ b/docs/nightscout/update-user.md
@@ -18,7 +18,7 @@ Once you have created a Nightscout site, there are some Nightscout Config Vars s
 
 These instructions are for people using Heroku, because that is the most common choice. If your Nightscout site is not on Heroku, this page provides a guide for the Config Vars used by Loop.
 
-[Login to your Heroku account](https://id.heroku.com/login), select the `Settings` tab near the top of the screen on your Heroku app.
+[Login to your Heroku account](https://id.heroku.com/login){: target="_blank" }, select the `Settings` tab near the top of the screen on your Heroku app.
 
 ![img/heroku5.png](img/heroku5.png){width="600"}
 {align="center"}
@@ -142,7 +142,7 @@ If the current display of your NS site has been not authenticated, you will not 
 
 The use of tokens is documented at this link to the security page in the Nightscout documentation.
 
-* Please see [Nightscout: Tokens](http://nightscout.github.io/nightscout/security/#create-authentication-tokens-for-users)
+* Please see [Nightscout: Tokens](http://nightscout.github.io/nightscout/security/#create-authentication-tokens-for-users){: target="_blank" }
 
 You can authenticate with your API_SECRET using either of these methods:
 
@@ -155,11 +155,11 @@ An authenticated site, with careportal plugin enabled, will show a &plus; at upp
 
 ## Nightscout Version Update
 
-If you are new to Loop and haven’t updated your Nightscout site for a while, check to see if there's an available update. Visit [Nightscout: Update Instructions](https://nightscout.github.io/update/update/) for directions on updating.
+If you are new to Loop and haven’t updated your Nightscout site for a while, check to see if there's an available update. Visit [Nightscout: Update Instructions](https://nightscout.github.io/update/update/){: target="_blank" } for directions on updating.
 
 
 ## More Variables for Loopers
 
 The list of [Variables for Loopers](#variables-for-loopers) above can be expanded if you want your site to automatically open with specific values and alarm settings.
 
-This [Loop and Learn: Nightscout Variables](https://www.loopandlearn.org/nightscout-variables/) page, created for folks using the Google Cloud method to create a Nightscout site, has a convenient, expanded list.
+This [Loop and Learn: Nightscout Variables](https://www.loopandlearn.org/nightscout-variables/){: target="_blank" } page, created for folks using the Google Cloud method to create a Nightscout site, has a convenient, expanded list.

--- a/docs/operation/features/bolus.md
+++ b/docs/operation/features/bolus.md
@@ -144,7 +144,7 @@ If an "uncertain" delivery is not resolved:
 
 * Make sure the RileyLink compatible device is communicating properly
 * You can try to turn off Bluetooth and then turn it back on again
-* [Quit the Loop app](https://support.apple.com/en-us/HT201330) and restart it. (Note - this is different from a power cycle of the phone which remembers settings within an app that was running before the power cycle.)
+* [Quit the Loop app](https://support.apple.com/en-us/HT201330){: target="_blank" } and restart it. (Note - this is different from a power cycle of the phone which remembers settings within an app that was running before the power cycle.)
 
 If that does not resolve the issue, please tap on Loop Settings, Issue Report and email it to yourself. Then [post](../../intro/loopdocs-how-to.md#how-to-find-help) on Facebook or Zulipchat, explain what happened and say you have an Issue Report. Someone should reach out to you.
 

--- a/docs/operation/features/ice.md
+++ b/docs/operation/features/ice.md
@@ -54,7 +54,7 @@ Some practical use of the ICE screen is provided in the [Meal Entries: Review Ca
     * Some people enter typical values for themselves for a given meal and let Loop handle the rest
     * Some people guess and then carb surf if their glucose goes higher than they like
 
-The rest of this page was written by Katie DiSimone before the non-linear carb model was added to Loop in 2019. You may also want to review her blog post from 2017: [Loop: Dynamic Carb Absorption](http://seemycgm.com/2017/07/25/loop-dynamic-carb-absorption/).
+The rest of this page was written by Katie DiSimone before the non-linear carb model was added to Loop in 2019. You may also want to review her blog post from 2017: [Loop: Dynamic Carb Absorption](http://seemycgm.com/2017/07/25/loop-dynamic-carb-absorption/){: target="_blank" }.
 
 A lot of the information is still relevant although some of the Loop carb modeling and prediction details have been updated over the years.
 

--- a/docs/operation/features/notifications.md
+++ b/docs/operation/features/notifications.md
@@ -156,12 +156,12 @@ Loop will notify when battery levels have approximately 8-10 hours of battery li
 
 ## Remote Notifications
 
-Loop does not have a remote notification to other devices.  If you are a remotely monitoring parent, you will want to read [here](https://nightscout.github.io/nightscout/setup_variables/#pushover) about setting up pushover alerts using your Nightscout site if you want proactive notifications of looping related information.
+Loop does not have a remote notification to other devices.  If you are a remotely monitoring parent, you will want to read [here](https://nightscout.github.io/nightscout/setup_variables/#pushover){: target="_blank" } about setting up pushover alerts using your Nightscout site if you want proactive notifications of looping related information.
 
 ## Loop Follow
 
-Many people use additional apps to assist in following a loved one or to support a loved one who needs help waking up to alarms. One of the more popular options is Loop Follow, written by a parent of a Looper. There are a number of features to assist in remote monitoring with a variety of options for the source of data.
+Many people use additional apps to assist in following a loved one or to support a loved one who needs help waking up to alarms. One of the more popular options is Loop Follow, written by a parent of a Looper. There are several features to assist in remote monitoring with a variety of options for the source of data.
 
 ![loop follow graphic from the README page](img/loop-follow.png)
 
-For more information, please read the [Loop Follow](https://www.loopandlearn.org/loop-follow) documentation. You can build Loop Follow using the same [Build Select Script](../../build/build-app.md#build-select-script) you used to build the Loop app or using the [GitHub Browser Build Method](../../gh-actions/gh-other-apps.md).
+For more information, please read the [Loop Follow](https://www.loopandlearn.org/loop-follow){: target="_blank" } documentation. You can build Loop Follow using the same [Build Select Script](../../build/build-app.md#build-select-script) you used to build the Loop app or using the [GitHub Browser Build Method](../../gh-actions/gh-other-apps.md).

--- a/docs/operation/features/premeal.md
+++ b/docs/operation/features/premeal.md
@@ -30,7 +30,7 @@ Pre-Meal.
 
 ## Assessing the impact of pre-meal
 
-The intent of the pre-meal icon on the toolbar is to [provide an eating-soon mode in Loop](https://diyps.org/2016/07/11/picture-this-how-to-do-eating-soon-mode/).
+The intent of the pre-meal icon on the toolbar is to [provide an eating-soon mode in Loop](https://diyps.org/2016/07/11/picture-this-how-to-do-eating-soon-mode/){: target="_blank" }.
 Do not set pre-meal limits to
 any hypoglycemic ranges that may require treatment.
 
@@ -40,4 +40,4 @@ To mitigate the impact of unintentional pre-meal activation:
 * If you are running Loop 2.2.x, you can set the pre-meal range to the same value as your usual correction range
 
 !!! tip "Custom Pre-Meal Overrides"
-Some loopers set up a custom override to use instead of the pre-meal icon.  This allows enabling the override remotely with Nightscout, permits specifying a custom duration, and will keep the override enabled after carbs are announced.
+    Some loopers set up a custom override to use instead of the pre-meal icon.  This allows enabling the override remotely with Nightscout, permits specifying a custom duration, and will keep the override enabled after carbs are announced.

--- a/docs/operation/loop-settings/configurations.md
+++ b/docs/operation/loop-settings/configurations.md
@@ -98,7 +98,7 @@ The maximum basal rate and maximum bolus settings are collectively referred to a
 
 ### Maximum Basal Rate
 
-Maximum basal rate will cap the maximum temporary basal rate that the Loop is allowed to enact to meet your correction range. Typically, Loop users set their maximum basal rate around 3-4 times their highest scheduled basal rate. When you are first beginning to use Loop, it is wise to start conservative (low) in setting your maximum basal rate. If your settings are incorrect in other areas (basal rates, insulin sensitivity, carb ratio, etc), you may need time to identify where settings need to be adjusted. This process is easier if Loop is given less latitude to set high basal rates. Gradually increase your maximum basal rate as your comfort and confidence in Loop increases. If you need help with your settings adjustment, head over to LoopTips for some [initial settings help](https://loopkit.github.io/looptips/settings/settings/)
+Maximum basal rate will cap the maximum temporary basal rate that the Loop is allowed to enact to meet your correction range. Typically, Loop users set their maximum basal rate around 3-4 times their highest scheduled basal rate. When you are first beginning to use Loop, it is wise to start conservative (low) in setting your maximum basal rate. If your settings are incorrect in other areas (basal rates, insulin sensitivity, carb ratio, etc), you may need time to identify where settings need to be adjusted. This process is easier if Loop is given less latitude to set high basal rates. Gradually increase your maximum basal rate as your comfort and confidence in Loop increases. If you need help with your settings adjustment, head over to LoopTips for some [initial settings help](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" }
 
 #### **Maximum Bolus**
 
@@ -106,7 +106,7 @@ Enter your desired single bolus maximum here. For safety, don't set a maximum bo
 
 ## Insulin Model
 
-There are four insulin models to choose from with Loop 2.x; Walsh, Rapid-Acting Adults, Rapid-Acting Children, and Fiasp. If you want to read the nitty-gritty discussion that went into the development of the Rapid-Acting and Fiasp curves (collectively called "exponential insulin models"), you can see that in GitHub [here](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473).
+There are four insulin models to choose from with Loop 2.x; Walsh, Rapid-Acting Adults, Rapid-Acting Children, and Fiasp. If you want to read the nitty-gritty discussion that went into the development of the Rapid-Acting and Fiasp curves (collectively called "exponential insulin models"), you can see that in GitHub [here](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473){: target="_blank" }.
 
 !!! tip "Loop 3 Insulin Type"
     Loop 3 drops the Walsh model and, by default, does not include the concept of child versus adult for "rapid" acting insulin, i.e., Humalog, Novalog and Apidra.
@@ -116,7 +116,7 @@ There are four insulin models to choose from with Loop 2.x; Walsh, Rapid-Acting 
 
 **We highly recommend selecting one of the exponential insulin models for Loop 2.2.x (in other words, not the Walsh model).**
 
-A common new Loop user error is to select Walsh model in order to easily shorten their insulin duration (DIA) to one like they used prior to Looping. This almost invariably leads to insulin stacking. If you would like to read more about why the duration of insulin action is important in Loop vs how you've traditionally used it, please click [here](https://seemycgm.com/2017/08/09/why-dia-matters/) to read a blog post about the subject. In summary, choosing Walsh curve just to shorten your DIA will lead to insulin stacking and less than desired bolusing recommendations.
+A common new Loop user error is to select Walsh model in order to easily shorten their insulin duration (DIA) to one like they used prior to Looping. This almost invariably leads to insulin stacking. If you would like to read more about why the duration of insulin action is important in Loop vs how you've traditionally used it, please click [here](https://seemycgm.com/2017/08/09/why-dia-matters/){: target="_blank" } to read a blog post about the subject. In summary, choosing Walsh curve just to shorten your DIA will lead to insulin stacking and less than desired bolusing recommendations.
 
 You can click on each model and see what each model's insulin activity curve looks like, active one selected in blue.
 
@@ -159,7 +159,7 @@ As with all Loop versions, you can manually bolus at any time by pressing the Bo
 
 ## Carb Ratios
 
-Click the &plus; in the upper right to add carb ratios for various times of day. Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/) your carb ratio settings for accuracy.
+Click the &plus; in the upper right to add carb ratios for various times of day. Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" } your carb ratio settings for accuracy.
 
 !!! warning "Beware of other apps writing carbs to Health app"
 
@@ -167,9 +167,9 @@ Click the &plus; in the upper right to add carb ratios for various times of day.
 
 ## Insulin Sensitivities
 
-Insulin Sensitivity Factor (ISF) is the same term as Correction Factor used in some clinics and endocrinology offices. ISF represents the drop in blood glucose levels expected from one unit of insulin. Click the &plus; in the upper right to add insulin sensitivities for various times of day. Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/) your ISF settings for accuracy. Insulin sensitivities can change for many reasons including waiting too long to change your infusion set. Loop will not auto-detect changes in ISF.
+Insulin Sensitivity Factor (ISF) is the same term as Correction Factor used in some clinics and endocrinology offices. ISF represents the drop in blood glucose levels expected from one unit of insulin. Click the &plus; in the upper right to add insulin sensitivities for various times of day. Loop works best if you have [tested and optimized](https://loopkit.github.io/looptips/settings/settings/){: target="_blank" } your ISF settings for accuracy. Insulin sensitivities can change for many reasons including waiting too long to change your infusion set. Loop will not auto-detect changes in ISF.
 
-Incorrectly set ISF is the most common cause of roller coaster glucose for new Loop users. You will need to raise (increase) your ISF value/number to help smooth a roller coaster glucose trend. You can read about that topic more over in LoopTips [here](https://loopkit.github.io/looptips/settings/settings/#3rd-insulin-sensitivity-factor).
+Incorrectly set ISF is the most common cause of roller coaster glucose for new Loop users. You will need to raise (increase) your ISF value/number to help smooth a roller coaster glucose trend. You can read about that topic more over in LoopTips [here](https://loopkit.github.io/looptips/settings/settings/#3rd-insulin-sensitivity-factor){: target="_blank" }.
 
 ## Loop 2 Services (Optional)
 

--- a/docs/operation/loop-settings/omnipod-pump.md
+++ b/docs/operation/loop-settings/omnipod-pump.md
@@ -56,7 +56,7 @@ When you finish entering these values, press the blue `Continue` button on the b
     If you overfill the pods, you may get a pod fault right after priming.
 
 !!! info "Pod Filling and Insertion"
-    The Pod filling and insertion instructions are the same with the Loop app as they are for the PDM.  These videos: [Filling a Pod with Insulin](https://youtu.be/qJBN6rlvn_Y) and [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI), may be useful.  You will use your phone and RileyLink compatible device instead of the PDM.  Be sure to keep the phone and RileyLink close during pairing and insertion because the Pod uses a low-power mode during these activities.
+    The Pod filling and insertion instructions are the same with the Loop app as they are for the PDM.  These videos: [Filling a Pod with Insulin](https://youtu.be/qJBN6rlvn_Y){: target="_blank" } and [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI){: target="_blank" }, may be useful.  You will use your phone and RileyLink compatible device instead of the PDM.  Be sure to keep the phone and RileyLink close during pairing and insertion because the Pod uses a low-power mode during these activities.
 
 1. Fill the Pod with insulin until it beeps (minimum fill is 80 units)
 1. Place the Pod about 6 inches from the RileyLink compatible device with the phone within a few feet
@@ -76,7 +76,7 @@ When you finish entering these values, press the blue `Continue` button on the b
 3. If the cannula is safely tucked away, apply the Pod to your desired infusion site. If cannula is sticking out, press `cancel` in the upper right corner of the screen and try a new Pod. (Report this issue to Insulet; it is a Pod problem.)
 4. Press the `Insert Cannula` button.
 5. Listen to the clicks filling the cannula, wait for insertion and the progress bar to complete. The number of clicks to insertion is not consistent. The cannula will deploy before the progress bar is completed.
-6. Confirm cannula has deployed: you should feel it and there is a pink slide that can be seen on the outside of the pod as shown in this video: [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI).
+6. Confirm cannula has deployed: you should feel it and there is a pink slide that can be seen on the outside of the pod as shown in this video: [Inserting the Cannula](https://youtu.be/ss1vpsmaLoI){: target="_blank" }.
 7. Proceed to the Expiration Reminder screen to accept or modify the default reminder.
 
 ![img/pod-setup-02-insert.png](img/pod-setup-02-insert.png){width="650"}

--- a/docs/operation/loop-settings/services-v2.md
+++ b/docs/operation/loop-settings/services-v2.md
@@ -16,9 +16,9 @@ Near the bottom of your Loop settings screen is a section called "Services".
 
 ## Nightscout
 
-There is a whole section in LoopDocs about Nightscout. Please follow this link to the [Using Nightscout with Loop](../../nightscout/overview.md) section of LoopDocs. That also has the links you might need to the official [Nightscout Documentation](https://nightscout.github.io/) (different website).
+There is a whole section in LoopDocs about Nightscout. Please follow this link to the [Using Nightscout with Loop](../../nightscout/overview.md) section of LoopDocs. That also has the links you might need to the official [Nightscout Documentation](https://nightscout.github.io/){: target="_blank" } (different website).
 
-If you have an existing Nightscout site, it's still a good idea to review that section, but here's the quick summary of how to add your Site URL and API_SECRET to have your Loop data transmitted to your Nightscout site. If you can’t remember your API_SECRET, it can be found under Settings, Reveal Config Vars for Heroku sites (or Application Settings, Connection Strings for Azure sites).
+If you have an existing Nightscout site, it's still a good idea to review that section, but here's a quick summary of how to add your Site URL and API_SECRET to have your Loop data transmitted to your Nightscout site. If you can’t remember your API_SECRET, it can be found under Settings, Reveal Config Vars for Heroku sites (or Application Settings, Connection Strings for Azure sites).
 
 The two most common errors in filling out this section are:
 
@@ -30,14 +30,14 @@ The two most common errors in filling out this section are:
 
 ## Loggly
 
-[Loggly](https://loggly.com) is a free logging service. If you sign up for an account, you'll need to go under Source Setup and then Customer Tokens. Copy and paste your customer token into your Loop App settings for Loggly.
+[Loggly](https://loggly.com){: target="_blank" } is a free logging service. If you sign up for an account, you'll need to go under Source Setup and then Customer Tokens. Copy and paste your customer token into your Loop App settings for Loggly.
 
 ![img/loggly.png](img/loggly.png){width="500"}
 {align="center"}
 
 ## Amplitude
 
-[Amplitude](https://amplitude.com) is a remote event monitoring service and can be used to quickly identify errors and events with Loop. Amplitude stores the events and allows you to view those events as points in time. To retrieve the details of the events you will need to look at corresponding mLab data entries to get a complete picture of the issues. If you sign up for a free account with Amplitude, you will be given an API Key that you can enter here to have Loop integration setup.
+[Amplitude](https://amplitude.com){: target="_blank" } is a remote event monitoring service and can be used to quickly identify errors and events with Loop. Amplitude stores the events and allows you to view those events as points in time. To retrieve the details of the events you will need to look at corresponding mLab data entries to get a complete picture of the issues. If you sign up for a free account with Amplitude, you will be given an API Key that you can enter here to have Loop integration setup.
 
 ![img/amplitude.png](img/amplitude.png){width="500"}
 {align="center"}

--- a/docs/operation/loop/looptips.md
+++ b/docs/operation/loop/looptips.md
@@ -11,7 +11,7 @@ Things such as:
 * What about pizza boluses?
 * What do I do when I shower or swim?
 
-All of those usability questions and more are addressed over in the companion site called [LoopTips](https://loopkit.github.io/looptips).  
+All of those usability questions and more are addressed over in the companion site called [LoopTips](https://loopkit.github.io/looptips){: target="_blank" }.
 
 Please head over to Looptips in order to read some really helpful tips to make your Looping easier.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -71,3 +71,14 @@ article ul ul ul {
 .loop-biggest {
     font-size: 1.6em;
 }
+
+/*
+ * Materialize links that open in a new window/tab with a right-up arrow icon
+ */
+a[target="_blank"]::after {
+    content:     '↗';
+    display:     inline-block;
+    margin-left: 0.2em;
+    width:       1em;
+    height:      1em;
+}

--- a/docs/translate.md
+++ b/docs/translate.md
@@ -1,56 +1,56 @@
 ## Language List
 
-[عربي](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ar)
+[عربي](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ar){: target="_blank" }
 
-[Български](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=bg)
+[Български](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=bg){: target="_blank" }
 
-[Čeština](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=cs)
+[Čeština](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=cs){: target="_blank" }
 
-[Deutsch](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=de)
+[Deutsch](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=de){: target="_blank" }
 
-[Dansk](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=da)
+[Dansk](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=da){: target="_blank" }
 
-[Ελληνικά](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=el)
+[Ελληνικά](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=el){: target="_blank" }
 
-[Español](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=es)
+[Español](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=es){: target="_blank" }
 
-[日本](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ja)
+[日本](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ja){: target="_blank" }
 
-[Suomi](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=fi)
+[Suomi](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=fi){: target="_blank" }
 
-[Français](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=fr)
+[Français](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=fr){: target="_blank" }
 
-[עברית](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=iw)
+[עברית](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=iw){: target="_blank" }
 
-[Hrvatski](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=hr)
+[Hrvatski](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=hr){: target="_blank" }
 
-[हिंदी](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=hi)
+[हिंदी](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=hi){: target="_blank" }
 
-[Italiano](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=it)
+[Italiano](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=it){: target="_blank" }
 
-[한국어](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ko)
+[한국어](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ko){: target="_blank" }
 
-[Norsk](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=no)
+[Norsk](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=no){: target="_blank" }
 
-[Nederlands](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=nl)
+[Nederlands](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=nl){: target="_blank" }
 
-[Polski](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=pl)
+[Polski](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=pl){: target="_blank" }
 
-[Português](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=pt)
+[Português](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=pt){: target="_blank" }
 
-[Română](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ro)
+[Română](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ro){: target="_blank" }
 
-[Русский](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ru)
+[Русский](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=ru){: target="_blank" }
 
-[Slovenčina](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=sk)
+[Slovenčina](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=sk){: target="_blank" }
 
-[Svenska](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=sv)
+[Svenska](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=sv){: target="_blank" }
 
-[Turkish](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=tr)
+[Turkish](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=tr){: target="_blank" }
 
-中文（[简体](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=zh-CN))
+中文（[简体](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=zh-CN){: target="_blank" })
 
-中文（[繁體](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=zh-TW))
+中文（[繁體](https://loopkit-github-io.translate.goog/loopdocs/?_x_tr_sl=auto&_x_tr_tl=zh-TW){: target="_blank" })
 
 ## Google Translate Links
 
@@ -58,7 +58,7 @@ Click on a language on the list of links above to turn on Google's automatic tra
 
 ## Change Language
 
-To modify the language choice for the whole site, copy the line below and paste it into the URL and then choose the desired language from the list above
+To modify the language choice for the whole site, copy the line below, and paste it into the URL, and then choose the desired language from the list above.
 
 ``` { .bash .copy title="Copy and Paste in Browser URL to return to original version" }
 https://loopkit.github.io/loopdocs/translate
@@ -74,7 +74,7 @@ Use the Google Translation three-dot menu and select `Go to Original URL` while 
 
 * The Google Translate Tool will appear at the top of each page
     * LoopDocs how-to: [Google Translate Tool Instructions](#google-translate-tool-instructions)
-    * Google how-to: [Google Translate Help Link](https://support.google.com/translate/answer/2534559?hl=en&co=GENIE.Platform%3DDesktop)
+    * Google how-to: [Google Translate Help Link](https://support.google.com/translate/answer/2534559?hl=en&co=GENIE.Platform%3DDesktop){: target="_blank" }
 
 !!! danger "Automatic Translation"
     These links connect this site to the Google Translation service.
@@ -83,7 +83,7 @@ Use the Google Translation three-dot menu and select `Go to Original URL` while 
     * Please use the translation with care
     * Not available in all regions
     * Some links may not work as expected
-    * Any "code" not protected by blocks may not appear correctly - be sure to click on Original to make sure you a viewing code properly
+    * Any "code" not protected by blocks may not appear correctly - be sure to click on Original to make sure you are viewing code properly
 
 ## Google Translate Tool Instructions
 

--- a/docs/troubleshooting/omnipod-faults.md
+++ b/docs/troubleshooting/omnipod-faults.md
@@ -12,7 +12,7 @@ Loop will put a higher battery load on a pod than the PDM due to its regular and
 
 ## Known internal pod fault codes
 
-The currently known pod faults are listed here on the openomni wiki page: [Pod Fault codes](https://github.com/openaps/openomni/wiki/Fault-event-codes)
+The currently known pod faults are listed here on the openomni wiki page: [Pod Fault codes](https://github.com/openaps/openomni/wiki/Fault-event-codes){: target="_blank" }
 
 ## Ways to reduce the possibility of a fault
 

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -8,7 +8,7 @@ If you have modified the Loop time (not changed time zone, but turned off automa
 
 ### Screenshots
 
-**Take a screenshot of your Loop main display screen**, or other screens such as the display when you touch a red loop icon that may help you or troubleshooters better understand your issue.  A lot of times a picture is worth a thousand words.  Being able to see recent Loop basal adjustments, predicted BG curve, and carb entries really help fill in the full story of the current Loop status.  If you didn't manage to get a screenshot when the issue was happening, you can also go to Nightscout and scroll back over the previous 48 hours to obtain much of the same information.  Try to capture a Nightscout screen from the time period in question.
+**Take a screenshot of your Loop main display screen**, or other screens such as the display when you touch a red loop icon that may help you or troubleshooters better understand your issue.  A lot of times a picture is worth a thousand words.  Being able to see recent Loop basal adjustments, predicted BG curve and carb entries really help fill in the full story of the current Loop status.  If you didn't manage to get a screenshot when the issue was happening, you can also go to Nightscout and scroll back over the previous 48 hours to obtain much of the same information.  Try to capture a Nightscout screen from the time period in question.
 
 ### Check the Docs
 
@@ -24,20 +24,20 @@ The Loop Report (a text file) contains important information about actions and s
 
 ### GitHub Issues
 
-Check the current list of [GitHub Loop Issues](https://github.com/LoopKit/Loop/issues) for known issues.  Many times other users have noticed the same issue previously and opened an Issue so that more information can be added to help develop a solution.  If you see your same issue has already been reported, please add to the open issue instead of creating a new one.
+Check the current list of [GitHub Loop Issues](https://github.com/LoopKit/Loop/issues){: target="_blank" } for known issues.  Many times other users have noticed the same issue previously and opened an Issue so that more information can be added to help develop a solution.  If you see the same issue has already been reported, please add it to the open issue instead of creating a new one.
 
-There is a nice search feature on github issues - type a keyword into the box next to Filters: where it says "is:issue is:open" in the graphic and the display will show just those open issues that contain the keyword in the title.
+There is a nice search feature on GitHub issues - type a keyword into the box next to Filters: where it says "is:issue is:open" in the graphic and the display will show just those open issues that contain the keyword in the title.
 
 ![img/loop-issues.png](img/loop-issues.png){width="800"}
 {align="center"}
 
 ### Zulipchat and Facebook
 
-Search in [Zulipchat]( https://loop.zulipchat.com), [Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup) or [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN).  Quite possibly someone else has already posted about the same issue and perhaps a resolution has already been provided.  
+Search in [Zulipchat]( https://loop.zulipchat.com){: target="_blank" }, [Looped Facebook Group](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } or [LoopandLearn Facebook Group](https://www.facebook.com/groups/LOOPandLEARN){: target="_blank" }.  Quite possibly someone else has already posted about the same issue and perhaps a resolution has already been provided.  
 
 ## Ask for Help
 
-If you can't find any information in LoopDocs, GitHub Issues, Zulipchat, or Facebook...PLEASE post and ask for help.  GitHub Issues list is an EXCELLENT place to post issues of unexpected Loop behavior (that you believe are errant or need improvement).  However, if you are just seeking clarifications on Loop, but don't necessarily expect that there's a problem with the underlying code, then Facebook and Zulipchat is a better place.  For example, Zulipchat and Facebook are great for asking about bolus strategies or exercise target use...those aren't really code issues.
+If you can't find any information in LoopDocs, GitHub Issues, Zulipchat, or Facebook...PLEASE post and ask for help.  GitHub Issues list is an EXCELLENT place to post issues of unexpected Loop behavior (that you believe are errant or need improvement).  However, if you are just seeking clarifications on Loop, but don't necessarily expect that there's a problem with the underlying code, then Facebook and Zulipchat are a better place.  For example, Zulipchat and Facebook are great for asking about bolus strategies or exercise target use...those aren't really code issues.
 
 When you post, provide a description along with any screenshots of the issue you are having and include the version of Loop you are running and the iOS on your device.  (Tap on Loop-Settings and look at the top of the screen to get the Loop version number).  You don't necessarily have to tag any particular person, the community is fairly active in replying to messages.
 

--- a/docs/troubleshooting/pod-pairing.md
+++ b/docs/troubleshooting/pod-pairing.md
@@ -189,7 +189,7 @@ Press the "`Continue`" button. The instructions start with "`fill a new pod with
 
 To help fix pairing bugs, some improvements have also been made in our ability to save the communications between the pods and Loop app during the pairing process. So, please help us leverage these new improvements and better squash bugs.
 
-If you run into any pairing problems, which required Step 5A or Step 5B to be able to pair, or you had a pod that had to be abandoned, it would be helpful to generate an "Issue Report" after you finally get a pod paired (whether it was the original pod or if a different pod) and then post the resulting "Loop Report" on [Zulipchat here](https://loop.zulipchat.com/#narrow/stream/144111-general/topic/Omnipod.20Pairing.20Issues) with a short explanation of what happened.
+If you run into any pairing problems, which required Step 5A or Step 5B to be able to pair, or you had a pod that had to be abandoned, it would be helpful to generate an "Issue Report" after you finally get a pod paired (whether it was the original pod or if a different pod) and then post the resulting "Loop Report" on [Zulipchat here](https://loop.zulipchat.com/#narrow/stream/144111-general/topic/Omnipod.20Pairing.20Issues){: target="_blank" } with a short explanation of what happened.
 
 ## What about other pod start-up failures?
 

--- a/docs/troubleshooting/pump-errors.md
+++ b/docs/troubleshooting/pump-errors.md
@@ -4,7 +4,7 @@ The Medtronic pumps are used and typically not under warranty.  Use this section
 
 ## A21 error
 
-This error message is common when a pump has been stored for a period of time without a battery.  Most pumps will show an A21 error when you first purchase them on the used market.  Not a big deal.  Press the down arrow (also has the symbol of a light bulb on it) and the pump screen message will scroll down to let you know how to clear that error message (press ESC then ACT).  If the message is coming up on a pump that hasn't been in storage, pull the battery out and replace with a fresh, new battery.  Chances are your battery or battery cap are old.  Look for signs of dirt or rust in the battery cap, give it a little cleaning.
+This error message is common when a pump has been stored for some time without a battery.  Most pumps will show an A21 error when you first purchase them on the used market.  Not a big deal.  Press the down arrow (it also has the symbol of a light bulb on it) and the pump screen message will scroll down to let you know how to clear that error message (press ESC then ACT).  If the message is coming up on a pump that hasn't been in storage, pull the battery out and replace it with a fresh, new battery.  Chances are your battery or battery cap is old.  Look for signs of dirt or rust in the battery cap, give it a little cleaning.
 
 !!! info "Display Tip"
 
@@ -22,7 +22,7 @@ This error message "battery out of limits" has to do with the internal pump batt
 
 ## Button Error
 
-The Button Error message usually happens from water, moisture, or dust getting under the pump's button pad and causing button(s) to fail.  The fix luckily is quite straight-forward and takes less than 30 minutes.  Check out the fix [here for a YouTube video](https://www.youtube.com/watch?v=nWRVSHXN5cQ) or [here for photo gallery](https://imgur.com/a/iOXAP). There is also a detailed page in the [OpenAPS docs](https://openaps.readthedocs.io/en/latest/docs/Resources/Medtronic-Button-Errors.html#medtronic-button-error-troubleshooting).
+The Button Error message usually happens from water, moisture, or dust getting under the pump's button pad and causing button(s) to fail.  The fix luckily is quite straight-forward and takes less than 30 minutes.  Check out the fix [here for a YouTube video](https://www.youtube.com/watch?v=nWRVSHXN5cQ){: target="_blank" } or [here for photo gallery](https://imgur.com/a/iOXAP){: target="_blank" }. There is also a detailed page in the [OpenAPS docs](https://openaps.readthedocs.io/en/latest/docs/Resources/Medtronic-Button-Errors.html#medtronic-button-error-troubleshooting){: target="_blank" }.
 
 ![img/button-error.jpg](img/button-error.jpg){width="400"}
 {align="center"}
@@ -44,11 +44,11 @@ After you finish your fix, another excellent idea is to make sure you add a leng
 
 ## Crack/Missing Piece Repairs
 
-Another common issue on these Medtronic pumps are cracks and/or missing bits of plastic near the battery cap or reservoir sleeve. You can repair these fairly easily. For filling small cracks, [Testor's plastic cement](https://www.amazon.com/Cement-Glue-Value-Testors-tubes/dp/B0013D53CS/ref=sr_1_2?s=toys-and-games&ie=UTF8&qid=1550883077&sr=1-2&keywords=testors+plastic+cement) or [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1) are good choices.
+Another common issue on these Medtronic pumps are cracks and/or missing bits of plastic near the battery cap or reservoir sleeve. You can repair these fairly easily. For filling small cracks, [Testor's plastic cement](https://www.amazon.com/Cement-Glue-Value-Testors-tubes/dp/B0013D53CS/ref=sr_1_2?s=toys-and-games&ie=UTF8&qid=1550883077&sr=1-2&keywords=testors+plastic+cement){: target="_blank" } or [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1){: target="_blank" } are good choices.
 
-For more extensive repairs to replace missing chunks of plastic, [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1) or [Sugru](https://www.amazon.com/Sugru-Mouldable-Glue-Original-Formula/dp/B01BFE0KNQ/ref=sr_1_4?ie=UTF8&qid=1550883178&sr=8-4&keywords=sugru) are excellent choices.  
+For more extensive repairs to replace missing chunks of plastic, [Gorilla epoxy](https://www.amazon.com/Gorilla-Epoxy-Minute-ounce-Syringe/dp/B001Z3C3AG/ref=sr_1_1_sspa?ie=UTF8&qid=1550883118&sr=8-1-spons&keywords=gorilla+epoxy&psc=1){: target="_blank" } or [Sugru](https://www.amazon.com/Sugru-Mouldable-Glue-Original-Formula/dp/B01BFE0KNQ/ref=sr_1_4?ie=UTF8&qid=1550883178&sr=8-4&keywords=sugru){: target="_blank" } are excellent choices.  
 
-You can use [teflon thread tape](https://www.amazon.com/LASCO-11-1033-Sealant-2-Inch-100-Inch/dp/B00ITPHXZI/ref=sr_1_17?ie=UTF8&qid=1550883881&sr=8-17&keywords=teflon+thread+tape) on the battery cap to make sure the epoxy or Sugru don't stick to the battery cap, but still recreate the threads.  The first photos are of a Sugru repair and second set of photos are Gorilla epoxy repair.
+You can use [teflon thread tape](https://www.amazon.com/LASCO-11-1033-Sealant-2-Inch-100-Inch/dp/B00ITPHXZI/ref=sr_1_17?ie=UTF8&qid=1550883881&sr=8-17&keywords=teflon+thread+tape){: target="_blank" } on the battery cap to make sure the epoxy or Sugru don't stick to the battery cap, but still recreate the threads.  The first photos are of a Sugru repair and second set of photos are Gorilla epoxy repair.
 
 ![img/after-sugru.jpg](img/after-sugru.jpg){width="750"}
 {align="center"}
@@ -67,9 +67,9 @@ Often a motor error is the result of a poorly seated reservoir or tubing cap.  I
 
 !!! warning "Safety warning"
 
-    If you get this error, DO NOT push on the bulged out end cap.  Always detach your tubing from your infusion set before addressing this error message.  If you push on the end cap in an attempt to get it back flush, you may delivery a dangerous amount of insulin mistakenly.
+    If you get this error, DO NOT push on the bulged-out end cap.  Always detach your tubing from your infusion set before addressing this error message.  If you push on the end cap in an attempt to get it back flush, you may deliver a dangerous amount of insulin mistakenly.
 
-This error is a bit more involved to repair.  The problem is that there is a loose drive support cap.  Most of the time this error message will appear during a priming event as the end cap of the drive will slip, releasing the ability of the reservoir plunger to get pressure to delivery insulin.  The pump senses the lack of pressure and delivers the A33 error.
+This error is a bit more involved to repair.  The problem is that there is a loose drive support cap.  Most of the time this error message will appear during a priming event as the end cap of the drive will slip, releasing the ability of the reservoir plunger to get pressure to deliver insulin.  The pump senses the lack of pressure and delivers the A33 error.
 
 ![img/A33-2.jpg](img/A33-2.jpg){width="400"}
 {align="center"}
@@ -77,18 +77,18 @@ This error is a bit more involved to repair.  The problem is that there is a loo
 ![img/A33.jpg](img/A33.jpg){width="400"}
 {align="center"}
 
-The solution is to UNHOOK from your site.  See warning above.  Remove reservoir and put your finger inside the reservoir sleeve.  Push on the drive so that the end cap is pushed out the most possible.  This will give your the most surface area possible to place the super glue GEL that you will use.  (don't use regular super glue...it must be gel.)  Remove the sticker that covers the end cap, save it for later because you can reattach when repair is completed.
+The solution is to UNHOOK from your site.  See the warning above.  Remove the reservoir and put your finger inside the reservoir sleeve.  Push on the drive so that the end cap is pushed out the most possible.  This will give you the most surface area possible to place the super glue GEL that you will use.  (don't use regular super glue...it must be gel.)  Remove the sticker that covers the end cap, and save it for later because you can reattach it when the repair is completed.
 
-With the end cap pushed out, take some glue gel with the toothpick and apply it on the outside of the popped out cap . Be generous cause you can do this only once . Once you are done take a napkin and press hard the cap toward the pump so it can go back inside and keep it pressed for a few seconds. Then remove all the small parts of the napkin that has glued to the pump. Leave the pump to dry for about 10-15 minutes.
+With the end cap pushed out, take some glue gel with the toothpick and apply it on the outside of the popped-out cap. Be generous cause you can do this only once. Once you are done take a napkin and press hard the cap toward the pump so it can go back inside and keep it pressed for a few seconds. Then remove all the small parts of the napkin that has glued to the pump. Leave the pump to dry for about 10-15 minutes.
 
 ![img/A33-4.jpg](img/A33-4.jpg){width="400"}
 {align="center"}
 
-Now to test whether the pumps was glued well. You have already waited about 10-15 minutes so put your finger back in and press hard the plunger.  If you glued it well, the end cap will not move.  If the cap goes out again, you have to glue one more time. If all looks well, put some glue back on top of the pump cap and reattach the sticker that was removed to start.
+Now to test whether the pump was glued well. You have already waited about 10-15 minutes so put your finger back in and press hard the plunger.  If you glued it well, the end cap will not move.  If the cap goes out again, you have to glue it one more time. If all looks well, put some glue back on top of the pump cap and reattach the sticker that was removed to start.
 
 ## A32 and E22 error loop
 
-From what we know, this set of error codes seems like a pump killer.  A call to Medtronic support gave this less than hopeful information:
+From what we know, this set of error codes seems like a pump killer.  A call to Medtronic support gave this less-than-hopeful information:
 
 A32 - failure of flash memory
 E22 - software re-installation is necessary

--- a/docs/troubleshooting/red-loop.md
+++ b/docs/troubleshooting/red-loop.md
@@ -114,7 +114,7 @@ If you have not enabled background app refresh on your phone, then Loop is likel
 1. While you are there - check your CGM app as well
 
 
-For iOS 15, there is a new feature described by [Dexcom](https://www.dexcom.com/faqs/what-are-the-recommended-iphone-settings)
+For iOS 15, there is a new feature described by [Dexcom](https://www.dexcom.com/faqs/what-are-the-recommended-iphone-settings){: target="_blank" }
 
 1. Phone Settings -> Screen Time -> choose Always Allowed -> select an app, tap the plus icon to add to Always Allowed list
     - add Dexcom
@@ -128,7 +128,7 @@ If you added your Nightscout URL to Loop and are uploading information to Nights
 1. Check that Nightscout database size isn't full (more details below)
 1. If Red Loops are resolved by removing the Nightscout URL from Loop; you need to figure out if it's the connection or the database or some other issue
 
-If you opted for the free DIY Nightscout, you will need to clean your database once or twice a year. Follow the [Nightscout Database cleanup steps](https://nightscout.github.io/troubleshoot/troubleshoot/#database-full). Make sure you are periodically checking your database size (and that the **dbsize** keyword is in your [ENABLE list](../nightscout/update-user.md#editadd-config-vars) and cleaning it.
+If you opted for the free DIY Nightscout, you will need to clean your database once or twice a year. Follow the [Nightscout Database cleanup steps](https://nightscout.github.io/troubleshoot/troubleshoot/#database-full){: target="_blank" }. Make sure you are periodically checking your database size (and that the **dbsize** keyword is in your [ENABLE list](../nightscout/update-user.md#editadd-config-vars) and cleaning it.
 
 ### Phone Storage is Full
 
@@ -198,7 +198,7 @@ There are a few other things to consider:
 
 ### RileyLink is Broken
 
-How can you tell if your RileyLink has a problem? The answer is mostly within the LED lights that display on the board. Some information is listed below, but also review the [FAQs at getrileylink.org](https://getrileylink.org/faq).
+How can you tell if your RileyLink has a problem? The answer is mostly within the LED lights that display on the board. Some information is listed below, but also review the [FAQs at getrileylink.org](https://getrileylink.org/faq){: target="_blank" }.
 
 If you have a different RileyLink compatible device, please check the appropriate site for troubleshooting help.
 
@@ -206,13 +206,13 @@ If you have a different RileyLink compatible device, please check the appropriat
 
 **Green light**: Indicates an active BT connection with the phone. You want the green light to stay on all the time on the RileyLink. If the green light is not on, then make sure your iPhone's bluetooth is still switched on.
 
-**Blue light**: The blue light will flash off/on periodically when the RileyLink and pump are actively communicating...it should NOT be always on. If your blue light is stuck on, that is an indication of a problem on the board. Try looking for signs of damage or debris that may be causing a short on the board. Clean the board with rubbing alcohol [(unplug the battery first](https://youtu.be/s2qNPLpfwww)). If you still can't get the blue light off, then contact GetRileyLink for help or check out [RileyLink Compatible Devices](../build/rileylink.md#rileylink-compatible-devices) for replacement options.
+**Blue light**: The blue light will flash off/on periodically when the RileyLink and pump are actively communicating...it should NOT be always on. If your blue light is stuck on, that is an indication of a problem on the board. Try looking for signs of damage or debris that may be causing a short on the board. Clean the board with rubbing alcohol [(unplug the battery first](https://youtu.be/s2qNPLpfwww){: target="_blank" }). If you still can't get the blue light off, then contact GetRileyLink for help or check out [RileyLink Compatible Devices](../build/rileylink.md#rileylink-compatible-devices) for replacement options.
 
 ### Battery has Failed
 
-Both [RileyLink](https://getrileylink.org/faq) and [EmaLink](https://github.com/sks01/EmaLink/wiki/Battery-swelling) use LiPo batteries.  If they stop holding charge for as long as they used to, or if they swell (often first noticed as bowing of the case), stop using the battery and replace it as soon as possible.
+Both [RileyLink](https://getrileylink.org/faq){: target="_blank" } and [EmaLink](https://github.com/sks01/EmaLink/wiki/Battery-swelling){: target="_blank" } use LiPo batteries.  If they stop holding charge for as long as they used to, or if they swell (often first noticed as bowing of the case), stop using the battery and replace it as soon as possible.
 
-[OrangeLink](https://getrileylink.org/faq) uses regular batteries, so just change them out.
+[OrangeLink](https://getrileylink.org/faq){: target="_blank" } uses regular batteries, so just change them out.
 
 ### OrangeLink Firmware
 

--- a/docs/version/build-dev.md
+++ b/docs/version/build-dev.md
@@ -10,7 +10,7 @@ There are several methods to build Loop-dev. First review the general informatio
 
 While Loop-dev is under active development, you should monitor zulipchat and update frequently. Sometimes the `dev` branch is quiet for a month or more and other times it gets updated daily. Please pay attention.
 
-Checking for updates every week is a good idea. Also - subscribe to all the streams on [Loop Zulipchat](https://loop.zulipchat.com) to make sure you don't miss critical information.
+Checking for updates every week is a good idea. Also - subscribe to all the streams on [Loop Zulipchat](https://loop.zulipchat.com){: target="_blank" } to make sure you don't miss critical information.
 
 ## Loop-dev Version
 

--- a/docs/version/code-custom-edits.md
+++ b/docs/version/code-custom-edits.md
@@ -45,7 +45,7 @@ This page is broken into two halves:
     * The first half of this page is for customizations that require you to edit your own code.
 
 * [Custom Edits Optional](#custom-edits-optional):
-    * The second half of this page provides instructions for some of the prepared customizations included in the [*Loop and Learn*: Customization Select Script](https://www.loopandlearn.org/custom-code). Some people prefer to make all their own edits.
+    * The second half of this page provides instructions for some of the prepared customizations included in the [*Loop and Learn*: Customization Select Script](https://www.loopandlearn.org/custom-code){: target="_blank" }. Some people prefer to make all their own edits.
 
 For each customization, you will be given landmarks to find the correct location in the code. You can choose to search using the `Key_Phrase` or navigate to the file in the folder structure and look for the line number. 
 
@@ -389,7 +389,7 @@ Each exponential model has 3 parameters that can be adjusted:
 * peakActivity: Peak of insulin activity (minutes)
 * delay: Delay before insulin begins to acts after delivery starts (minutes)
 
-Please read the nitty-gritty discussion that went into the development of the "exponential insulin models" in this [Comment](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473).
+Please read the nitty-gritty discussion that went into the development of the "exponential insulin models" in this [Comment](https://github.com/LoopKit/Loop/issues/388#issuecomment-317938473){: target="_blank" }.
 
 If you wish to customize these values, please make sure you know what you are doing.  This is not a modification recommended for Loop novices.
 
@@ -423,7 +423,7 @@ This Loop 3 table of default values is provided for convenience. The times are a
 !!! warning "*Mac* Instructions"
     This can be done with Build with Browser but the instructions might need to be adjusted for that case.
 
-If you want an app logo other than the default green circle for your Loop app, you can easily customize this.  To make it easy to generate the correct sizes of icons, you can use a site like [appicon.build](http://www.appicon.build/) or [appicon.co](https://appicon.co/) and just drag and drop your source image. The source image needs to be 1024 pixels x 1024 pixels.  The site will email you a zip file or automatically download a set of files.  Highlight and copy the contents of the Appicon.appiconset that you are sent, including the Contents.json file
+If you want an app logo other than the default green circle for your Loop app, you can easily customize this.  To make it easy to generate the correct sizes of icons, you can use a site like [appicon.build](http://www.appicon.build/){: target="_blank" } or [appicon.co](https://appicon.co/){: target="_blank" } and just drag and drop your source image. The source image needs to be 1024 pixels x 1024 pixels.  The site will email you a zip file or automatically download a set of files.  Highlight and copy the contents of the Appicon.appiconset that you are sent, including the Contents.json file
 
 1. Navigate to the LoopWorkspace folder
 1. Open the OverrideAssetsLoop.xcassets folder
@@ -518,7 +518,7 @@ _Code Before Modification_
 
 #### `"low_carb_limit"`
 
-This first example might be used by a parent for a child with very small carb entries. It is provided as one of the prepared customizations supplied by the [*Loop and Learn* Customization as `"low_carb_limit`"](https://www.loopandlearn.org/custom-code/#custom-list).
+This first example might be used by a parent for a child with very small carb entries. It is provided as one of the prepared customizations supplied by the [*Loop and Learn* Customization as `"low_carb_limit`"](https://www.loopandlearn.org/custom-code/#custom-list){: target="_blank" }.
 
 _Code After Modification to enable the warning at lower levels and limit maximum_
 
@@ -528,7 +528,7 @@ _Code After Modification to enable the warning at lower levels and limit maximum
 
 #### `"high_carb_limit"`
 
-This second example might be used by a person who routinely enters large meals and does not want to be warned with every meal. It is provided as one of the prepared customizations supplied by the [*Loop and Learn* Customization as `"high_carb_limit`"](https://www.loopandlearn.org/custom-code/#custom-list).
+This second example might be used by a person who routinely enters large meals and does not want to be warned with every meal. It is provided as one of the prepared customizations supplied by the [*Loop and Learn* Customization as `"high_carb_limit`"](https://www.loopandlearn.org/custom-code/#custom-list){: target="_blank" }.
 
 _Code After Modification to warn if entry is between 201 and 300g_
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -28,7 +28,7 @@ This section is an early look at what has been added to `dev` since*&nbsp;<span 
 
 ### <span>Support for <code>Libre</code> Sensors</span>
 
-[LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop) support was <span>merged into the `dev` branch</span> in July 2023.
+[LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop){: target="_blank" } support was <span>merged into the `dev` branch</span> in July 2023.
 
 If you are using the *GitHub* / *Browser Build* method, please review: 
 
@@ -50,7 +50,7 @@ Two algorithm experiments have been added to `dev``. These are &nbsp;<span trans
 
 ### <span translate="no">Glucose Based Partial Application</span>&nbsp; (<code>GBPA</code>):
 
-* Originally proposed in [Pull-Request 1988](https://github.com/LoopKit/Loop/pull/1988) for *Loop*.
+* Originally proposed in [Pull-Request 1988](https://github.com/LoopKit/Loop/pull/1988){: target="_blank" } for *Loop*.
 * It is only used when <code>Automatic Bolus</code> (AB) is selected for <code>Dosing Strategy</code>
 * This modification **does not affect the recommended dose**, only how quickly the recommended dose is automatically delivered
 
@@ -102,10 +102,10 @@ The <code>Temp Basal Only</code> <code>Dosing Strategy</code> provides about 17%
 
 ### <span translate="no">Integral Retrospective Correction</span>&nbsp; (<code>IRC</code>):
 
-* Originally proposed in [*Loop* Issue 695](https://github.com/LoopKit/Loop/issues/695)
+* Originally proposed in [*Loop* Issue 695](https://github.com/LoopKit/Loop/issues/695){: target="_blank" }
     * This was tested in a few `forks` but not included into `dev` until recently
-    * Initial merge into dev: [*Loop* PR 2008](https://github.com/LoopKit/Loop/pull/2008)
-* Updated with a modification to limit stacking of <code>IRC</code> with Glucose `Momentum`: [*Loop* PR 2028](https://github.com/LoopKit/Loop/pull/2028)
+    * Initial merge into dev: [*Loop* PR 2008](https://github.com/LoopKit/Loop/pull/2008){: target="_blank" }
+* Updated with a modification to limit stacking of <code>IRC</code> with Glucose `Momentum`: [*Loop* PR 2028](https://github.com/LoopKit/Loop/pull/2028){: target="_blank" }
 * <span translate="no">Integral Retrospective Correction</span>, when enabled:
     * changes the *Loop* app prediction model and thus can affect the recommended dose
     * applies to both <code>Dosing Strategies</code>: <code>Temp Basal</code> or <code>Automatic Bolus</code>
@@ -127,12 +127,12 @@ Note that the Momentum&#8203; term does not just add to the other effects; it is
 ![predicted glucose retrospective section with irc disabled and enabled](img/glucose-details-irc.svg){width="400"}
 {align="center"}
 
-<span>The <code>IRC</code> term</span> is described in this (updated) [comment](https://github.com/LoopKit/Loop/issues/695#issue-310265141) including plots and equations. Some of the information in that comment is repeated below: [<span>Important points about <code>IRC</code></span>](#important-points-about-irc).
+<span>The <code>IRC</code> term</span> is described in this (updated) [comment](https://github.com/LoopKit/Loop/issues/695#issue-310265141){: target="_blank" } including plots and equations. Some of the information in that comment is repeated below: [<span>Important points about <code>IRC</code></span>](#important-points-about-irc).
 
 If you want to look at the code, the version (as of 14-Aug-2023) is found in `LoopKit/LoopKit`:
 
-* <code>RetrospectiveCorrection</code> code: [`StandardRetrospectiveCorrection.swift`](https://github.com/LoopKit/LoopKit/blob/675655b833bcd5aef2391c47562b57a213bfffb4/LoopKit/RetrospectiveCorrection/StandardRetrospectiveCorrection.swift)
-* <code>IntegralRetrospectiveCorrection</code> code: [`IntegralRetrospectiveCorrection.swift`](https://github.com/LoopKit/LoopKit/blob/675655b833bcd5aef2391c47562b57a213bfffb4/LoopKit/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift)
+* <code>RetrospectiveCorrection</code> code: [`StandardRetrospectiveCorrection.swift`](https://github.com/LoopKit/LoopKit/blob/675655b833bcd5aef2391c47562b57a213bfffb4/LoopKit/RetrospectiveCorrection/StandardRetrospectiveCorrection.swift){: target="_blank" }
+* <code>IntegralRetrospectiveCorrection</code> code: [`IntegralRetrospectiveCorrection.swift`](https://github.com/LoopKit/LoopKit/blob/675655b833bcd5aef2391c47562b57a213bfffb4/LoopKit/RetrospectiveCorrection/IntegralRetrospectiveCorrection.swift){: target="_blank" }
 
 #### Important points about <code>IRC</code>
 
@@ -200,10 +200,10 @@ It is strongly recommended that all users of the released code (main branch), ma
 
 For users of the `dev` branch, it is not uncommon to disable the automatic update portion so they can choose when to update their development version, but should probably keep the monthly build portion of the process.
 
-* [Configure GH_PAT](https://github.com/LoopKit/LoopWorkspace/blob/dev/fastlane/testflight.md#gh_pat-workflow-permission)
-* [Modify Scheduled Building and Synchronization](https://github.com/LoopKit/LoopWorkspace/blob/dev/fastlane/testflight.md#modify-scheduled-building-and-synchronization)
+* [Configure GH_PAT](https://github.com/LoopKit/LoopWorkspace/blob/dev/fastlane/testflight.md#gh_pat-workflow-permission){: target="_blank" }
+* [Modify Scheduled Building and Synchronization](https://github.com/LoopKit/LoopWorkspace/blob/dev/fastlane/testflight.md#modify-scheduled-building-and-synchronization){: target="_blank" }
 
-In addition to the easier to read error messages found with these updates, these additional simplification include:
+In addition to the easier to read error messages found with these updates, these additional simplifications include:
 
 * Actions are broken into logical components, each of which provides an easy to understand error message if it fails which includes a suggested fix
 * A new builder no longer needs to create the &nbsp;<span translate="no">Match-Secrets repository</span>
@@ -222,7 +222,7 @@ These sections are still useful for version 3.3.0 `dev` users:
 
 #### G7 Sensors: Duplicate CGM Values
 
-Fixed with [PR 16: Fix parsing of age field of message](https://github.com/LoopKit/G7SensorKit/pull/16)
+Fixed with [PR 16: Fix parsing of age field of message](https://github.com/LoopKit/G7SensorKit/pull/16){: target="_blank" }
 
 * Most sensors report the time with very little offset between time of arrival and time of sensing
 * If the time discrepancy is large, the error (using one byte instead of two for age of the reading) could cause CGM values to appear as duplicate readings in Loop
@@ -235,11 +235,11 @@ The code that feeds Loop data to remote services like Tidepool and Nightscout ha
 
 There is a lot of discussion about *branches* with *Loop* but the concept is simple. Basically, they are all slightly different versions of *Loop*...kind of like different edits of the same book.
 
-To really understand what branches are, we should probably explain a little more about the software and how development works.  You can watch a 30-minute long, classic Katie DiSimone [video explanation about branches](https://www.youtube.com/watch?v=cWqvYs4Azt0&t=4s) created when *Loop* Version 2.0 was newly released. Keep in mind while watching the video that `master` was the old name for the `main` branch. The information in this video is still generally useful with the last half focused on automatic-bolus - the automatic-bolus dosing strategy has now been incorporated into <span>*Loop* `main` branch</span>. *Loop* has moved on to using only one stable branch (`main`), with `dev` recommended for developers/testers.
+To really understand what branches are, we should probably explain a little more about the software and how development works.  You can watch a 30-minute long, classic Katie DiSimone [video explanation about branches](https://www.youtube.com/watch?v=cWqvYs4Azt0&t=4s){: target="_blank" } created when *Loop* Version 2.0 was newly released. Keep in mind while watching the video that `master` was the old name for the `main` branch. The information in this video is still generally useful with the last half focused on automatic-bolus - the automatic-bolus dosing strategy has now been incorporated into <span>*Loop* `main` branch</span>. *Loop* has moved on to using only one stable branch (`main`), with `dev` recommended for developers/testers.
 
 ### `Loop` GitHub Information
 
-*Loop* developers own an account in *GitHub* called [LoopKit](https://github.com/LoopKit).  Within that account, the developers have several <code>repositories</code> that support *Loop* in particular. A repository&#8203; is like a book...let's think of it like a cookbook for now. Within the `LoopKit` account, there are `repositories` for Loop&#8203; itself, *LoopDocs*, and various other supporting "frameworks" that are <span>helper &#8203;repositories&#8203; for *Loop*</span> to build correctly. For example, Loop&#39;s &#8203;repository&#8203; has a lot of info about the app itself; the outward-facing things that you interact with. How information is put to you and taken in from you...that's in *Loop* <code>repository</code> code. But, there's more than just a user interface for Loop. *Loop* has to do a lot of complex work like Bluetooth communications, algorithm math, pump communications, etc. The *Loop* app has help from frameworks to do those other parts. `CGMBLEkit`&nbsp; for some of the transmitter parts of *Loop*, `RileyLink_ios` for the pump managers (talking to the pumps and decoding their information), `LoopKit` for the algorithm about carbs and insulin curves, etc.
+*Loop* developers own an account in *GitHub* called [LoopKit](https://github.com/LoopKit){: target="_blank" }.  Within that account, the developers have several <code>repositories</code> that support *Loop* in particular. A repository&#8203; is like a book...let's think of it like a cookbook for now. Within the `LoopKit` account, there are `repositories` for Loop&#8203; itself, *LoopDocs*, and various other supporting "frameworks" that are <span>helper &#8203;repositories&#8203; for *Loop*</span> to build correctly. For example, Loop&#39;s &#8203;repository&#8203; has a lot of info about the app itself; the outward-facing things that you interact with. How information is put to you and taken in from you...that's in *Loop* <code>repository</code> code. But, there's more than just a user interface for Loop. *Loop* has to do a lot of complex work like Bluetooth communications, algorithm math, pump communications, etc. The *Loop* app has help from frameworks to do those other parts. `CGMBLEkit`&nbsp; for some of the transmitter parts of *Loop*, `RileyLink_ios` for the pump managers (talking to the pumps and decoding their information), `LoopKit` for the algorithm about carbs and insulin curves, etc.
 
 When you build *Loop*, in the background, *Loop* pulls those other frameworks (7 in total) into the build process using `Carthage`.  `Carthage`&nbsp;  is like a personal shopper. You give it a shopping list (the cart file in *Loop* code is that shopping list) and it goes and fetches that for you during the build process. Sometimes your computer has an old shopping list...and that can cause build errors. Hence the `carthage update` fix in the Build Errors page...that command updates the shopping list to get the right versions of those frameworks.
 
@@ -250,7 +250,7 @@ Anyways...so now you know about the general structure of *Loop* and *LoopKit* in
 
 So let's imagine *Loop* as a cookbook. The developers are the authors/chefs of the recipes (code) in the cookbook. The authors spend countless hours testing new recipes, taste testing, and documenting improvements. They send the drafts to the editor, who makes suggestions and eventually, the cookbook is finalized. There are no grammar issues, and no typos, the photos are beautiful and the recipes are yummy. They publish the book and you see a gorgeous final product on the shelves. That is called a release&#8203, and it is the `main` branch. This book has been well-tested and is super stable. Every time you cook with those recipes, you know exactly what you're getting and lots of people have had a chance before you to make sure that it all tastes good. The `main` branch is stable and tested.
 
-But then...the chefs/developers go on a trip. They are inspired by new cuisine and want to add new recipes to the old cookbook. (Things like Omnipod&#8203; support and the overrides are new "recipes" that were developed since the last `main` release, for example.) But, the process of developing a recipe is arduous. There was a lot of trial and error involved. Lots of tweaking ingredients (code). The editors try out the new recipes and offer feedback (similar to the [Issues List on GitHub](https://github.com/LoopKit/Loop/issues)). While the recipes are being developed, they have a version of the old cookbook that gets marked up...edited in pencil a lot. Scribbles and notes in the side. Revisions happen frequently because that's what testing new recipes is all about. These marked-up versions of the cookbook are called the `dev` branch. Short for "development" branch. Like the name sounds...this is where new developments are happening, new recipes, and tweaks.
+But then...the chefs/developers go on a trip. They are inspired by new cuisine and want to add new recipes to the old cookbook. (Things like Omnipod&#8203; support and the overrides are new "recipes" that were developed since the last `main` release, for example.) But, the process of developing a recipe is arduous. There was a lot of trial and error involved. Lots of tweaking ingredients (code). The editors try out the new recipes and offer feedback (similar to the [Issues List on GitHub](https://github.com/LoopKit/Loop/issues){: target="_blank" }). While the recipes are being developed, they have a version of the old cookbook that gets marked up...edited in pencil a lot. Scribbles and notes in the side. Revisions happen frequently because that's what testing new recipes is all about. These marked-up versions of the cookbook are called the `dev` branch. Short for "development" branch. Like the name sounds...this is where new developments are happening, new recipes, and tweaks.
 
 After much testing and tweaking, eventually, the recipes get the flavors right (bugs in code are squashed) and enough people have provided feedback and careful observations of results...that the book goes to the publishing house for the next printing. The cookbook is republished with an updated edition number and new recipes are highlighted. When this happens in *Loop*,  <span>Loop&#39;s `main` branch</span> is updated with the new features coming from `dev` (aka, the `dev` branch is merged into the `main` branch). When that happens, the `main` branch gets another `release` version. At this point, `dev` and `main` are identical. They remain so until the development team for *Loop*&nbsp; starts working on the next batch of improvements, which could be in the next hour or even days later, but then the cycle starts again.  The developers will start editing the code again and dropping those edits in the `dev` branch for further development.
 
@@ -264,24 +264,24 @@ If you choose to use a `dev` build, you can stay abreast of developments in a nu
 
 ### Subscribe to the Zulipchat channels
 
-Use [Zulipchat](https://loop.zulipchat.com) forums for *Loop*.  
+Use [Zulipchat](https://loop.zulipchat.com){: target="_blank" } forums for *Loop*.  
 This forum has several streams of conversations (`streams`) depending on interest. I highly recommend following all the streams so you do not miss conversations.  You can select by stream and by topic within a stream to focus on a given conversation.  
 
 !!! tip "Zulip Chat Streams"
-    - If you are using the **dev** branch, you **must** be in the **[#development](https://loop.zulipchat.com/#narrow/stream/144182-development)** stream.  
-    - If you want to know when **LoopDocs** gets updated, follow the **[#documentation](https://loop.zulipchat.com/#narrow/stream/270362-documentation)** stream.  
+    - If you are using the **dev** branch, you **must** be in the **[#development](https://loop.zulipchat.com/#narrow/stream/144182-development){: target="_blank" }** stream.  
+    - If you want to know when **LoopDocs** gets updated, follow the **[#documentation](https://loop.zulipchat.com/#narrow/stream/270362-documentation){: target="_blank" }** stream.  
     - **Code changes** are called commits in GitHub.  
-      The **[#github](https://loop.zulipchat.com/#narrow/stream/144191-github)** stream will have an automated post whenever a new commit is made and it will give a brief line description of the commit.
+      The **[#github](https://loop.zulipchat.com/#narrow/stream/144191-github){: target="_blank" }** stream will have an automated post whenever a new commit is made and it will give a brief line description of the commit.
 
 ![img/zulipchat.png](img/zulipchat.png){width="650"}
 {align="center"}
 
-You can also go directly to the git commit history for each of the  branches if you'd like.
+You can also go directly to the git commit history for each of the branches if you'd like.
 
-- [`Loop` **`main`** branch: git commit history](https://github.com/LoopKit/Loop/commits/main)
-- [`Loop` **`dev`** branch: git commit history](https://github.com/LoopKit/Loop/commits/dev)
+- [`Loop` **`main`** branch: git commit history](https://github.com/LoopKit/Loop/commits/main){: target="_blank" }
+- [`Loop` **`dev`** branch: git commit history](https://github.com/LoopKit/Loop/commits/dev){: target="_blank" }
 
-If you click on the commit, you can see exactly what changes to the code were made. It's an interesting learning experience. In red is the code that is old, and in green is the updated code. The line numbers and file names of the edited code are also there to help.
+If you click on the commit, you can see exactly what changes to the code were made. It's an interesting learning experience. In red is the old code, and in green is the updated code. The line numbers and file names of the edited code are also there to help.
 
 ![img/commit.png](img/commit.png){width="550"}
 {align="center"}
@@ -290,16 +290,16 @@ I don't expect many of you would understand exactly what the edits mean, or how 
 
 ### Watch the `Loop Repository` and `Issues List`
 
-Open the [`Loop repository`](https://github.com/LoopKit/Loop) and subscribe to the `Issues`. 
+Open the [`Loop repository`](https://github.com/LoopKit/Loop){: target="_blank" } and subscribe to the `Issues`. 
 
-You can choose to watch the `repository` so that you get emails when new `Issues` are reported. This is a good way to find out if there are other people reporting odd behavior that you are wondering about. If you use `dev` and wonder about something you are seeing in *Loop*, you can check [`Issues` list](https://github.com/LoopKit/Loop/issues) to see if others are noticing the same. If so, you can help by capturing information and reporting it. Not super helpful to just say "Yeah, me too..." but better if you can attach screenshots, `Issue Reports` from *Loop* settings, and a thorough description of the problem you are seeing. Be a part of the solution by thoughtfully providing information to help debug.
+You can choose to watch the `repository` so that you get emails when new `Issues` are reported. This is a good way to find out if other people are reporting odd behavior that you are wondering about. If you use `dev` and wonder about something you are seeing in *Loop*, you can check [`Issues` list](https://github.com/LoopKit/Loop/issues){: target="_blank" } to see if others are noticing the same. If so, you can help by capturing information and reporting it. Not super helpful to just say "Yeah, me too..." but better if you can attach screenshots, `Issue Reports` from *Loop* settings, and a thorough description of the problem you are seeing. Be a part of the solution by thoughtfully providing information to help debug.
 
 ![img/watching.png](img/watching.png){width="650"}
 {align="center"}
 
 ### Keep checking `Looped` group
 
-Keep watching [`The Looped Group`](https://www.facebook.com/groups/TheLoopedGroup) on  *Facebook*. Major concerns/issues are brought up there...so it doesn't hurt to scroll through and see what's going on there.
+Keep watching [`The Looped Group`](https://www.facebook.com/groups/TheLoopedGroup){: target="_blank" } on  *Facebook*. Major concerns/issues are brought up there...so it doesn't hurt to scroll through and see what's going on there.
 
 ### Become familiar with your data sources
 
@@ -312,24 +312,24 @@ Know how to generate an `Issue Report` when you see a problem so you can provide
 * *<span translate="no">Loop v2.2.9</span>*&nbsp; and earlier:` Loop Settings -> Issue Report`
 * *<span translate="no">Loop 3</span>*&nbsp; and later: `Loop Settings -> Support -> Issue Report`
 
-Do not confuse this with reporting an issue with *Loop*.  That is done by logging into *GitHub* and going to the [`Issue` page](https://github.com/LoopKit/Loop/issues) to report a new issue.  You can read about existing issues without logging in, but to report a new one, you must log in to *GitHub*.
+Do not confuse this with reporting an issue with *Loop*.  That is done by logging into *GitHub* and going to the [`Issue` page](https://github.com/LoopKit/Loop/issues){: target="_blank" } to report a new issue.  You can read about existing issues without logging in, but to report a new one, you must log in to *GitHub*.
 
 ### Create a Debug Report
 
-This 6-minute long, classic Katie DiSimone video shows how to [capture debugging logs](https://youtu.be/Ac4MguvUO7M). If you are testing a new branch, this is a valuable skill to assist developers in identifying problems. In addition to showing you how to generate and save the debug text information, the video explains how to create a <code>gist</code> with the debug information using your *GitHub* account and file an official Issue on the *Loop* *GitHub* <code>repository</code>. This may be required in some cases.  But start by chatting directly on [Zulipchat](https://loop.zulipchat.com) with the developer. What you are experiencing may already be known. If the developers need you to open a new `Issue`, they will say so on *Zulipchat*.
+This 6-minute long, classic Katie DiSimone video shows how to [capture debugging logs](https://youtu.be/Ac4MguvUO7M){: target="_blank" }. If you are testing a new branch, this is a valuable skill to assist developers in identifying problems. In addition to showing you how to generate and save the debug text information, the video explains how to create a <code>gist</code> with the debug information using your *GitHub* account and file an official Issue on the *Loop* *GitHub* <code>repository</code>. This may be required in some cases.  But start by chatting directly on [Zulipchat](https://loop.zulipchat.com){: target="_blank" } with the developer. What you are experiencing may already be known. If the developers need you to open a new `Issue`, they will say so on *Zulipchat*.
 
 
 ## `Repositories` and Code
 
 If you're a developer looking for direct links to the **code and documentation** in *GitHub*:
 
-* [`Loop`](https://github.com/LoopKit/Loop)
-* [`LoopDocs`](https://github.com/LoopKit/Loopdocs)
+* [`Loop`](https://github.com/LoopKit/Loop){: target="_blank" }
+* [`LoopDocs`](https://github.com/LoopKit/Loopdocs){: target="_blank" }
 
 For more information on **how to contribute code to the *Loop* project**, please review:
 
-  * [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
-  * the [LICENSE](https://github.com/LoopKit/Loop/blob/main/LICENSE.md)
-  * the  [CODE_OF_CONDUCT](https://github.com/LoopKit/Loop/blob/main/CODE_OF_CONDUCT.md)
+  * [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/){: target="_blank" }
+  * the [LICENSE](https://github.com/LoopKit/Loop/blob/main/LICENSE.md){: target="_blank" }
+  * the  [CODE_OF_CONDUCT](https://github.com/LoopKit/Loop/blob/main/CODE_OF_CONDUCT.md){: target="_blank" }
 
-If you want to contribute **code improvements**, please join [*Loop Zulipchat*](https://loop.zulipchat.com) and be sure to subscribe to all the channels. Meet the developers and testers who make this app, and learn about what is coming next.
+If you want to contribute **code improvements**, please join [*Loop Zulipchat*](https://loop.zulipchat.com){: target="_blank" } and be sure to subscribe to all the channels. Meet the developers and testers who make this app, and learn about what is coming next.

--- a/docs/version/loopworkspace.md
+++ b/docs/version/loopworkspace.md
@@ -40,7 +40,7 @@ There are several ways to use this to sign the targets automatically.
 
 Your Apple Developer ID is the 10-character Team ID
   found on the Membership page after logging into your account at:
-   [https://developer.apple.com/account/#!/membership](https://developer.apple.com/account/#!/membership).
+   [https://developer.apple.com/account/#!/membership](https://developer.apple.com/account/#!/membership){: target="_blank" }.
 
 
 ### What is git?
@@ -55,7 +55,7 @@ But yes, git commands take awhile to properly use. And they are not plain Englis
 
 There is more information in [Loop Development](../version/development.md#what-are-git-branches) that is not repeated here.
 
-The important fact for this discussion on *LoopWorkspace* is that Loop developers own an account in *GitHub* called [`LoopKit`](https://github.com/LoopKit).  Within that account, the developers have several `repositories` that support *Loop* in particular. A `repository` is like a book...let's think of it like a cookbook for now. Within the `LoopKit` account, there are repositories for *Loop* itself, *LoopDocs*, and various other supporting "frameworks" that are helper repositories for Loop to build correctly. For example, Loop&#39;s repo has a lot of info about the app itself; and the outward-facing things that you interact with. How information is put to you and taken in from you...that's in *Loop* `repository` code. But, there's more than just a user interface for *Loop*. Loop has to do a lot of complex work like Bluetooth communications, algorithm math, pump communications, etc. The *Loop* app has help from frameworks to do those other parts. `CGMBLEkit` for some of the transmitter parts of *Loop*, `RileyLink_ios` for the pump managers (talking to the pumps and decoding their information), *LoopKit* for the algorithm about carbs and insulin curves, etc.
+The important fact for this discussion on *LoopWorkspace* is that Loop developers own an account in *GitHub* called [`LoopKit`](https://github.com/LoopKit){: target="_blank" }.  Within that account, the developers have several `repositories` that support *Loop* in particular. A `repository` is like a book...let's think of it like a cookbook for now. Within the `LoopKit` account, there are repositories for *Loop* itself, *LoopDocs*, and various other supporting "frameworks" that are helper repositories for Loop to build correctly. For example, Loop&#39;s repo has a lot of info about the app itself; and the outward-facing things that you interact with. How information is put to you and taken in from you...that's in *Loop* `repository` code. But, there's more than just a user interface for *Loop*. Loop has to do a lot of complex work like Bluetooth communications, algorithm math, pump communications, etc. The *Loop* app has help from frameworks to do those other parts. `CGMBLEkit` for some of the transmitter parts of *Loop*, `RileyLink_ios` for the pump managers (talking to the pumps and decoding their information), *LoopKit* for the algorithm about carbs and insulin curves, etc.
 
 When you build *Loop* from `LoopWorkspace`, each of those repositories is downloaded to your computer.  This is slower than the old zip-download as far as downloading *Loop* - but it is much faster when you build Loop because all the files are already on your computer.
 
@@ -163,7 +163,7 @@ Be sure your terminal is in the correct location using [Open a Terminal in `Loop
     git pull --recurse
     ```
 
-If you are testing the LoopKit dev branch, you need to be on [zulipchat](https://loop.zulipchat.com) and subscribe to at least the #development and #github streams. (It's a good idea to subscribe to all the streams.) When you see repository updates similar to the graphic below, there may also be an announcement in the #development channel that LoopWorkspace is updated and ready to test. If not you can check the commits in LoopWorkspace and see if they've been updated. It's a good idea to wait 24 hours. My procedure is to build dev to my backup phone and then put it on my "real" phone. Otherwise, wait for someone else to do it and give the all-clear in zulipchat.
+If you are testing the LoopKit dev branch, you need to be on [zulipchat](https://loop.zulipchat.com){: target="_blank" } and subscribe to at least the #development and #github streams. (It's a good idea to subscribe to all the streams.) When you see repository updates similar to the graphic below, there may also be an announcement in the #development channel that LoopWorkspace is updated and ready to test. If not you can check the commits in LoopWorkspace and see if they've been updated. It's a good idea to wait 24 hours. My procedure is to build dev to my backup phone and then put it on my "real" phone. Otherwise, wait for someone else to do it and give the all-clear in zulipchat.
 
 ![there has been an update in three submodules](img/zulipchat-github.svg){width="600"}
 {align="center"}
@@ -341,11 +341,11 @@ There are 2 main ways to do this.
 This tutorial is pretty nice.
 
 !!! tip "Git Tutorial"
-    When I first started using git, my adult son answered all my questions very politely then started sending me links to this tutorial instead.
+    When I first started using git, my adult son answered all my questions very politely and then started sending me links to this tutorial instead.
 
-    * [Learn Git Branching](https://learngitbranching.js.org/)
+    * [Learn Git Branching](https://learngitbranching.js.org/){: target="_blank" }
 
-    There's a section called `Main` which goes over commands in your local copy (clone) of the code. There's a section called `Remote` that goes over fetching, pulling, and pushing to remote copies.
+    There's a section called `Main` that goes over commands in your local copy (clone) of the code. There's a section called `Remote` that goes over fetching, pulling, and pushing to remote copies.
 
     For Open Source Software, you might fetch and pull from the LoopKit repositories, but you will only push to your fork.
 
@@ -362,7 +362,7 @@ Scenario: You have a friend named DeveloperBob who has his own version of LoopWo
 `git clone --branch=new-features --recurse-submodules https://github.com/DeveloperBob/LoopWorkspace`
 
 So...if you are trying to grab someone's LoopWorkspace to use it, you'll need to make sure you get the command correct if they don't specify it for you.
-You can't clone mutliple "LoopWorkspaces" into the exact same home directory (because they will have the same name), so you may want to create a subdirectory to put them in. Like you could make a folder called "DeveloperBob" and then move into that directory in Terminal before you clone DeveloperBob's LoopWorkspace.
+You can't clone multiple "LoopWorkspaces" into the exact same home directory (because they will have the same name), so you may want to create a subdirectory to put them in. Like you could make a folder called "DeveloperBob" and then move into that directory in Terminal before you clone DeveloperBob's LoopWorkspace.
 
 How would you do that? Simple `cd && mkdir DeveloperBob` would make the new folder in your home directory. And then `cd DeveloperBob` would move your Terminal app to be working inside the new DeveloperBob folder. So if you wanted to clone DeveloperBob's LoopWorkspace, that would be a good way to keep track of where the code came from.
 
@@ -370,12 +370,12 @@ If you ever get in doubt and can't remember where your code was cloned from, you
 
 ## Pushing commits from LoopWorkspace
 
-So you've got a great idea for a new feature, made those changes to your LoopWorkspace and want to get them into GitHub. Awesome!
+So you've got a great idea for a new feature, made those changes to your LoopWorkspace, and want to get them into GitHub. Awesome!
 
-To understand how to do this, we'll need to understand a bit more about how git keeps track of changes. In git, developers can have different "branches" (see [What are Git Branches?](../version/development.md#what-are-git-branches) on the Loop Development page for more details about what a branch is). There are two different types of branches: remote and local. If you were to fork Loop on GitHub, then the branches that you can see on GitHub are "remote" branches - they're hosted on the GitHub server. On the other hand, you can also create "local" branches that are stored directly on your computer by "checking out" the remote branch. You'll need to "commit" your changes to the local branch, then "push" those changes to the remote branch in order to be able to see them in GitHub. There are specific commands that you can type into the command line to do all of these actions, but I'm not going to go into detail because there are different ways and everyone has their own preference.
+To understand how to do this, we'll need to understand a bit more about how git keeps track of changes. In git, developers can have different "branches" (see [What are Git Branches?](../version/development.md#what-are-git-branches) on the Loop Development page for more details about what a branch is). There are two different types of branches: remote and local. If you were to fork Loop on GitHub, then the branches that you can see on GitHub are "remote" branches - they're hosted on the GitHub server. On the other hand, you can also create "local" branches that are stored directly on your computer by "checking out" the remote branch. You'll need to "commit" your changes to the local branch, and then "push" those changes to the remote branch in order to be able to see them in GitHub. There are specific commands that you can type into the command line to do all of these actions, but I'm not going to go into detail because there are different ways and everyone has their own preference.
 
 It's a little easier to think about this with an analogy. Let's say you're working at a company that's creating a cookbook. There's a centralized, production-ready version of the cookbook on their website that all the employees can view. Think of the website version of this cookbook as being like the remote branch. You're assigned to change the pancake recipe in the cookbook. Since the company doesn't want employees to make changes directly to the version of the cookbook that the customers see, you need to make a copy of it on your computer so you can make your changes to the pancake recipe. When you make the personal copy on your computer, it's like "checking out" the remote branch. Your copy is like the local branch - you can make whatever changes you want without having to worry about customers accidentally seeing them. When you make an important change to the recipe (like adding a photo or changing the ingredients), you might want to make a note in the edit history so that you can go back to that version of the recipe in case you accidentally make unintended changes - those notes you make would be "commits". Once you're happy with the recipe, you'll add it back into the production version of the cookbook on the website, which is similar to what you're doing when you "push" your changes.
 
 Where do the submodules fit in? Each submodule is actually a branch, so when you make changes to multiple submodules, you'll need to commit those changes to their respective branches. Let's say you've made changes to Loop and LoopKit. You'll need to go into Loop and commit and push the changes, then go into LoopKit and commit and push the changes.
 
-There are a few different ways to keep track of all these different branches. Some people like using the command line (which is what you're using when you do commands like `git clone`) because it's very customizable and has the largest variety of commands. Others like to use graphical Git editors, which make it easier to see changes and be able to do a variety of common actions (like cloning, committing, and pushing) with the push of a button. Everyone has their own preferences, but some methods that Loop contributors have used in the past include the command line, [Gitkraken](https://www.gitkraken.com/), and [SourceTree](https://www.sourcetreeapp.com/).
+There are a few different ways to keep track of all these different branches. Some people like using the command line (which is what you're using when you do commands like `git clone`) because it's very customizable and has the largest variety of commands. Others like to use graphical Git editors, which make it easier to see changes and be able to do a variety of common actions (like cloning, committing, and pushing) with the push of a button. Everyone has their own preferences, but some methods that Loop contributors have used in the past include the command line, [Gitkraken](https://www.gitkraken.com/){: target="_blank" }, and [SourceTree](https://www.sourcetreeapp.com/){: target="_blank" }.

--- a/docs/version/releases.md
+++ b/docs/version/releases.md
@@ -30,7 +30,7 @@ Tap on the Settings icon at the toolbar of the *Loop* app and look at the versio
 
 ### Is the Released Version Newer?
 
-Release information is always found on the [*GitHub*&nbsp;_<span translate="no">LoopKit/Loop</span>_&nbsp;release page](https://github.com/LoopKit/Loop/releases).
+Release information is always found on the [*GitHub*&nbsp;_<span translate="no">LoopKit/Loop</span>_&nbsp;release page](https://github.com/LoopKit/Loop/releases){: target="_blank" }.
 
 Additional information including links is found here, but be aware that updates to&nbsp;_<span translate="no">LoopDocs</span>_&nbsp;may take some time after a new release comes out.
 
@@ -91,12 +91,12 @@ Pete's announcment:
 
 Loop 3.2 Is released! This contains some very important bug fixes for everyone. If you are running latest dev, you do not need to update, but everyone else running older 3.x versions of Loop should consider upgrading as soon as you can.
 
-[https://github.com/LoopKit/Loop/releases/tag/v3.2.0](https://github.com/LoopKit/Loop/releases/tag/v3.2.0)
+[https://github.com/LoopKit/Loop/releases/tag/v3.2.0](https://github.com/LoopKit/Loop/releases/tag/v3.2.0){: target="_blank" }
 
 Bug Fixes (Please update ASAP):
 
-* Omnipod bolus tracking issue fixed: [link](https://github.com/LoopKit/Loop/issues/1941)
-* Medtronic temp basal tracking issue fixed: [link](https://github.com/ps2/rileylink_ios/pull/775)
+* Omnipod bolus tracking issue fixed: [link](https://github.com/LoopKit/Loop/issues/1941){: target="_blank" }
+* Medtronic temp basal tracking issue fixed: [link](https://github.com/ps2/rileylink_ios/pull/775){: target="_blank" }
 * Crashes caused by large updates from Apple Health fixed
 * Automatic refresh timers for Omnipod (both Dash and Eros) have been removed, to reduce load on pods and reduce frequency of failed pods.
 
@@ -106,9 +106,9 @@ Updates and new Features:
 * Tidepool Service added. This lets you upload your diabetes data from Loop to Tidepool! It is in early stages, so there may be issues. Please report any issues you have with this integration on DIY Loop forums, like Zulip, GitHub, or the Looped group.
 * Translations! Loop now has very good coverage for several languages, including German, Spanish, Italian, French, Danish, Polish, Dutch, Norwegian, Russian, Turkish, and Romanian!
     * Warning - a few items got overwritten by Spanish - if you can't figure it out, try Google translate
-* A new safeguard restricts automatic dosing to keep your IOB below a limit of 2 times your max bolus. Manual dosing can still be delivered to put your IOB above this amount. [link](https://github.com/LoopKit/Loop/pull/1871)
-* Add missing X-Large watch complications. [link](https://github.com/LoopKit/Loop/pull/1901)
-* “Deactivate Pod” button on some screens changed to not be so alarming, as it doesn’t actually deactivate the pod, but takes you to a screen where you can, and has an option to cancel: [link](https://github.com/LoopKit/OmniBLE/pull/76)
+* A new safeguard restricts automatic dosing to keep your IOB below a limit of 2 times your max bolus. Manual dosing can still be delivered to put your IOB above this amount. [link](https://github.com/LoopKit/Loop/pull/1871){: target="_blank" }
+* Add missing X-Large watch complications. [link](https://github.com/LoopKit/Loop/pull/1901){: target="_blank" }
+* “Deactivate Pod” button on some screens changed to not be so alarming, as it doesn’t actually deactivate the pod, but takes you to a screen where you can, and has an option to cancel: [link](https://github.com/LoopKit/OmniBLE/pull/76){: target="_blank" }
 
 
 
@@ -118,7 +118,7 @@ After several years of development and a lot of testing, Loop 3 is here!
 
 Loop v3.0.0 was released on January 14, 2023.
 
-[Link to release notes for Loop 3.0](https://github.com/LoopKit/Loop/releases/tag/v3.0.0)
+[Link to release notes for Loop 3.0](https://github.com/LoopKit/Loop/releases/tag/v3.0.0){: target="_blank" }
 
 !!! warning "Use Script not Zip"
     If you follow that link above, there is an `Assets` section with a zip link
@@ -142,7 +142,7 @@ The storage of data with Loop 3 is not backward compatible. In other words, if y
 
 At this point, you can restore your Loop 3 build on your phone and continue using Loop 3 or you delete all apps on your phone with a shared app group. This list includes Loop, FreeAPS, FreeAPS X, xDrip4iOS, Glucose-Direct, and the g5 Transmitter Reset app.
 
-If you tried to delete "all" the apps and still have something causing an issue; you can follow the directions to [Review Provisioning Profiles](https://www.loopandlearn.org/loop-expiration-date) and then delete the profiles for all the apps by using the - sign. 
+If you tried to delete "all" the apps and still have something causing an issue; you can follow the directions to [Review Provisioning Profiles](https://www.loopandlearn.org/loop-expiration-date){: target="_blank" } and then delete the profiles for all the apps by using the - sign. 
 
 You do not need to delete Loop Follow, so if you use Loop Follow - do not delete that provisioning profile.
 
@@ -220,12 +220,12 @@ Omnipod Code Fixes:
 * Make insertion more robust (LoopKit issue #1369)
 * Fix “Pod already primed” errors when priming cancelled (rileylink_ios issue #661)
 * Prevent 049 pod faults during setup (rileylink_ios issue #627)
-* See [RileyLink Pull Request 676](https://github.com/ps2/rileylink_ios/pull/676) for additional details.
+* See [RileyLink Pull Request 676](https://github.com/ps2/rileylink_ios/pull/676){: target="_blank" } for additional details.
 
 (REMOVED) Insulin Accounting:
 
 * Reduced occurrences of overlaps in accounting for insulin via reservoir and dose history, which causes temporary overestimation of IOB
-* See [Loop Pull Request 344](https://github.com/LoopKit/LoopKit/pull/344) for details
+* See [Loop Pull Request 344](https://github.com/LoopKit/LoopKit/pull/344){: target="_blank" } for details
 * This modification (in v2.2.5) was removed for v2.2.6
     - It worked as advertised during testing, but . . .
     - If the user's phone had trouble communicating with the Apple HealthKit app, this could cause IOB to be under-reported and cause Loop to provide more insulin than needed


### PR DESCRIPTION
This PR improves LoopDocs' _User Experience_ when clicking a link to an external site.

Links to external websites will now open in a new window (or a new tab depending on the browser's configuration) whereas before it was opening in the same window.

The PR also:
- appends the attribute list suffix `{: target="_blank" }` to existing external links so that they open in a new window
- replaces mentions of `right-click the link to open in a new tab` with `click ...`.
- Updates the _README_ to explain how to make an external link open in a new window

Most non-tech-savvy users do not know how to open links in a new tab/window using `⌘ Click` (Command-Click) on Mac or `⌃ Click` (Control-Click) on Windows. The goal is to help them so that they do not lose track of where they have been in LoopDocs as soon as they close the new window.

🙏🏻 Thank you @dnzxy for suggesting this improvement:

```markdown
[Link Label](Link URL){:target="_blank"}
```


