### PR TITLE
Update warning about moving to dev branch on phone

### DIFF
--- a/docs/version/loopworkspace.md
+++ b/docs/version/loopworkspace.md
@@ -107,7 +107,7 @@ cd LoopWorkspace
 xed .
 ```
 
-Remember the warning - if you build the `dev` branch on your phone from `Loop main`, it should work fine. Going backward, please delete the app from your phone and enter all your settings again to return to `main`.
+Remember the warning - if you move to the `dev` branch on your phone from `Loop main`, it should work fine. Going backward, you may need to delete the app from your phone and enter all your settings again to return to `main`.
 
 
 ### Start Xcode using Finder


### PR DESCRIPTION
Clarify that loop app may need to be deleted if you switch from dev to main.