### PR TITLE
👽️ Fix Broken image URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Open **your** **`loopdocs` repository** on Github: `https://github.com/YOUR_GITH
 5. **Second** drop-down: Select **`"/(root)"`**
 6. Click **`Save`** 
 
->    ![GitHub Pages Configuration](/LoopKit/loopdocs/raw/main/img/gh_pages_config.png)
+>    ![GitHub Pages Configuration](img/gh_pages_config.png)
 
 
 


### PR DESCRIPTION
GitHub changed the way raw.githubusercontent.com URLs are built.
The URL is now much simpler because we no longer need to build an image URL using such a convoluted method.