### PR TITLE
🔧 Ensure the `/loopdocs/` path prefix is present in local and on GitHub Pages URLs built dynamically

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
 site_name: LoopDocs
+site_url: https://loopkit.github.io/loopdocs/
 
 theme:
     name: material


### PR DESCRIPTION
Even if the `/loopdocs/` path prefix is always present in Loopdocs' static URLs it is not in dynamic URLs.
Some URLs are built dynamically like the ones in `404.html` which makes this page broken because its assets (CSS, images...) are searched in `/` instead of their actual location `/loopdocs/`. 

This PR fixes this by making things explicit by adding this prefix to the path using the [`site_url`](https://www.mkdocs.org/user-guide/configuration/#site_url) property:

```yaml
site_url: https://loopkit.github.io/loopdocs/
```
Below is a screenshot of the broken `404.html` when rendered.

> ![CleanShot 2025-01-13 at 10 53 49@2x](https://github.com/user-attachments/assets/d48488ef-c16c-4bae-b036-746544ef306a)
