### PR TITLE
✏️ Remove links from Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,19 +250,12 @@ title: How to prevent Google Translate from automatically translating a text?
 ---
 flowchart TD
     A[Start] --> B{Is Text a Key, Identifier,<br/> Variable, Filename, Folder, <br/>Error Message,<br/> or UI Label?}
-    click A "#entity"
     B --> |Yes| C{is Text <br/>a Glossary Item?}
-    click C "#entity"
     C --> |Yes| D["&lt;code&gt;text&lt;/code&gt;"]
-    click D "#entity"
-    C --> |No| E[`text`]
-    click E "#entity"
+    C --> |No| E["&grave;text&grave;"]
     B --> |No| F{Is Text <br/>a Product Name,<br/>a Project Name,<br/>or a Brand Name?}
-    click F "#name"
-    F --> |Yes| G[*text*]
-    click G "#name"
+    F --> |Yes| G["&ast;text&ast;"]
     F --> |No| H["&lt;span translate=&quot;no&quot;&gt;text&lt;span&gt;"]
-    click H "#generic"
 ```
 
 If the automatic translation is still incorrect after applying these rules, [read this](#when-rules-fail).


### PR DESCRIPTION
This PR fixes the Mermaid **flowchart diagram** an the text of nodes in the `README file.
It: 
- removes links (no longer functional)
- replaces the star (`*`) and backtick (`` ` ``) characters in the text nodes with HTML entities (resp. (`&ast;`) and (``)) to prevent these characters from being interpreted. 
 
These characters (`*` and `` ` ``) were previously interpreted as regular text.
GitHub recently made a configuration change to **enable Markdown by default** in the **text of a Node**. They are now interpreted as the Markdown directives _italic_ and _inline code block_.
The fix is to replace these characters with the appropriate HTML entity so that they are displayed literally.

Character | When Replaced with this HTML Entity | is rendered in a Text Node as
---       |                  ---                |---
 `*`      | `&ast;`                             | `*` 
 `` ` ``  | `&grave;`                           | `` ` ``

Markdown in text Node          | Input            | Rendered Output
---                            | ---              | ---
Disabled (previous default)    | `*text*`         | `*text*`
Disabled                       | `` `text` ``     | `` `text` ``
Enabled (new default)          | `*text*`         | *text*
Enabled                        | `&ast;text&ast;` | `*text*`
Enabled                        | `` `text` ``      | `&grave;text&grave;`



