### PR TITLE
Change explanation of insulin activity

### DIFF
--- a/docs/operation/algorithm/prediction.md
+++ b/docs/operation/algorithm/prediction.md
@@ -94,7 +94,7 @@ The insulin effect can be expressed mathematically:
 
 $$ \Delta BG_{I}[t] = ISF[t] \times IA[t] $$
 
-where BG is the expected change in blood glucose with the units (mg/dL/5min), ISF is the insulin sensitivity factor (mg/dL/U) at time t, and IA is the insulin activity (U/5min) at time *t*. Insulin activity can also be thought of as a velocity or rate of change in blood glucose due to insulin. The insulin activity accounts for the EGP and any active insulin from basals and boluses.
+where BG is the expected change in blood glucose with the units (mg/dL/5min), ISF is the insulin sensitivity factor (mg/dL/U) at time t, and IA is the insulin activity (U/5min) at time *t*. Insulin activity can also be thought of as a velocity or rate of change in insulin in the blood as it acts on glucose. Insulin activity explicitly accounts for active insulin from temporary basals and boluses, and implicitly accounts for scheduled basal which is assumed to balance out with EGP.
 
 ## Carbohydrate Effect
 


### PR DESCRIPTION
First part of the proposed change:

Original text of first sentence cannot be right - delta BG is the velocity or rate of change in blood glucose due to insulin, so this cannot also be the definition of insulin activity. Have proposed a change that inverts this part of the sentence, which I think is consistent with the relationship of IA and Delta BG in the formula; but there may be a better physiological explanation.

Second part of the proposed change:

My change in the second sentence I'm not fully comfortable with, but the original sentence I found confusing. What is the EGP? How does it account for the EGP? Does 'basal' in this sentence relate to scheduled basal or variations from it due to temporary basals?

Initially I came here just to propose an edit so that EGP was defined (unlike ISF, Loop etc it doesn't get the 'definition on hover over' treatment) but on closer reading the sentence didn't seem right