### PR TITLE
✏️ Fix LibreTransmitter repository URL

### DIFF
--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -130,7 +130,7 @@ It is suggested that you enable [Remote Upload from Loop](#remote-upload-from-lo
 
 ### Libre
 
-The Libre plugin for Loop, [LibreTransmitter](https://github.com/dabear/LibreTransmitter#libretransmitter-for-loop), connects directly via Near Field Communication (NFC) during pairing (for some sensors) and via Bluetooth (direct to sensor or direct to a transmitter attached to the sensor) for regular readings. No other app is needed.
+The Libre plugin for Loop, [LibreTransmitter](https://github.com/LoopKit/LibreTransmitter/), connects directly via Near Field Communication (NFC) during pairing (for some sensors) and via Bluetooth (direct to sensor or direct to a transmitter attached to the sensor) for regular readings. No other app is needed.
 
 * Libre 1 are supported but must use a third-party transmitter (miaomiao and bubble transmitters are supported)
 * European Libre 2 can be used directly or via transmitter


### PR DESCRIPTION
> _Dabear_ `LibreTransmitter` repository is now being retired and archived as it has been upstreamed.

However, LoopDocs's [_Add CGM_ page](https://loopkit.github.io/loopdocs/loop-3/add-cgm/#libre)  still contains the old repository URL.

This PR corrects this page to use the new repository URL: 
  https://github.com/LoopKit/LibreTransmitter/

Cf. https://loopandlearneditors.slack.com/archives/C03HD46P8CS/p1737210729918899