### PR TITLE
➖ Remove mkdocs-material-extensions now deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ mkdocs==1.6.0
 mkdocs-get-deps==0.2.0
 mkdocs-htmlproofer-plugin==1.2.1
 mkdocs-material==9.5.21
-mkdocs-material-extensions==1.3.1
 mkdocs-redirects==1.2.1
 mkdocs-unused-files==0.2.0
 packaging==24.0


### PR DESCRIPTION
This PR removes the `mkdocs-material-extensions` dependency.

The `mkdocs-material-extensions` package is now deprecated because it provided a feature that is now part of `mkdocs-material`. 
> This project is now deprecated as `mkdocs-material` now implements this logic directly. Users should migrate to using `mkdocs-material`'s `material.extensions.emoji.twemoji` and `material.extensions.emoji.to_svg` in place of the respective `materialx.emoji.twemoji` and `materialx.emoji.to_svg` functions provided by this library.

Source: https://github.com/facelessuser/mkdocs-material-extensions

The migration to use `mkdocs-material` native syntax instead was made a long time ago in LoopDocs.


Even if `mkdocs-material` still depends on it, it is redundant.
You can remove it manually, even if `mkdocs-material` still pulls it for now.

```shell
pip uninstall mkdocs-material-extensions
```

