### PR TITLE
Revert "Bump pygments from 2.19.2 to 2.20.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ playwright==1.58.0
     # via mkdocs-exporter
 pyee==13.0.0
     # via playwright
-pygments==2.20.0
+pygments==2.19.2
     # via mkdocs-material
 pymdown-extensions==10.20.1
     # via mkdocs-material


### PR DESCRIPTION
Reverts LoopKit/loopdocs#1004

The pages stopped being published after this PR.