### PR TITLE
Update maximum basal rate section with safety note

### DIFF
--- a/docs/loop-3/therapy-settings.md
+++ b/docs/loop-3/therapy-settings.md
@@ -153,7 +153,7 @@ Delivery Limits are safety guardrails for your insulin delivery.
 
 ### Maximum Basal Rate
 
-Maximum Basal Rate is the maximum automatically adjusted basal rate that Loop is allowed to enact to help reach your correction range. Some users choose a value 2, 3, or 4 times their highest scheduled basal rate. Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as is comfortable.
+Maximum Basal Rate is the maximum automatically adjusted basal rate that Loop is allowed to enact to help reach your correction range. Some users choose a value 2, 3, or 4 times their highest scheduled basal rate. Work with your healthcare provider to choose a value that is higher than your highest scheduled basal rate, but as conservative or aggressive as is comfortable.   For safety, don't set a maximum bolus limit any higher than your typical large meal bolus. It is recommended to set a value less than 10 U, for example, 9 or 9.9 U, to avoid accidentally typing in a bolus of 10 instead of 1.0 U.
 
 If the Dosing Strategy is configured to Temp Basal Only, then the maximum basal rate can be used to limit how much extra insulin can be supplied automatically.
 


### PR DESCRIPTION
Added safety recommendation for maximum bolus limit to avoid accidental high dosages.