### PR TITLE
Minor Updates

### DIFF
--- a/docs/browser/bb-errors.md
+++ b/docs/browser/bb-errors.md
@@ -120,7 +120,7 @@ Early in the log file you will see two phrases in red font:
 
 > security: SecItemCopyMatching: The specified item could not be found in the keychain.
 
-This is normal. The next steps will set up a keychain for you using your Match-Secrets repository and your MATCH_PASSWORD pass phrase.
+This is normal. The next steps will set up a keychain for you using your Match-Secrets repository and your MATCH_PASSWORD passphrase.
 
 #### Where to find the Certificate Solutions
 
@@ -198,7 +198,7 @@ These are some of the most common errors to date.
 1. You made a spelling error when adding <code>Secrets</code>
     * Each secret must be spelled exactly the way it is presented in the instructions
     * If you are using an automatic translation, please keep an original page open too and copy from it to make sure there are no spelling errors in the secret name
-1. You did not add the `App Group Identifier` to all 4 of the required identifiers in this step: [Add `App Group` to `Identifiers`](prepare-app.md#add-app-group-to-identifiers){: target="_blank" }
+1. You made a spelling error in creating the `App Group Identifier` or did not add the `App Group Identifier` to all 4 of the required identifiers in this step: [Add `App Group` to `Identifiers`](prepare-app.md#add-app-group-to-identifiers){: target="_blank" }
     * See [Annotation without Clear Message (*Build*)](#annotation-without-clear-message-build) for an example of this kind of failure
 1. You used a smart editor instead of a text-only editor to save your information
     * It only takes one letter to be changed from small to capital by your smart editor to ruin your day

--- a/docs/build/build-dev-mac.md
+++ b/docs/build/build-dev-mac.md
@@ -18,13 +18,14 @@ There is a script to assist in building the `dev branch`. It gives you the optio
   https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoopDev.sh)"
 ```
 
-### BuildLoopDev Other Branches
+### Build Other Branches
 
-You can use the BuildLoopDev script to build a specific development branch, other than `dev`. See the example below that would build `other-branch`, if such a branch existed. This is just an example. You need to substitute the branch you desire for `other-branch`. There must be a space after the final quote, followed by a hyphen, another space and then the branch name.
+You can use the BuildLoopDev script to build a specific development branch, other than `dev`. At the end of the script (from above), add a space after the final quote, followed by a hyphen, another space and then the branch name. See the example below that would build `other-branch`, if such a branch existed. This is just an example. You need to substitute the branch you desire for `other-branch`. The example below uses a continuation character to put the extra characters on a new line to make this easier to read.
 
-``` { .bash .copy title="Example using <code>other-branch</code> with the BuildLoopDev script" }
+``` { title="Replace <code>other-branch</code> with the desired branch" }
 /bin/bash -c "$(curl -fsSL \
-  https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoopDev.sh)" - other-branch
+  https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoopDev.sh)" \
+   - other-branch
 ```
 
 ## Update Loop-dev


### PR DESCRIPTION
Fix a typo.
Make it harder to make a mistake when downloading a different branch for Mac-Xcode build
* remove the copy button
* clarify wording