### PR TITLE
💄 Fix/mermaid diagram colors differs from loop color scheme #2

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -13,8 +13,12 @@ article ul ul ul {
         list-style-type:  square !important;
 }
 
+
 .mermaid { 
-   --md-mermaid-node-fg-color:  #18A0A0;
+  --md-mermaid-sequence-number-bg-color: #18A0A0;
+  --md-mermaid-sequence-actorman-line-color: #18A0A0;
+  --md-mermaid-sequence-node-fg-color: #18A0A0;
+  --md-mermaid-sequence-actor-border-color: #18A0A0;
 }
 
 .passed {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,8 @@ theme:
 # repo_url: https://github.com/LoopKit/Loop
 
 extra_css:
-    - stylesheets/extra.css
     - stylesheets/primary-color.css
+    - stylesheets/extra.css
 
 markdown_extensions:
     - meta


### PR DESCRIPTION
The foreground color of [Mermaid Diagrams](https://loopkit.github.io/loopdocs/faqs/cgm-faqs/?h=transmitter#dexcom-g5-g6-and-one) does not follow LoopDoc's color scheme.

This PR fixes issue [#588](https://github.com/LoopKit/loopdocs/issues/588#issuecomment-1914872337).