### PR TITLE
limit automatic publish to LoopKit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: github.repository_owner == 'LoopKit'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
If a user makes a fork from LoopKit/loopdocs and then pushes a change to their main branch and has actions and github pages enabled, then the publish.yml file would publish a version of loopdocs under their username.

This modification limits the automatic publish upon push to main branch to just the official LoopKit version of loopdocs.

Others can still publish if they choose, but this limits inadvertent creation of copies of loopdocs that might not be up-to-date.