### PR TITLE
update for dev version of 3.14.2

### DIFF
--- a/docs/browser/build-dev-browser.md
+++ b/docs/browser/build-dev-browser.md
@@ -47,16 +47,8 @@ Your `LoopWorkspace fork` is at `https://github.com/username/LoopWorkspace` wher
 If you're building `dev`, you can skip ahead to [Add `Branch`](#add-branch).  If you're building a feature branch, copy the branch name into your paste buffer to minimize typographical errors.
 
 
-``` { .bash .copy title="Add Dana and Medtrum pumps to dev branch" }
-feat/dev-dana-medtrum
-```
-
-``` { .bash .copy title="Add Dana and Medtrum pumps, Eversense CGM to dev branch" }
-feat/eversense
-```
-
-``` { .bash .copy title="Add Dana, Medtrum and All Omnipod Types, Eversense CGM to dev branch" }
-feat/omnipodkit
+``` { .bash .copy title="Add Dana pump to dev branch" }
+feat/all-managers
 ```
 
 ### Add `Branch`

--- a/docs/browser/build-dev-browser.md
+++ b/docs/browser/build-dev-browser.md
@@ -47,7 +47,7 @@ Your `LoopWorkspace fork` is at `https://github.com/username/LoopWorkspace` wher
 If you're building `dev`, you can skip ahead to [Add `Branch`](#add-branch).  If you're building a feature branch, copy the branch name into your paste buffer to minimize typographical errors.
 
 
-``` { .bash .copy title="Add Dana pump to dev branch" }
+``` { .bash .copy title="Branch to Add Dana Pump Support" }
 feat/all-managers
 ```
 

--- a/docs/build/cgm.md
+++ b/docs/build/cgm.md
@@ -62,7 +62,7 @@ With Loop 3.4 and newer versions, some *Libre* CGM are supported.
 ## *Eversense* E3 and 365 CGM
 ![img/eversense.png](img/eversense.png){width="150"}
 
-Both the Eversense E3 (90 days & 180 days) and the Eversense 365 (full year) transmitters are supported, on an experimental branch feat/eversense.
+Both the Eversense E3 (90 days & 180 days) and the Eversense 365 (full year) transmitters are supported, on the `dev` branch with v3.14.2.
 
 * See [Loop Development: Branches](../version/development.md#branches){: target="_blank" } for more information on how to build this branch.
 

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -196,7 +196,7 @@ Loop does not support Omnipod 5 pods.
 ## Sooil Dana pumps
 
 !!! warning "You must build a feature branch to use Dana pumps"
-    Dana is supported in both of [these feature branches](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }, `feat/dev-dana-medtrum` or `feat/eversense`.
+    Dana is supported in [`feat/all-managers` feature branch](../version/development.md#feature-branch-featall-managers){: target="_blank" }.
     
     * You must follow [zulipchat DanaKit topic](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/DanaKit.20Troubleshooting/with/547829260)
 
@@ -225,7 +225,7 @@ The DanaRS was first released in 2002, with firmware version v1 which is not sup
 ## Medtrum Nano
 
 !!! warning "You must build a feature branch to use Medtrum pumps"
-    Medtrum Nano is supported in both of [these feature branches](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }, `feat/dev-dana-medtrum` or `feat/eversense`.
+    Medtrum Nano is supported in the 
     
     * You must follow [zulipchat Medtrum channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Medtrum.20Nano.20-.20pumps.20for.20development.20use/with/481836247)
 

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -224,7 +224,7 @@ The DanaRS was first released in 2002, with firmware version v1 which is not sup
 
 ## Medtrum Nano
 
-Metrum support was added to the `dev` branch in version 3.14.2, and is will be included in the next release.
+Metrum support was added to the `dev` branch in version 3.14.2, and will be included in the next release.
 
 !!! info "All versions are supported!"
     Both 200U (MD0201 & MD8201) and 300U (MD8301) version are supported with the correct version of the *Loop* app.

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -26,12 +26,12 @@ These types of pumps are compatible with the *Loop* app.
 * [Older Medtronic pumps](pump.md#check-medtronic-pump-version)
 * [Omnipod Eros pumps](pump.md#omnipod-pumps)
 * [Omnipod DASH pumps](#omnipod-dash)
-    * See caveat about [iPhone 16](phone.md#compatible-device){: target="_blank" }
+    * See caveat about [iPhone 16 and 17e](phone.md#compatible-device){: target="_blank" }
+* [Medtrum Touchcare Nano](#medtrum-nano) (included in `dev` branch, planned for next release)
 
-You must build a special branch to test these pumps. Please only test if you are willing to update frequently, pay close attention and return to open loop as needed.
+You must build a special branch to test some pumps. Please only test if you are willing to update frequently, pay close attention and return to open loop as needed.
 
-* [Dana-i / DanaRS-v3](#sooil-dana-pumps) (new pump manager, work in progress)
-* [Medtrum Touchcare Nano](#medtrum-nano) (new pump manager, work in progress)
+* [Dana-i / DanaRS-v3](#sooil-dana-pumps) (new pump manager, work in progress, included in `feat/all-managers` branch)
 
 ## Check Medtronic Pump Version
 

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -224,14 +224,7 @@ The DanaRS was first released in 2002, with firmware version v1 which is not sup
 
 ## Medtrum Nano
 
-!!! warning "You must build a feature branch to use Medtrum pumps"
-    Medtrum Nano is supported in the 
-    
-    * You must follow [zulipchat Medtrum channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Medtrum.20Nano.20-.20pumps.20for.20development.20use/with/481836247)
-
-    Read this section in LoopDocs:
-
-    * [Medtrum Nano](../loop-3/add-pump.md#medtrum-nano){: target="_blank" }
+Metrum support was added to the `dev` branch in version 3.14.2, and is will be included in the next release.
 
 !!! info "All versions are supported!"
     Both 200U (MD0201 & MD8201) and 300U (MD8301) version are supported with the correct version of the *Loop* app.

--- a/docs/build/pump.md
+++ b/docs/build/pump.md
@@ -224,7 +224,7 @@ The DanaRS was first released in 2002, with firmware version v1 which is not sup
 
 ## Medtrum Nano
 
-Metrum support was added to the `dev` branch in version 3.14.2, and will be included in the next release.
+Medtrum support was added to the `dev` branch in version 3.14.2, and will be included in the next release.
 
 !!! info "All versions are supported!"
     Both 200U (MD0201 & MD8201) and 300U (MD8301) version are supported with the correct version of the *Loop* app.

--- a/docs/faqs/cgm-faqs.md
+++ b/docs/faqs/cgm-faqs.md
@@ -131,10 +131,7 @@ If you prefer not to customize Loop, then you can configure [Nightscout](https:/
 
 ## Can I use Eversense E3 or Eversense 365?
 
-Using the experimental branch, feat/eversense using Loop 3.11.0 or newer, you can make a native connection to your Eversense E3 or 365.
-
-* See [Loop Development: Branches](../version/development.md#branches){: target="_blank" } for more information on how to build this branch.
-
+With `dev` branch, 3.14.2 and later, Eversense is included in the Loop build.
 
 ## Can the *Loop* app read CGM data from Nightscout?
 

--- a/docs/intro/overview-intro.md
+++ b/docs/intro/overview-intro.md
@@ -98,3 +98,6 @@ Here are development history links to other resources for you to explore.
 * How the Omnipod Eros pods were cracked to work with&nbsp;<span translate="no">Loop</span>:
     * [Insulin Pumps, Decapped Chips and Software Defined Radios](https://medium.com/@ps2) written by&nbsp;<span translate="no">Loop</span>&nbsp;developer Pete Schwamb
     * [Deep Dip Teardown of Tubeless Insulin Pump](https://arxiv.org/ftp/arxiv/papers/1709/1709.06026.pdf) by Sergei Skorobogatov
+
+* What role does *Tidepool* play in *Loop* development?
+    * Please see [Relationship with *Tidepool Loop*](../version/development.md#relationship-with-tidepool-loop){: target="_blank" }

--- a/docs/loop-3/add-cgm.md
+++ b/docs/loop-3/add-cgm.md
@@ -15,7 +15,7 @@ Loop can be connected to the following CGMs:
     * [Dexcom G7 or ONE+](#dexcom-g7-or-one)
     * [Libre](#libre) **(Loop 3.4 and later)**
         * Only some Libre sensors are supported; some have encryption that limits DIY use
-    * [Eversense E3/365](#eversense-e3365) **Experimental branch only**
+    * [Eversense E3/365](#eversense-e3365) **`dev` branch, v3.14.2**
     * [Minimed Enlite CGM](#medtronic-enlite-cgm)
         * Medtronic Pump only
         * **You must [add the Medtronic pump](add-pump.md) first**
@@ -158,6 +158,8 @@ With Eversense added to *Loop* you get direct connection to your transmitter for
 
 The *Loop* app does not have glucose notification features, at this time. You can enable the on-transmitter notification within the *Loop* app so the transmitter will vibrate to alert you of an issue.
 
+The Eversense implementation for Loop (and other OS-AID systems) enables you to upload your readings through the Eversense system and to use the Eversense NOW app. You can invite people to follow your CGM values.
+
 Review the graphic and text below for the steps to add the Eversense CGM. Note the middle screen of that graphic is only shown for the 365 transmitter. The E3 does not require a login step.
 
 ![Steps to add Eversense CGM](img/eversense-login-screen.png){width="750"}
@@ -184,10 +186,7 @@ If you are having trouble with connecting to the Eversense, try these steps.
 
 #### Important Information
 
-!!! warning "You must build feat/eversense branch to use the Eversense CGM"
-    The Eversense CGM is in feat/eversense (as of version v3.11.0) and is experimental as of now.
-
-    This branch adds the [EversenseKit](https://github.com/loopandlearn/EversenseKit) repository to the *Loop* app.
+!!! warning "You must build the `dev` branch to use the Eversense CGM"
 
 !!! important "Wait till initialization phase is completed"
     During the initialization phase after insertion of a new sensor, the glucose reading might be incorrect.

--- a/docs/loop-3/add-pump.md
+++ b/docs/loop-3/add-pump.md
@@ -255,6 +255,7 @@ The Medtronic status and commands available are shown in the [Pump Settings](med
 ### Before Testing Dana
 
 You must build a feature branch to get Dana support in Loop
+
 * `feat/all-managers`.
 
 * Please refer to information summarized at [Status for Dana Support](../version/development.md#status-for-dana-support){: target="_blank" }.

--- a/docs/loop-3/add-pump.md
+++ b/docs/loop-3/add-pump.md
@@ -17,7 +17,7 @@ Loopers can choose from multiple pumps and a simulator:
     * Please refer to [Compatible Pump](../build/pump.md#check-medtronic-pump-version) for additional details
 * Omnipod
 * Omnipod DASH
-* [All Omnipod Types](../version/development.md#feature-branch-omnipodkit-pump-manager){: target="_blank" } (available with `dev` v3.14.2)
+* [All Omnipod Types](../version/development.md#transition-to-omnipodkit){: target="_blank" } (available with `dev` v3.14.2)
 * Dana-i / DanaRS-v3 (**work-in-progress; new pump manager, use with care**)
     * Note: DanaRS-v1 or any Dana Korean versions are not supported
 * Medtrum Nano patch pump (available in `dev` branch, v3.14.2)
@@ -56,7 +56,7 @@ Here is an overview of the different steps for adding each pump.  Before changin
 
 #### Other Pumps
 
-> These are new pump managers that can be built using `dev` for Medtrum or a feature branch for Dana. See (../version/development.md#fstatus-for-dana-support){: target="_blank" }.
+> These are new pump managers that can be built using the `dev` branch for Medtrum or a [feature branch for Dana](../version/development.md#status-for-dana-support){: target="_blank" }.
 
 * [Dana-i / DanaRS-v3](#dana-i-danars-v3)
 * [Medtrum Nano](#medtrum-nano)

--- a/docs/loop-3/add-pump.md
+++ b/docs/loop-3/add-pump.md
@@ -17,10 +17,10 @@ Loopers can choose from multiple pumps and a simulator:
     * Please refer to [Compatible Pump](../build/pump.md#check-medtronic-pump-version) for additional details
 * Omnipod
 * Omnipod DASH
-* [All Omnipod Types](../version/development.md#feature-branch-omnipodkit-pump-manager){: target="_blank" } (available with `feat/omnipodkit` feature branch)
+* [All Omnipod Types](../version/development.md#feature-branch-omnipodkit-pump-manager){: target="_blank" } (available with `dev` v3.14.2)
 * Dana-i / DanaRS-v3 (**work-in-progress; new pump manager, use with care**)
     * Note: DanaRS-v1 or any Dana Korean versions are not supported
-* Medtrum Nano patch pump (**work-in-progress; new pump manager, use with care**)
+* Medtrum Nano patch pump (available in `dev` branch, v3.14.2)
 * Insulin Pump Simulator
 
 !!! info "Omnipod Terms"
@@ -56,7 +56,7 @@ Here is an overview of the different steps for adding each pump.  Before changin
 
 #### Other Pumps
 
-> These are new pump managers that can be built using one of [two feature branches](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }, `feat/dev-dana-medtrum` or `feat/eversense`.
+> These are new pump managers that can be built using `dev` for Medtrum or a feature branch for Dana. See (../version/development.md#fstatus-for-dana-support){: target="_blank" }.
 
 * [Dana-i / DanaRS-v3](#dana-i-danars-v3)
 * [Medtrum Nano](#medtrum-nano)
@@ -250,13 +250,14 @@ The Medtronic status and commands available are shown in the [Pump Settings](med
 
 ### Dana is a New Pump Manager
 
-**WARNING: Dana support in Loop is a work-in-progress; this is one of several new pump managers.**
+**WARNING: Dana support in Loop is a work-in-progress.**
 
 ### Before Testing Dana
 
-You must build a feature branch to get Dana support in Loop. You can use either one of two feature branches: `feat/dev-dana-medtrum` or `feat/eversense`.
+You must build a feature branch to get Dana support in Loop
+* `feat/all-managers`.
 
-* Please refer to information summarized at [Feature Branch: Dana and Medtrum Support](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }.
+* Please refer to information summarized at [Status for Dana Support](../version/development.md#status-for-dana-support){: target="_blank" }.
 
 
 ### When Testing Dana
@@ -375,16 +376,9 @@ Therefore, it is important to check if your CGM provides a heartbeat. If it does
 
 ### Medtrum is a New Pump Manager
 
-**WARNING: Medtrum support in Loop is a work-in-progress; this is one of several new pump managers.**
+**Medtrum is available in `dev` branch, v3.14.2.**
 
-You must build a feature branch to get Medtrum support in Loop. You can use either one of two feature branches: `feat/dev-dana-medtrum` or `feat/eversense`.
-
-* Please refer to information summarized at [Feature Branch: Dana and Medtrum Support](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }.
-
-
-### When Testing Medtrum Nano
-
-* Please do not use Medtrum Nano with Loop unless you are willing to test and communicate with  [developers on zulipchat in the Medtrum channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Medtrum.20Nano.20-.20pumps.20for.20development.20use/with/481836247)
+You must build the `dev` branch to get Medtrum support in Loop.
 
 ### Confirm Patch and Pump Base are Compatible
 

--- a/docs/loop-3/dana.md
+++ b/docs/loop-3/dana.md
@@ -16,9 +16,8 @@
 
 ### Testing Dana with the *Loop* App
 
-* The branch needed to get Dana in *Loop* is: `feat/dev-dana-medtrum`
+* The branch needed to get Dana in *Loop* is: `feat/all-managers`
     * This branch is subject to rapid updates
-    * If you also want to use the Eversense CGM, the `feat/eversense` branch provides support for Dana and Medtrum along with the Eversense CGM
 
 * Please refer to the [zulipchat Loop-dev development channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Loop-dev.20Status/with/515372445) before building this branch.
 

--- a/docs/loop-3/eversense.md
+++ b/docs/loop-3/eversense.md
@@ -6,13 +6,9 @@
     
     Please review the [EversenseKit Issues](https://github.com/bastiaanv/EversenseKit/issues) page for open issues reported for the EversenseKit CGM Manager.
 
-## Testing Eversense with the *Loop* App
+## Using Eversense with the *Loop* App
 
-* The branch needed to get Eversense in *Loop* is: `feat/eversense`
-    * This branch is subject to rapid updates
-    * This branch provides support for Dana and Medtrum along with the Eversense CGM
-
-* Please refer to the [zulipchat Loop-dev development channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Loop-dev.20Status/with/515372445) before building this branch.
+Eversense support was added to the `dev` branch in version 3.14.2.
 
 ## Eversense 365 Screen
 

--- a/docs/loop-3/medtrum.md
+++ b/docs/loop-3/medtrum.md
@@ -8,19 +8,11 @@
  
 ## Medtrum Nano Pump
 
-The Medtrum Nano Pump is supported using the *Loop* app built with a feature branch.  See [Feature Branches](../version/development.md#how-to-build-feature-branches){: target="_blank" } for building instructions.
+The Medtrum Nano Pump support was added to the `dev` branch in version 3.14.2.
 
 * The pump patch is designed to be changed every 3 days
 * The pump base is reusable - do not accidentally discard the base after removing the patch
 * Versions 200U (MD0201 & MD8201) and 300U (MD8301) are supported 
-
-### Testing Medtrum with the *Loop* App
-
-* The branch needed to get Medtrum in *Loop* is: `feat/dev-dana-medtrum`
-    * This branch is subject to rapid updates
-    * If you also want to use the Eversense CGM, the `feat/eversense` branch provides support for Dana and Medtrum along with the Eversense CGM
-
-* Please refer to the [zulipchat Loop-dev development channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Loop-dev.20Status/with/515372445) before building this branch.
 
 - - -
 

--- a/docs/loop-3/settings.md
+++ b/docs/loop-3/settings.md
@@ -160,11 +160,8 @@ The information about the pump section is detailed on several different pages. F
 * [Add or Modify Pump](add-pump.md)
 * [Omnipod or Omnipod DASH](omnipod.md) Status and Commands
 * [Medtronic](medtronic.md) Status and Commands
-
-There are several new pump managers available when you [build a feature branch](../version/development.md#feature-branch-dana-and-medtrum-support){: target="_blank" }:
-
-* [Dana Pumps](dana.md)
-* [Medtrum Pumps](medtrum.md)
+* [Medtrum Pumps](medtrum.md) requires `dev` branch
+* [Dana Pumps](dana.md) requires a feature branch: [Status for Dana Support](../version/development.md#status-for-dana-support){: target="_blank" }:
 
 ### [CGM Settings](add-cgm.md)
 

--- a/docs/troubleshooting/dana-faq.md
+++ b/docs/troubleshooting/dana-faq.md
@@ -12,7 +12,7 @@
 
 You must build the `feat/all-managers` branch to get support for Dana.
 
-This branch is subject to rapid updates. Any updates to Dana and Medtrum pumps are found in both branches.
+This branch is subject to rapid updates.
 
 ## Q: How long should the Dana pump last on a battery?
 

--- a/docs/troubleshooting/dana-faq.md
+++ b/docs/troubleshooting/dana-faq.md
@@ -10,13 +10,9 @@
 
 ## Branch for Dana
 
-You may choose one of two feature branches to get Dana in Loop
+You must build the `feat/all-managers` branch to get support for Dana.
 
-* `feat/dev-dana-medtrum`: adds support for Dana and Medtrum pumps
-* `feat/eversense`: adds support for the Eversense CGM in addition to the Dana and Medtrum pumps
-
-
-These branches are subject to rapid updates. Any updates to Dana and Medtrum pumps are found in both branches.
+This branch is subject to rapid updates. Any updates to Dana and Medtrum pumps are found in both branches.
 
 ## Q: How long should the Dana pump last on a battery?
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -13,7 +13,7 @@ The next version of the *Loop* app is developed using branches.
 * The `dev` branch is used by the developers to push out changes for users to test before that code is released
     * Sometimes there are breaking changes
         * A breaking change is when you can build the new branch over your existing app, but cannot go backwards without deleting your app from your phone
-    * We are bringing in updates for Tidepool that will intially land in a special branch `next_dev`
+    * We are bringing in updates for Tidepool in a special branch `next_dev`
         * Note that you might be able to go backward to `main` or `dev` from `next_dev` but it is not guaranteed
 * In addition there are specific feature branches that enable users to test new pump and cgm managers or features for existing managers before they are added to the `dev` branch
 * You should only test a development or feature branch if you are willing to be an active participant with the developers:
@@ -28,7 +28,12 @@ Please read this entire page before using any version of *Loop* other than the r
 
 This section provides an overview of changes to `dev` compared to the current release: `Loop v3.14.0`. 
 
-The current version of `dev` is v3.14.2. This has a very significant change - please read the warning.
+The current version of `dev` is v3.14.2. This has some very significant changes - please read the bullets and the Omnipod warning.
+
+* The Medtrum Nano 200 U / 300 U pump manager is added to the dev branch and will be in the next release
+* The Eversense E3 and 365 sensor CGM manager is added to the dev branch and will be in the next release
+* The unified OmnipodKit pump managaer, which controls either Classic (Eros) or DASH pods, is added to the dev branch and will be in the next release
+    * The OmniBLE and OmniKit single-pod-type pump managers were removed from the dev branch
 
 !!! important "Omnipod Users cannot return to v3.14.0 after building v3.14.2 without replacing their Pod"
     The new unified Omnipod Pump Manager, OmnipodKit, is the only pump manager available in v3.14.2.
@@ -36,6 +41,10 @@ The current version of `dev` is v3.14.2. This has a very significant change - pl
     If you are running a Pod, you can install v3.14.2 over v3.14.0 and the Pod will be automatically transition to the OmnipodKit Pump Manager.
 
     If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod. Simply rebuild v3.14.2 back on your phone and control will be restored.
+
+For those on the Dana pump. You need to keep building a feature branch, but it might be a different branch from what you used before. 
+
+Please see [Table of Retired Branches](#table-of-retired-branches) for up to date information about what branch you need to build for Dana support.
 
 Please check the [development channel in zulipchat](https://loop.zulipchat.com/#narrow/channel/144182-development) for notifications when an update to the `dev` branch is expected so you will be prepared. Do this **before** you install a `dev` build from TestFlight.
 
@@ -48,6 +57,8 @@ In addition to the main and dev branches, which are tightly controlled and only 
 
 The graphic below shows the `main` and `dev` branches along with some feature branches and an update branch.
 
+TO-DO - update this graphic
+
 > ![Active branches for LoopWorkspace](img/loop-development-branches.png ){width="750"}
 {align="center"}
 
@@ -59,20 +70,19 @@ The graphic below shows the `main` and `dev` branches along with some feature br
 
 ### Table of Active Branches
 
-The table below lists active branches. Note that updates may occur and be announced in zulipchat a day or two before updates propogate to *LoopDocs*. The feature branches listed below will be replaced shortly after the next release. Any one using a feature branch needs to be alert and check zulipchat regularly.
+The table below lists active branches. 
+
+* Note that updates may occur and be announced in zulipchat a day or two before updates propagate to *LoopDocs*
+* Any one using a feature branch needs to be alert and check zulipchat regularly
+* For example, while preparing for v3.14.2, older feature branches were retired
+    * Check the [Table of Retired Branches](#table-of-retired-branches) to get the support you need.
 
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR453](https://github.com/LoopKit/LoopWorkspace/pull/452#top) replace OmniBLE and OmniKit with OmnipodKit |
-| [feat/dev-dana-medtrum](#feature-branch-dana-and-medtrum-support) <br>- SHA `e0331eb` | 3.14.1  | 26 May 2026 | - adds support for Dana and Medtrum pumps<br>  - SHA  `DanaKit @ c544c42`<br>  - SHA `MedtrumKit @ 6060747`<br>**Medtrum User Interface Redesigned** to be more like the Omnipod User Interac.<br>Several fixes added for MedtrumKit, not yet in DanaKit |
-| [feat/eversense](#feature-branch-eversense-support) <br>- SHA `e909b2e` | 3.14.1  | 26 May 2026 | - adds experimental support for Eversense (includes Dana and Medtrum pumps support - same SHA as above)<br>- this branch is ready for use to evaluate and report back<br>  - SHA `EversenseKit @ 43b8080` |
-| [feat/omnipodkit](#feature-branch-omnipodkit-pump-manager)<br>- SHA `10fd21f` | 3.14.1 | 03 June 2026| The new OmnipodKit pump manager, controls all Types of pods. Initially only the Eros and DASH pod types are available for feature branch testers<br>  - SHA `OmnipodKit @ d68699c`<br>**Please read [Feature Branch: OmnipodKit Pump Manager](#feature-branch-omnipodkit-pump-manager)** |
-
-!!! important "Eversense Support"
-    The Eversense CGM is now supported by the *Loop* app in a feature branch. To simplify maintenance, the branch which supports Eversense also supports the two new pumps: Dana and Medtrum.
-
-    The branch which support Evensense E3 and E365 CGM is simply called `feat/eversense`.
+| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/452#top)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
+| `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana suppor: [Feature: All Managers] |
+| `next_dev` | 3.15.0 | subject to rapid change | [PR 454]((https://github.com/LoopKit/LoopWorkspace/pull/454) |
 
 ??? question "What is SHA? (Click to Open/Close)"
     SHA-1 means Secure Hash Algorithm 1. This is used to generate an alphanumeric code to identify which version of a repository is used. 
@@ -80,6 +90,14 @@ The table below lists active branches. Note that updates may occur and be announ
     Each time you save a change to your&nbsp;<span translate="no">GitHub repository</span>, a unique SHA-1 is created. That identifier is used to tell *GitHub* a specific change that you want applied or identifies a specific version for that <code>repository</code>. These work for any compatible <code>fork</code> from the original&nbsp;<span translate="no">GitHub repository</span>.
 
     The SHA-1 20-character value is abbreviated as SHA and typically only the first 7 or 8 characters are presented to identify the commit for a particular repository.
+
+### Table of Retired Branches
+
+| Retired Branch |  Use Instead | Status Link |
+|:--|:--|:--|
+| feat/dev-dana-medtrum |For Medtrum, use `dev`<br>For Dana, use `feat/all-managers` | [Status for Medtrum](#status-for-medtrum-support)<br>[Status for Dana](#status-for-dana-support) |
+| feat/eversense |  For Eversense, use `dev` | [Status for Eversense](#status-for-eversense-support) |
+| feat/omnipodkit | Use `dev` unless you are a developer<br>developers can use `feat/all-managers` | [Feature Branch: All Managers](#feature-branch-all-managers) |
 
 ### How to Build Feature Branches
 
@@ -97,29 +115,16 @@ Use the page linked above to add the desired branch name (from the table above) 
 
 For Mac Xcode build, the lines you need to copy and paste into a Terminal window are explicitly provided below:
 
-``` { .bash .copy  title="Download and build the feat/omnipodkit branch" }
+``` { .bash .copy  title="Download and build the feat/all-managers branch" }
 /bin/bash -c "$(curl -fsSL \
   https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoop.sh)" \
-   - feat/omnipodkit
+   - feat/all-managers
 ```
 
-``` { .bash .copy  title="Download and build the feat/dev-dana-medtrum branch" }
-/bin/bash -c "$(curl -fsSL \
-  https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoop.sh)" \
-   - feat/dev-dana-medtrum
-```
-
-``` { .bash .copy title="Download and build the feat/eversense branch" }
-/bin/bash -c "$(curl -fsSL \
-  https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/BuildLoop.sh)" \
-   - feat/eversense
-```
 
 ### Version Number Plan
 
 Please see [`Loop` Version Numbering](releases.md#loop-version-numbering) for the current method for version numbering for the `main` and `dev` branches.
-
-The idea of having a feature branch is not new for the *Loop* app but hasn't been used for a few years. At this point, we have several feature branches.
 
 The version number in the feature branch will match either the `dev` branch version number or a work-in-progress update to the `dev` branch which uses the naming convention `update_dev_to_M.m.#`.
 
@@ -127,73 +132,43 @@ The version number in the feature branch will match either the `dev` branch vers
 * Each feature has an associated repository that contains the feature
     * When updates to the feature are added, the SHA for the feature branch and the SHA for the submodule(s) which support that feature will be reported in the table above and can be found by examining the LoopWorkspace repository for that feature branch
 
-### Feature Branch: OmnipodKit Pump Manager
+- - -
 
-!!! Question "What is different between `feat/omnipodkit` and `dev` branch"
-    There are several differences between `feat/omnipodkit` and `dev` branch.  For one thing, this branch (which will be renamed soon - so pay attention) has all the pump managers: OmniBLE, OmniKit, OmnipodKit, DanaKit, MedtrumKit and MinimedKit and the new CGM manager EversenseKit.
+### Status for Pod Keep Alive Support
 
-    Keeping OmniBLE & OmniKit in this branch is useful for developers. Those pump managers were removed from `dev` branch (3.14.2) and will soon be removed from `main` when `dev` is merged into main.
+For those using iPhone 16 or 17e with Atlas DASH Pods, the keep alive support is available in the released code, `main`, v3.14.0 or in the development code, `dev`, v3.14.2.
 
-    Because OmniBLE & OmniKit are present, a tester who comes in with a Pod attached to one of those managers stays with the manager. The automatic conversion to OmnipodKit, which happens with v3.14.2, does not happen with this branch. The tester has to manually change pump managers during a Pod change.
+- - -
 
-#### OmnipodKit Pump Manager
+### Status for Medtrum Support
 
-The OmnipodKit pump manager comes with improved user interface and user experience for Omnipod Classic (Eros) and DASH pods including
+Metrum support was added to the `dev` branch in version 3.14.2.
 
-* Some layout adjustments
-* Some new labels
-* Some reworked sub-menus with added information or features
+- - -
 
-If you are running the `dev` branch - your Pod is automatically transitioned to OmnipodKit. You will notice the user interface is a little different. If you are running `feat/omnipodkit` branch, see [Manual transition with `feat/omnipodkit`](#manual-transition-with-featomnipodkit).
+### Status for Eversense Support
 
-One of the biggest things is that you can change Pod types between Pods. With this version of OmnipodKit, only Eros and DASH are supported.
+Eversense support was added to the `dev` branch in version 3.14.2.
 
-!!! question "Why OmnipodKit?"
-    When the initial work to add DASH to the supported pumps was started in 2021, a completely separate pump submodule was created distinct from the Classic (Eros) pump submodule. In other words, OmniBLE handled DASH and OmniKit handled Eros.
+- - -
 
-    A significant portion of the two repositories serve the same function. Whenever a fix or improvement was added to OmniBLE, it was duplicated and added to OmniKit. Having a universal pod manager saves significant developer resources.
+### Status for Dana Support
 
-    OmnipodKit provides the individual support needed for different `Pod Types` while using a single copy of code for most of the logic and user interface.
+For Dana support, you must build a new feature branch. The old feature branches were deleted.
 
-    The improvements that have been going on in the background landed in the new pump manager only - and were not replicated in the OmniKit or OmniBLE repositories.
+See [Feature Branch: All Managers](#feature-branch-all-managers) for more information about the branch. Keep reading here for Dana specific status.
 
-    This will be a significant time saver for developers moving forward for updating code and adding support for new types of pods.
+Anyone using Dana pumps must build a new feature branch, feat/all-managers. Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
 
-#### Manual transition with `feat/omnipodkit`
+* `feat/all-managers`
 
-If you are running `feat/omnipodkit` branch, you need to take these steps to switch to using the new pump manager.
-
-The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
-
-* Select `All Omnipod Types` as your new pump manager.
-* Go through the onboarding of selecting notifications and reminders and insulin type.
-* You will then be presented with a screen to select the type of pod. 
-* Choose the Classic (Eros) or DASH Pod type
-
-!!! important "Once you transition to OmnipodKit, stay with OmnipodKit"
-    The new unified Omnipod Pump Manager, OmnipodKit, is the only available in v3.14.2 or newer.
-
-    If you are running a Pod and you transition to the OmnipodKit Pump Manager, then any build you install on your phone should have OmnipodKit. If you need to downgrade to a build earlier than v3.14.2, do so after deactivating a Pod.
-
-### Feature Branch: Pod Keep Alive Feature
-
-The feat/pod-keep-alive branch has been deleted. It was updated and incorporated into the released code. Please build the `main` branch over your existing app. All your selections will remain as you configured them when building the `feat/pod-keep-alive` branch.
-
-See [Pod Keep Alive Feature](../loop-3/omnipod.md#pod-keep-alive-feature){: target="_blank" }.
-
-
-### Feature Branch: Dana and Medtrum Support
-
-Anyone using Dana or Medtrum pumps must build one of these branches. The pump manager support is identical. The difference is the second one includes support for the Eversense CGM. Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
-
-* `feat/dev-dana-medtrum` 
-* `feat/eversense` 
-
-!!! important "New Pump Managers"
-    These are new Pump Managers and may have known or unknown bugs. Please only use a feature branch if you are prepared to follow along in zulipchat and are willing to help test and resolve issues. This is critical when using new pump managers.
+!!! important "New Managers"
+    This branch is used to add new Pump Managers and CGM Managers which may have known or unknown bugs. Once the managers are deemed reliable, they are added to the `dev` branch and subsequently released. This branch gets updated when that happens.
+    
+    Please only use a feature branch if you are prepared to follow along in zulipchat and are willing to help test and resolve issues. This is critical when using new pump managers.
 
     * Please ensure you have the latest version of a given branch by synching before you build:
-        * Browser Build: be sure you select `feat/dev-dana-medtrum` or `feat/eversense` branch
+        * Browser Build: be sure you select `feat/all-managers` branch
             * The Build Loop action automatically syncs your fork when building
             * Be sure to install the resultant build from *TestFlight* onto your phone
         * Mac-Xcode: you can update your clone or download a fresh copy
@@ -205,23 +180,9 @@ Anyone using Dana or Medtrum pumps must build one of these branches. The pump ma
     
     The behavior of your OS-AID system needs to properly handle bolus and temp basal rate events in progress if that communication is interrupted.  This can happen if someone walks away from their phone during a bolus or while a temp basal rate is in progress.
 
+    There are known issues with this for DanaKit, which is why that pump manager is not yet in the `dev` branch
+
     Please read the rest of this section to learn about how this might affect an older or current version of your OS-AID app.
-
-#### Recently Closed Issue for Medtrum
-
-!!! success "Medtrum Bluetooth Comms Loss Updated"
-
-    #### MedtrumKit - fixed on 29 April 2026
-
-    [MedtrumKit Issue 112](https://github.com/jbr7rr/MedtrumKit/issues/112) reported that MedtrumKit did not properly handle a Temp Basal Rate (TBR) event if BLE comms was lost at the time the TBR completed.
-
-    [MedtrumKit PR 118](https://github.com/jbr7rr/MedtrumKit/pull/118) provided an updated management of TBR providing accurate handling of TBR when BLE was interrupted and later restored.
-
-    #### MedtrumKit - fixed on 25 March 2026
-
-    [MedtrumKit Issue 92](https://github.com/jbr7rr/MedtrumKit/issues/92) reported that when the Medtrum moved out of Bluetooth range, the app reported an interrupted bolus when in fact the bolus continued. This led to underreported values for Active Insulin, also known as Insulin on Board (IOB).
-
-    [MedtrumKit Pull Request 93](https://github.com/jbr7rr/MedtrumKit/pull/93) fixed this issue.  Now if Bluetooth communication is lost, the pump manager relies on expected timing to continue the bolus progress display.  The bolus is not considered final until BLE is restored and the app is able to communicate with the pump.
 
 #### Open Issue for DanaKit
 
@@ -258,42 +219,61 @@ Anyone using Dana or Medtrum pumps must build one of these branches. The pump ma
 
 - - -
 
-### Feature Branch: Eversense Support
+### Feature Branch: All Managers
 
-#### Recently Closed Issue for Eversense
+This branch replaces several [retired feature branches](#table-of-retired-branches). If you need a feature branch for a Dana pump - you need to build this branch. Be sure to review the [Status For Dana Support](#status-for-dana-support) section.
 
-!!! success "Eversense Placement Guide updated"
+If you previously used a feature branch for Medtrum or Eversense support, you can switch to the `dev` branch.
 
-    #### EversenseKit - fixed on 30 April 2026
+!!! Question "What is different between `feat/all-managers` and `dev` branch"
+    There are several differences between `feat/all-managers` and `dev` branch.  For one thing, this branch has all the pump managers: OmniBLE, OmniKit, OmnipodKit, DanaKit, MedtrumKit and MinimedKit and the new CGM manager EversenseKit. When other new managers become available, they may be added here for testing.
 
-    [EversenseKit Issue 26](https://github.com/bastiaanv/EversenseKit/issues/26) reported that the placement guide graph was not updating when attaching the Transmitter over the sensor.
+    Keeping OmniBLE & OmniKit in this branch is useful for developers. Those pump managers were removed from `dev` branch (3.14.2) and will soon be removed from `main` when `dev` is merged into main. We expect those managers will eventually be dropped from this branch, but only when the developers agree to do so.
 
-    [EversenseKit PR 30](https://github.com/bastiaanv/EversenseKit/pull/30) fixed the problem. The solution was to enable debug mode while using the placement guide and disable debug mode when done.
+    Because OmniBLE & OmniKit are present, a tester who comes in with a Pod attached to one of those managers stays with the manager. The automatic conversion to OmnipodKit, which happens with v3.14.2, does not happen with this branch. The tester has to manually change pump managers during a Pod change.
 
-There is a new feature branch available, `feat/eversense` which supports the Eversense E365 and E3 transmitters. In addition to Eversense support, this branch also has the same pump support as the `feat/dev-dana-medtrum` branch.
+#### Transition to OmnipodKit
 
-For anyone who tests this branch with Eversense, if there are issues with your use of Loop with Eversense please report in this [zulipchat channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Eversense.20CGM/with/569969251). 
+!!! important "Once you transition to OmnipodKit, stay with OmnipodKit"
+    The new unified Omnipod Pump Manager, OmnipodKit, is provided in v3.14.2 or newer.
 
-Be sure to include:
+    If you are running a Pod and you transition to the OmnipodKit Pump Manager, then any build you install on your phone should have OmnipodKit. If you need to downgrade to a build earlier than v3.14.2, do so after deactivating a Pod.
 
-* a description of your issue
-* your phone model and iOS version
-* your build method:
-    * Browser Build
-    * Mac-Xcode and include Xcode version
-* which version of code you are running (branch name and SHA)
-* share your Eversense logs (at bottom of the Loop Eversense screen)
 
-If you prefer to create an issue directly at the Eversense repo, create it here:
+The OmnipodKit pump manager comes with improved user interface and user experience for Omnipod Classic (Eros) and DASH pods including
 
-* [https://github.com/bastiaanv/EversenseKit/issues](https://github.com/bastiaanv/EversenseKit/issues)
+* Some layout adjustments
+* Some new labels
+* Some reworked sub-menus with added information or features
 
-> Note
+If you are running the `dev` branch - your Pod is automatically transitioned to OmnipodKit. You will notice the user interface is a little different. If you are running `feat/all-managers` branch, see [Manual transition with `feat/all-managers`](#manual-transition-with-featall-managers).
 
-> * This was tested using an E365 transmitter attached to a small vial containing a sensor in glucose solution
-> * This enabled testing the Eversense behavior with Loop on a test phone
-> * No testing with the E3 (3-month, 90-day) sensor has been performed
+One of the biggest things is that you can change Pod types between Pods. With this version of OmnipodKit, only Eros and DASH are supported.
 
+!!! question "Why OmnipodKit?"
+    When the initial work to add DASH to the supported pumps was started in 2021, a completely separate pump submodule was created distinct from the Classic (Eros) pump submodule. In other words, OmniBLE handled DASH and OmniKit handled Eros.
+
+    A significant portion of the two repositories serve the same function. Whenever a fix or improvement was added to OmniBLE, it was duplicated and added to OmniKit. Having a universal pod manager saves significant developer resources.
+
+    OmnipodKit provides the individual support needed for different `Pod Types` while using a single copy of code for most of the logic and user interface.
+
+    The improvements that have been going on in the background landed in the new pump manager only - and were not replicated in the OmniKit or OmniBLE repositories.
+
+    This will be a significant time saver for developers moving forward for updating code and adding support for new types of pods.
+
+#### Manual transition with `feat/all-managers`
+
+If you are running `feat/all-managers` branch, you need to take these steps to switch to using the new pump manager.
+
+The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
+
+* Select `All Omnipod Types` as your new pump manager.
+* Go through the onboarding of selecting notifications and reminders and insulin type.
+* You will then be presented with a screen to select the type of pod. 
+* Choose the Classic (Eros) or DASH Pod type
+
+
+- - -
 
 ## Older updates
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -6,6 +6,20 @@ The [*Loop* Releases](releases.md){: target="_blank"}  page lists releases since
 
 The current released version of the *Loop* app is always in the `main` branch of the LoopWorkspace repository.
 
+
+### Relationship with *Tidepool Loop*
+
+*Tidepool Loop* is an independent version of *Loop*. *Tidepool Loop* started with *Loop* code, added safety features, and additional FDA approved device integrations. Much of the *Tidepool Loop* improvements are also published as open source, which volunteers in the community are free to incorporate back into *Loop*. The device integrations for *Tidepool Loop* are generally closed source when required by device manufacturers.
+
+* In 2019, the non-profit *Tidepool* organization partnered with the JAEB Foundation to review outcomes from volunteers using *Loop*
+    * *Tidepool* successfully submitted *Tidepool Loop* to the Federal Drug Administration as an approved automated insulin delivery system
+    * *Tidepool Loop* is available now, please see their website for more information: [*Tidepool Loop*](https://www.tidepool.org/tidepool-loop)
+* In 2022, some of the *Tidepool* open-source code was brought into the *Loop* project by dedicated volunteers and eventually released as *Loop* 3
+    * The traditional OS-AID process of community volunteers providing updates continued throughout
+* In 2026, volunteers are once-again bringing in upgrades from *Tidepool* open-source code, laying the foundation for what will be *Loop* 4.
+    * Look for upcoming information about `next-dev` branch - it is awesome, but still being tested
+    * If you are interested, follow along in [zulipchat: Loop next-dev Status](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Loop.20next-dev.20Status/with/600761707)
+
 ### Development Branches and Breaking Changes
 
 The next version of the *Loop* app is developed using branches. 
@@ -40,9 +54,11 @@ The current version of `dev` is v3.14.2. This has some very significant changes 
 
     If you are running a Pod, you can install v3.14.2 over v3.14.0 or earlier and the Pod control will automatically transition to the OmnipodKit Pump Manager.
 
-    If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod. Simply rebuild v3.14.2 back on your phone and control will be restored.
+    If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod.
+    
+    * If this happens to you: **install v3.14.2 on your phone and control will be restored**.
 
-For those on the Dana pump. You need to keep building a feature branch, but the name of the branch changed. 
+For those on the Dana pump. You need to keep building a feature branch, but the name of the branch changed. The old one is still available but has been removed from LoopDocs.
 
 Please see [Table of Retired Branches](#table-of-retired-branches) for up to date information about what branch you need to build for Dana support.
 
@@ -78,7 +94,7 @@ The table below lists active branches.
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
+| dev | 3.14.2 | 5 June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
 | `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana support: [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
 | `next-dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454) |
 
@@ -152,16 +168,15 @@ Eversense support was added to the `dev` branch in version 3.14.2.
 
 ### Status for Dana Support
 
-For Dana support, you must build a new feature branch. The old feature branches were deleted.
+For Dana support, you must build a new feature branch, feat/all-managers. The old feature branches will be deleted without further warning.
 
-See [Feature Branch: feat/all-managers](#feature-branch-featall-managers) for more information about the branch. Keep reading here for Dana specific status.
+* Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
+* See [Feature Branch: feat/all-managers](#feature-branch-featall-managers) for more information about the branch. 
+* Keep reading here for Dana specific status.
 
-Anyone using Dana pumps must build a new feature branch, feat/all-managers. Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
-
-* `feat/all-managers`
 
 !!! important "New Managers"
-    This branch is used to add new Pump Managers and CGM Managers which may have known or unknown bugs. Once the managers are deemed reliable, they are added to the `dev` branch and subsequently released. This branch gets updated when that happens.
+    The `feat/all-managers` branch is used to add new Pump Managers and CGM Managers which may have known or unknown bugs. Once the managers are deemed reliable, they are added to the `dev` branch and subsequently released. This branch contains new and old managers (like OmniBLE and OmniKit) for use by developers.
     
     Please only use a feature branch if you are prepared to follow along in zulipchat and are willing to help test and resolve issues. This is critical when using new pump managers.
 
@@ -178,7 +193,9 @@ Anyone using Dana pumps must build a new feature branch, feat/all-managers. Buil
     
     The behavior of your OS-AID system needs to properly handle bolus and temp basal rate events in progress if that communication is interrupted.  This can happen if someone walks away from their phone during a bolus or while a temp basal rate is in progress.
 
-    There are known issues with this for DanaKit, which is why that pump manager is not yet in the `dev` branch
+    These issues were fixed in MedtrumKit and the lessons learned will be applied to DanaKit.
+
+    There are known issues for DanaKit, which is why that pump manager is not yet in the `dev` branch
 
     Please read the rest of this section to learn about how this might affect an older or current version of your OS-AID app.
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -263,7 +263,7 @@ The OmnipodKit pump manager comes with improved user interface and user experien
 
 If you are running the `dev` branch - your Pod is automatically transitioned to OmnipodKit. You will notice the user interface is a little different. If you are running `feat/all-managers` branch, see [Manual transition with `feat/all-managers`](#manual-transition-with-featall-managers).
 
-One of the biggest things is that you can change Pod types between Pods. With this version of OmnipodKit, only Eros and DASH are supported.
+One of the biggest things is that you can change Pod types between Pods without deleting the pump manager. That means all your configuration choices for desired notifications and type of Insulin are maintained when you change Pod Types. With this version of OmnipodKit, only Eros and DASH are supported.
 
 !!! question "Why OmnipodKit?"
     When the initial work to add DASH to the supported pumps was started in 2021, a completely separate pump submodule was created distinct from the Classic (Eros) pump submodule. In other words, OmniBLE handled DASH and OmniKit handled Eros.

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -42,7 +42,7 @@ The current version of `dev` is v3.14.2. This has some very significant changes 
 
     If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod. Simply rebuild v3.14.2 back on your phone and control will be restored.
 
-For those on the Dana pump. You need to keep building a feature branch, but it might be a different branch from what you used before. 
+For those on the Dana pump. You need to keep building a feature branch, but the name of the branch changed. 
 
 Please see [Table of Retired Branches](#table-of-retired-branches) for up to date information about what branch you need to build for Dana support.
 
@@ -55,9 +55,7 @@ In addition to the main and dev branches, which are tightly controlled and only 
 * The `update_dev_to_M.m.#` is where the next version of dev is tested before becoming part of `dev` and later being released as `main`
 * The branches starting with `feat/` have one or more special features, like support for new pumps, CGM or the new universal pump manager for all types of Omnipods
 
-The graphic below shows the `main` and `dev` branches along with some feature branches and an update branch.
-
-TO-DO - update this graphic
+The graphic below shows the `main` and `dev` branches along with some feature branches and an update branch. This is a snapshot in time and no longer reflects the current status. Always check [Table of Active Branches](#table-of-active-branches).
 
 > ![Active branches for LoopWorkspace](img/loop-development-branches.png ){width="750"}
 {align="center"}

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -13,8 +13,8 @@ The next version of the *Loop* app is developed using branches.
 * The `dev` branch is used by the developers to push out changes for users to test before that code is released
     * Sometimes there are breaking changes
         * A breaking change is when you can build the new branch over your existing app, but cannot go backwards without deleting your app from your phone
-    * We are bringing in updates for Tidepool in a special branch `next_dev`
-        * Note that you might be able to go backward to `main` or `dev` from `next_dev` but it is not guaranteed
+    * We are bringing in updates for Tidepool in a special branch `next-dev`
+        * Note that you might be able to go backward to `main` or `dev` from `next-dev` but it is not guaranteed
 * In addition there are specific feature branches that enable users to test new pump and cgm managers or features for existing managers before they are added to the `dev` branch
 * You should only test a development or feature branch if you are willing to be an active participant with the developers:
     * [Monitor announcements in zulipchat](https://loop.zulipchat.com/#narrow/channel/144182-development) 
@@ -80,7 +80,7 @@ The table below lists active branches.
 | main | 3.14.0 | 14 May 2026 | release |
 | dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
 | `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana support: [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
-| `next_dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454) |
+| `next-dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454) |
 
 ??? question "What is SHA? (Click to Open/Close)"
     SHA-1 means Secure Hash Algorithm 1. This is used to generate an alphanumeric code to identify which version of a repository is used. 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -154,7 +154,7 @@ Eversense support was added to the `dev` branch in version 3.14.2.
 
 For Dana support, you must build a new feature branch. The old feature branches were deleted.
 
-See [Feature Branch: All Managers](#feature-branch-all-managers) for more information about the branch. Keep reading here for Dana specific status.
+See [Feature Branch: feat/all-managers](#feature-branch-featall-managers) for more information about the branch. Keep reading here for Dana specific status.
 
 Anyone using Dana pumps must build a new feature branch, feat/all-managers. Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -50,7 +50,7 @@ The current version of `dev` is v3.14.2. This has some very significant changes 
     * The OmniBLE and OmniKit single-pod-type pump managers were removed from the dev branch
 
 !!! important "Omnipod Users cannot return to v3.14.0 after building v3.14.2 without replacing their Pod"
-    The new unified Omnipod Pump Manager, OmnipodKit, is the only pump manager available in v3.14.2.
+    The new unified Omnipod Pump Manager, OmnipodKit, is the only Omnipod pump manager available in v3.14.2.
 
     If you are running a Pod, you can install v3.14.2 over v3.14.0 or earlier and the Pod control will automatically transition to the OmnipodKit Pump Manager.
 
@@ -94,9 +94,9 @@ The table below lists active branches.
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.2 | 5 June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
-| `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana support: [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
-| `next-dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454) |
+| dev | 3.14.2 | 5 June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read** [Transition to OmnipodKit](#transition-to-omnipodkit) |
+| `feat/all-managers`<br>- SHA `1b4718f` | 3.14.2 | 5 June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides `DanaKit @ c544c42` support<br>**Please read** [Status for Dana Support](#status-for-dana-support)<br>**Please read** [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
+| `next-dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454)<br>[zulipchat: Loop next-dev Status](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Loop.20next-dev.20Status/with/600761707) |
 
 ??? question "What is SHA? (Click to Open/Close)"
     SHA-1 means Secure Hash Algorithm 1. This is used to generate an alphanumeric code to identify which version of a repository is used. 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -57,14 +57,14 @@ The graphic below shows the `main` and `dev` branches along with some feature br
     * There are also feature branches for items like new pumps and new CGMs:
         * The feature branches typically spin off of `dev`, but if a `updates_dev_to_ . . .` branch is in work, it is merged into the feature branches as items get included
 
-#### Table of Active Branches
+### Table of Active Branches
 
 The table below lists active branches. Note that updates may occur and be announced in zulipchat a day or two before updates propogate to *LoopDocs*. The feature branches listed below will be replaced shortly after the next release. Any one using a feature branch needs to be alert and check zulipchat regularly.
 
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>[PR453](https://github.com/LoopKit/LoopWorkspace/pull/452#top) replace OmniBLE and OmniKit with OmnipodKit |
+| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR453](https://github.com/LoopKit/LoopWorkspace/pull/452#top) replace OmniBLE and OmniKit with OmnipodKit |
 | [feat/dev-dana-medtrum](#feature-branch-dana-and-medtrum-support) <br>- SHA `e0331eb` | 3.14.1  | 26 May 2026 | - adds support for Dana and Medtrum pumps<br>  - SHA  `DanaKit @ c544c42`<br>  - SHA `MedtrumKit @ 6060747`<br>**Medtrum User Interface Redesigned** to be more like the Omnipod User Interac.<br>Several fixes added for MedtrumKit, not yet in DanaKit |
 | [feat/eversense](#feature-branch-eversense-support) <br>- SHA `e909b2e` | 3.14.1  | 26 May 2026 | - adds experimental support for Eversense (includes Dana and Medtrum pumps support - same SHA as above)<br>- this branch is ready for use to evaluate and report back<br>  - SHA `EversenseKit @ 43b8080` |
 | [feat/omnipodkit](#feature-branch-omnipodkit-pump-manager)<br>- SHA `10fd21f` | 3.14.1 | 03 June 2026| The new OmnipodKit pump manager, controls all Types of pods. Initially only the Eros and DASH pod types are available for feature branch testers<br>  - SHA `OmnipodKit @ d68699c`<br>**Please read [Feature Branch: OmnipodKit Pump Manager](#feature-branch-omnipodkit-pump-manager)** |
@@ -169,6 +169,11 @@ The next time you change a pod, delete the pump manager you are using and add a 
 * Go through the onboarding of selecting notifications and reminders and insulin type.
 * You will then be presented with a screen to select the type of pod. 
 * Choose the Classic (Eros) or DASH Pod type
+
+!!! important "Once you transition to OmnipodKit, stay with OmnipodKit"
+    The new unified Omnipod Pump Manager, OmnipodKit, is the only available in v3.14.2 or newer.
+
+    If you are running a Pod and you transition to the OmnipodKit Pump Manager, then any build you install on your phone should have OmnipodKit. If you need to downgrade to a build earlier than v3.14.2, do so after deactivating a Pod.
 
 ### Feature Branch: Pod Keep Alive Feature
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -6,12 +6,15 @@ The [*Loop* Releases](releases.md){: target="_blank"}  page lists releases since
 
 The current released version of the *Loop* app is always in the `main` branch of the LoopWorkspace repository.
 
+### Development Branches and Breaking Changes
+
 The next version of the *Loop* app is developed using branches. 
 
 * The `dev` branch is used by the developers to push out changes for users to test before that code is released
-    * Sometimes there are breaking changes in `dev`
-    * A breaking change is when you can build the `dev` branch over your existing app, but cannot leave the `dev` branch without deleting your app from your phone
-    * It's been a few years since this happened (when we went from Loop 2 to Loop 3), but it will be happening again soon with an upcoming merge from Tidepool
+    * Sometimes there are breaking changes
+        * A breaking change is when you can build the new branch over your existing app, but cannot go backwards without deleting your app from your phone
+    * We are bringing in updates for Tidepool that will intially land in a special branch `next_dev`
+        * Note that you might be able to go backward to `main` or `dev` from `next_dev` but it is not guaranteed
 * In addition there are specific feature branches that enable users to test new pump and cgm managers or features for existing managers before they are added to the `dev` branch
 * You should only test a development or feature branch if you are willing to be an active participant with the developers:
     * [Monitor announcements in zulipchat](https://loop.zulipchat.com/#narrow/channel/144182-development) 
@@ -25,7 +28,14 @@ Please read this entire page before using any version of *Loop* other than the r
 
 This section provides an overview of changes to `dev` compared to the current release: `Loop v3.14.0`. 
 
-The current version of `dev` is v3.14.1. It is functionally identical the released code. The only difference is we added an alert you must acknowledge if you are running the `dev` branch.
+The current version of `dev` is v3.14.2. This has a very significant change - please read the warning.
+
+!!! important "Omnipod Users cannot return to v3.14.0 after building v3.14.2 without replacing their Pod"
+    The new unified Omnipod Pump Manager, OmnipodKit, is the only pump manager available in v3.14.2.
+
+    If you are running a Pod, you can install v3.14.2 over v3.14.0 and the Pod will be automatically transition to the OmnipodKit Pump Manager.
+
+    If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod. Simply rebuild v3.14.2 back on your phone and control will be restored.
 
 Please check the [development channel in zulipchat](https://loop.zulipchat.com/#narrow/channel/144182-development) for notifications when an update to the `dev` branch is expected so you will be prepared. Do this **before** you install a `dev` build from TestFlight.
 
@@ -49,15 +59,15 @@ The graphic below shows the `main` and `dev` branches along with some feature br
 
 #### Table of Active Branches
 
-The table below lists active branches. Note that updates may occur and be announced in zulipchat a day or two before updates propogate to *LoopDocs*.
+The table below lists active branches. Note that updates may occur and be announced in zulipchat a day or two before updates propogate to *LoopDocs*. The feature branches listed below will be replaced shortly after the next release. Any one using a feature branch needs to be alert and check zulipchat regularly.
 
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.1 | 23 May 2026 | functionally the same as `main`<br>3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch |
+| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>[PR453](https://github.com/LoopKit/LoopWorkspace/pull/452#top) replace OmniBLE and OmniKit with OmnipodKit |
 | [feat/dev-dana-medtrum](#feature-branch-dana-and-medtrum-support) <br>- SHA `e0331eb` | 3.14.1  | 26 May 2026 | - adds support for Dana and Medtrum pumps<br>  - SHA  `DanaKit @ c544c42`<br>  - SHA `MedtrumKit @ 6060747`<br>**Medtrum User Interface Redesigned** to be more like the Omnipod User Interac.<br>Several fixes added for MedtrumKit, not yet in DanaKit |
 | [feat/eversense](#feature-branch-eversense-support) <br>- SHA `e909b2e` | 3.14.1  | 26 May 2026 | - adds experimental support for Eversense (includes Dana and Medtrum pumps support - same SHA as above)<br>- this branch is ready for use to evaluate and report back<br>  - SHA `EversenseKit @ 43b8080` |
-| [feat/omnipodkit](#feature-branch-omnipodkit-pump-manager)<br>- SHA `a625519` | 3.14.1 | 01 June 2026| The new OmnipodKit pump manager, controls all Types of pods. Initially only the Eros and DASH pod types are available for feature branch testers<br>  - SHA `OmnipodKit @ c04c4d4`<br>**Please read [Feature Branch: OmnipodKit Pump Manager](#feature-branch-omnipodkit-pump-manager)** |
+| [feat/omnipodkit](#feature-branch-omnipodkit-pump-manager)<br>- SHA `10fd21f` | 3.14.1 | 03 June 2026| The new OmnipodKit pump manager, controls all Types of pods. Initially only the Eros and DASH pod types are available for feature branch testers<br>  - SHA `OmnipodKit @ d68699c`<br>**Please read [Feature Branch: OmnipodKit Pump Manager](#feature-branch-omnipodkit-pump-manager)** |
 
 !!! important "Eversense Support"
     The Eversense CGM is now supported by the *Loop* app in a feature branch. To simplify maintenance, the branch which supports Eversense also supports the two new pumps: Dana and Medtrum.
@@ -119,22 +129,24 @@ The version number in the feature branch will match either the `dev` branch vers
 
 ### Feature Branch: OmnipodKit Pump Manager
 
-You need to build the `feat/omnipodkit` branch if you want to test the new `All Omnipod Types` pump manager. Build instructions are found here: [How to Build Feature Branches](#how-to-build-feature-branches).
+!!! Question "What is different between `feat/omnipodkit` and `dev` branch"
+    There are several differences between `feat/omnipodkit` and `dev` branch.  For one thing, this branch (which will be renamed soon - so pay attention) has all the pump managers: OmniBLE, OmniKit, OmnipodKit, DanaKit, MedtrumKit and MinimedKit and the new CGM manager EversenseKit.
 
-This pump manager comes with improved user interface and user experience for Omnipod Classic (Eros) and DASH pods including
+    Keeping OmniBLE & OmniKit in this branch is useful for developers. Those pump managers were removed from `dev` branch (3.14.2) and will soon be removed from `main` when `dev` is merged into main.
+
+    Because OmniBLE & OmniKit are present, a tester who comes in with a Pod attached to one of those managers stays with the manager. The automatic conversion to OmnipodKit, which happens with v3.14.2, does not happen with this branch. The tester has to manually change pump managers during a Pod change.
+
+#### OmnipodKit Pump Manager
+
+The OmnipodKit pump manager comes with improved user interface and user experience for Omnipod Classic (Eros) and DASH pods including
 
 * Some layout adjustments
 * Some new labels
 * Some reworked sub-menus with added information or features
 
-The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
+If you are running the `dev` branch - your Pod is automatically transitioned to OmnipodKit. You will notice the user interface is a little different. If you are running `feat/omnipodkit` branch, see [Manual transition with `feat/omnipodkit`](#manual-transition-with-featomnipodkit).
 
-* Select `All Omnipod Types` as your new pump manager.
-* Go through the onboarding of selecting notifications and reminders and insulin type.
-* You will then be presented with a screen to select the type of pod. 
-* Choose the Classic (Eros) or DASH Pod type
-
-The underyling control code should be the same, but we want more people testing it to ensure this works as well as the older pod managers. The developers have been using it on themselves before making this publicly available.
+One of the biggest things is that you can change Pod types between Pods. With this version of OmnipodKit, only Eros and DASH are supported.
 
 !!! question "Why OmnipodKit?"
     When the initial work to add DASH to the supported pumps was started in 2021, a completely separate pump submodule was created distinct from the Classic (Eros) pump submodule. In other words, OmniBLE handled DASH and OmniKit handled Eros.
@@ -147,13 +159,16 @@ The underyling control code should be the same, but we want more people testing 
 
     This will be a significant time saver for developers moving forward for updating code and adding support for new types of pods.
 
-!!! tip "feat/omnipodkit supports other plugins"
-    For the convenience of the developers and testers, this feature branch, feat/omnipodkit, also supports the new pump and cgm managers that are found in the other feature branches.
+#### Manual transition with `feat/omnipodkit`
 
-    In other words:
+If you are running `feat/omnipodkit` branch, you need to take these steps to switch to using the new pump manager.
 
-    * Eversense is available as a CGM
-    * Dana and Medtrum are available as a pump, in addtion to OmnipodKit and all the older pump managers
+The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
+
+* Select `All Omnipod Types` as your new pump manager.
+* Go through the onboarding of selecting notifications and reminders and insulin type.
+* You will then be presented with a screen to select the type of pod. 
+* Choose the Classic (Eros) or DASH Pod type
 
 ### Feature Branch: Pod Keep Alive Feature
 

--- a/docs/version/development.md
+++ b/docs/version/development.md
@@ -32,13 +32,13 @@ The current version of `dev` is v3.14.2. This has some very significant changes 
 
 * The Medtrum Nano 200 U / 300 U pump manager is added to the dev branch and will be in the next release
 * The Eversense E3 and 365 sensor CGM manager is added to the dev branch and will be in the next release
-* The unified OmnipodKit pump managaer, which controls either Classic (Eros) or DASH pods, is added to the dev branch and will be in the next release
+* The unified OmnipodKit pump manager, which controls either Classic (Eros) or DASH pods, is added to the dev branch and will be in the next release
     * The OmniBLE and OmniKit single-pod-type pump managers were removed from the dev branch
 
 !!! important "Omnipod Users cannot return to v3.14.0 after building v3.14.2 without replacing their Pod"
     The new unified Omnipod Pump Manager, OmnipodKit, is the only pump manager available in v3.14.2.
 
-    If you are running a Pod, you can install v3.14.2 over v3.14.0 and the Pod will be automatically transition to the OmnipodKit Pump Manager.
+    If you are running a Pod, you can install v3.14.2 over v3.14.0 or earlier and the Pod control will automatically transition to the OmnipodKit Pump Manager.
 
     If you are running a Pod with v3.14.2, but reinstall 3.14.0 or earlier over it, there will not be an OmnipodKit Pump Manager available so you lose contact with your Pod. Simply rebuild v3.14.2 back on your phone and control will be restored.
 
@@ -71,16 +71,16 @@ The graphic below shows the `main` and `dev` branches along with some feature br
 The table below lists active branches. 
 
 * Note that updates may occur and be announced in zulipchat a day or two before updates propagate to *LoopDocs*
-* Any one using a feature branch needs to be alert and check zulipchat regularly
+* Anyone using a feature branch needs to be alert and check zulipchat regularly
 * For example, while preparing for v3.14.2, older feature branches were retired
     * Check the [Table of Retired Branches](#table-of-retired-branches) to get the support you need.
 
 | <div style="width:140px"> branch | version # | <div style="width:140px">last updated | comments |
 |:--|:--|:--|:--|
 | main | 3.14.0 | 14 May 2026 | release |
-| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/452#top)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
-| `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana suppor: [Feature: All Managers] |
-| `next_dev` | 3.15.0 | subject to rapid change | [PR 454]((https://github.com/LoopKit/LoopWorkspace/pull/454) |
+| dev | 3.14.2 | TBD June 2026 | v3.14.2 has a breaking change wrt `main`<br>- v3.14.1: [PR 452](https://github.com/LoopKit/LoopWorkspace/pull/452#top) add alert about dev branch<br>- v3.14.2 [PR 453](https://github.com/LoopKit/LoopWorkspace/pull/453)<br>- add MedtrumKit<br>- add EversenseKit<br>- add OmnipodKit<br>- delete OmniBLE and OmniKit<br>**Please read [Transition to OmnipodKit](#transition-to-omnipodkit)** |
+| `feat/all-managers`<br>- SHA `TBD` | 3.14.2 | TBD June 2026| This branch contains all the managers and is primarily for developers to use for testing<br>It also provides Dana support: [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
+| `next_dev` | 3.15.0 | subject to rapid change | [PR 454](https://github.com/LoopKit/LoopWorkspace/pull/454) |
 
 ??? question "What is SHA? (Click to Open/Close)"
     SHA-1 means Secure Hash Algorithm 1. This is used to generate an alphanumeric code to identify which version of a repository is used. 
@@ -95,7 +95,7 @@ The table below lists active branches.
 |:--|:--|:--|
 | feat/dev-dana-medtrum |For Medtrum, use `dev`<br>For Dana, use `feat/all-managers` | [Status for Medtrum](#status-for-medtrum-support)<br>[Status for Dana](#status-for-dana-support) |
 | feat/eversense |  For Eversense, use `dev` | [Status for Eversense](#status-for-eversense-support) |
-| feat/omnipodkit | Use `dev` unless you are a developer<br>developers can use `feat/all-managers` | [Feature Branch: All Managers](#feature-branch-all-managers) |
+| feat/omnipodkit | Use `dev` unless you are a developer<br>developers can use `feat/all-managers` |  [Feature Branch: feat/all-managers](#feature-branch-featall-managers) |
 
 ### How to Build Feature Branches
 
@@ -140,7 +140,7 @@ For those using iPhone 16 or 17e with Atlas DASH Pods, the keep alive support is
 
 ### Status for Medtrum Support
 
-Metrum support was added to the `dev` branch in version 3.14.2.
+Medtrum support was added to the `dev` branch in version 3.14.2.
 
 - - -
 
@@ -217,9 +217,9 @@ Anyone using Dana pumps must build a new feature branch, feat/all-managers. Buil
 
 - - -
 
-### Feature Branch: All Managers
+### Feature Branch: feat/all-managers
 
-This branch replaces several [retired feature branches](#table-of-retired-branches). If you need a feature branch for a Dana pump - you need to build this branch. Be sure to review the [Status For Dana Support](#status-for-dana-support) section.
+The `feat/all-managers` branch replaces several [retired feature branches](#table-of-retired-branches). If you need a feature branch for a Dana pump - you need to build this branch. Be sure to review the [Status For Dana Support](#status-for-dana-support) section.
 
 If you previously used a feature branch for Medtrum or Eversense support, you can switch to the `dev` branch.
 
@@ -263,7 +263,7 @@ One of the biggest things is that you can change Pod types between Pods. With th
 
 If you are running `feat/all-managers` branch, you need to take these steps to switch to using the new pump manager.
 
-The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
+The next time you change a pod, delete the pump manager you are using and add a new pump. See [Change Pump Type](../loop-3/add-pump.md#change-pump-type){: target="_blank" } for detailed instructions.
 
 * Select `All Omnipod Types` as your new pump manager.
 * Go through the onboarding of selecting notifications and reminders and insulin type.

--- a/docs/version/releases.md
+++ b/docs/version/releases.md
@@ -655,9 +655,17 @@ This is one of the bigger updates to Loop. Since the last release [`Loop v2.2.9`
 
 ## `Loop` Version Numbering
 
-With the release of version 3.14.0, the numbering is changing again. We will not be using even numbers for main and odd numbers for dev.
+With the release of version 3.14.0, the numbering is changing again.
 
-We will start out with main and dev at the same number, e.g., 3.14.0. When changes are incorporated into dev via a formal pull request, dev will be bumped up in the last position, e.g., to 3.14.1, then 3.14.2, etc to indicate updates brought into dev.
+### `Loop` 3 versus `Loop` 4
+
+We are bringing in input from Tidepool that brings a whole new set up enhancements. This will eventually be released as version 4.0.0, but while we are testing in a branch called `next_dev`, it will be version 3.15.n.
+
+The existing version of Loop will continue to be updated, but it will all be in the 3.14.n series.
+
+We started out with main and dev at the same number, e.g., 3.14.0. When changes are incorporated into dev via a formal pull request, dev will be bumped up in the last position, e.g., to 3.14.1, then 3.14.2, etc to indicate updates brought into dev. When a given version of dev needs to be released, the main branch will be updated to the same code and version number as the dev branch.
+
+### Older Version Numbering
 
 With the release of `Loop 3`, there was a new pattern for identifying the releases as distinct from the development work. This pattern was revised again starting with `Loop v3.6`.
 

--- a/docs/version/releases.md
+++ b/docs/version/releases.md
@@ -217,21 +217,7 @@ This version updates a few iOS 26 interface issues, moves support for Dana pumps
 > **A pump manager that works for Trio must be separately tested for Loop**
 
 * Several issues were reported regarding bolus accounting and IOB reporting for *Loop* v3.8.1
-* For this reason, Dana support is only found in 2 special branches
-
-If you were using Dana with v3.8.1, a branch called `release/3.8.1` was created for your continued use.
-
-* The `release/3.8.1` branch will remain available while troubleshooting continues
-* This branch is meant to support people already using Dana with v3.8.1 who understand how to manage the issues with that version
-
-If you are an expert and want to use [Dana](../loop-3/add-pump.md#dana-in-loop-requires-expert-testing){: target="_blank" } or [Medtrum](../loop-3/add-pump.md#medtrum-in-loop-requires-expert-testing){: target="_blank" }, the experimental branch is `feat/dev-dana-medtrum`
-
-* This branch is subject to rapid updates
-* Please do not use Dana with Loop unless you are willing to test and communicate with [developers on zulipchat in this DanaKit channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/DanaKit.20Troubleshooting/with/547829260)
-
-* Please do not use Medtrum with Loop unless you are willing to test and communicate with [developers on zulipchat in the Medtrum channel](https://loop.zulipchat.com/#narrow/channel/144182-development/topic/Medtrum.20Nano.20-.20pumps.20for.20development.20use/with/481836247)
-
-
+* For this reason, Dana support is only found in a feature branch
 
 ### Loop v3.8.1
 

--- a/docs/version/releases.md
+++ b/docs/version/releases.md
@@ -645,7 +645,7 @@ With the release of version 3.14.0, the numbering is changing again.
 
 ### `Loop` 3 versus `Loop` 4
 
-We are bringing in input from Tidepool that brings a whole new set of enhancements. This will eventually be released as version 4.0.0, but while we are testing in a branch called `next_dev`, it will be version 3.15.n.
+We are bringing in input from Tidepool that brings a whole new set of enhancements. This will eventually be released as version 4.0.0, but while we are testing in a branch called `next-dev`, it will be version 3.15.n.
 
 The existing version of Loop will continue to be updated, but it will all be in the 3.14.n series.
 

--- a/docs/version/releases.md
+++ b/docs/version/releases.md
@@ -659,7 +659,7 @@ With the release of version 3.14.0, the numbering is changing again.
 
 ### `Loop` 3 versus `Loop` 4
 
-We are bringing in input from Tidepool that brings a whole new set up enhancements. This will eventually be released as version 4.0.0, but while we are testing in a branch called `next_dev`, it will be version 3.15.n.
+We are bringing in input from Tidepool that brings a whole new set of enhancements. This will eventually be released as version 4.0.0, but while we are testing in a branch called `next_dev`, it will be version 3.15.n.
 
 The existing version of Loop will continue to be updated, but it will all be in the 3.14.n series.
 


### PR DESCRIPTION
Prepare for the merge of LoopWorkspace PR 543 which updates dev to 3.14.2. This is a precursor to the next release of 3.14.2.