### PR TITLE
⬆️  Upgrade `actions/setup-python` to `v5` from `v4`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install -r requirements.txt


### PR DESCRIPTION
`actions/setup-python` also uses Node.js v16 and needs to be upgraded as this version of Node is deprecated on GitHub Actions.

Fix #781 ([part 2](https://github.com/LoopKit/loopdocs/issues/781#issuecomment-1912101612))